### PR TITLE
Expose delete method for Cloud Subnet

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_cloud_subnet.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_cloud_subnet.rb
@@ -3,5 +3,6 @@ module MiqAeMethodService
     expose :cloud_network,     :association => true
     expose :availability_zone, :association => true
     expose :vms,               :association => true
+    expose :delete_cloud_subnet
   end
 end


### PR DESCRIPTION
This exposes the delete method for Cloud Subnet in OpenStack Cloud Provider.

Original PR https://github.com/ManageIQ/manageiq/pull/14516
Depends on ManageIQ/manageiq#15087