### PR TITLE
Expose evacuate VM method to automate

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
@@ -41,6 +41,7 @@ module MiqAeMethodService
     expose :compliances,           :association => true
     expose :last_compliance,       :association => true
     expose :ems_events,            :association => true
+    expose :evacuate
 
 
     METHODS_WITH_NO_ARGS = %w(start stop suspend unregister collect_running_processes shutdown_guest standby_guest reboot_guest)


### PR DESCRIPTION
Expose the `evacuate` method for instances in OpenStack Cloud Provider