### PR TITLE
Remove zip-zip

### DIFF
--- a/app/models/miq_ae_yaml_export_zipfs.rb
+++ b/app/models/miq_ae_yaml_export_zipfs.rb
@@ -18,7 +18,7 @@ class MiqAeYamlExportZipfs < MiqAeYamlExport
   end
 
   def export
-    require 'zip/zipfilesystem'
+    require 'zip/filesystem'
 
     Zip::ZipFile.open(@temp_file_name, Zip::ZipFile::CREATE) do |zf|
       @zip_file = zf

--- a/app/models/miq_ae_yaml_export_zipfs.rb
+++ b/app/models/miq_ae_yaml_export_zipfs.rb
@@ -20,7 +20,7 @@ class MiqAeYamlExportZipfs < MiqAeYamlExport
   def export
     require 'zip/filesystem'
 
-    Zip::ZipFile.open(@temp_file_name, Zip::ZipFile::CREATE) do |zf|
+    Zip::File.open(@temp_file_name, Zip::File::CREATE) do |zf|
       @zip_file = zf
       write_model
       @zip_file.close unless @zip_file.nil?

--- a/app/models/miq_ae_yaml_import_zipfs.rb
+++ b/app/models/miq_ae_yaml_import_zipfs.rb
@@ -6,7 +6,7 @@ class MiqAeYamlImportZipfs < MiqAeYamlImport
   end
 
   def load_zip
-    require 'zip/zipfilesystem'
+    require 'zip/filesystem'
 
     raise MiqAeException::FileNotFound, "import file: #{@options['zip_file']} not found" \
       unless File.exist?(@options['zip_file'])

--- a/app/models/miq_ae_yaml_import_zipfs.rb
+++ b/app/models/miq_ae_yaml_import_zipfs.rb
@@ -10,7 +10,7 @@ class MiqAeYamlImportZipfs < MiqAeYamlImport
 
     raise MiqAeException::FileNotFound, "import file: #{@options['zip_file']} not found" \
       unless File.exist?(@options['zip_file'])
-    @zip = Zip::ZipFile.open(@options['zip_file'])
+    @zip = Zip::File.open(@options['zip_file'])
     @sorted_entries = @zip.entries.sort
   end
 

--- a/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -850,7 +850,7 @@ describe MiqAeDatastore do
   end
 
   def create_bogus_zip_file
-    require 'zip/zipfilesystem'
+    require 'zip/filesystem'
     Zip::ZipFile.open(@zip_file, Zip::ZipFile::CREATE) do |zh|
       zh.file.open("first.txt", "w") { |f| f.puts "Hello world" }
       zh.dir.mkdir("mydir")

--- a/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -851,7 +851,7 @@ describe MiqAeDatastore do
 
   def create_bogus_zip_file
     require 'zip/filesystem'
-    Zip::ZipFile.open(@zip_file, Zip::ZipFile::CREATE) do |zh|
+    Zip::File.open(@zip_file, Zip::File::CREATE) do |zh|
       zh.file.open("first.txt", "w") { |f| f.puts "Hello world" }
       zh.dir.mkdir("mydir")
       zh.file.open("mydir/second.txt", "w") { |f| f.puts "Hello again" }


### PR DESCRIPTION
Split from https://github.com/ManageIQ/manageiq/pull/14881

From what I can tell, the only thing holding us back from dropping our dependency on zip-zip was the usage of some aliased constants, so I changed to use the ones provided by Rubyzip.