### PR TITLE
Expose the port open method via a utils instance

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -1,6 +1,7 @@
 require_relative './miq_ae_service_model_legacy'
 require_relative './miq_ae_service_vmdb'
 require_relative './miq_ae_service_rbac'
+require_relative './/miq_ae_service_utils'
 module MiqAeMethodService
   class MiqAeService
     include Vmdb::Logging
@@ -316,6 +317,10 @@ module MiqAeMethodService
       return nil if aec.nil?
 
       aec.ae_instances.detect { |i| instance.casecmp(i.name) == 0 }
+    end
+
+    def utils
+      MiqAeServiceUtils.new
     end
 
     private

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_utils.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_utils.rb
@@ -1,0 +1,30 @@
+require 'discovery/port_scanner'
+
+# Automate Method Utility Class
+class MiqAeServiceUtils
+  include Vmdb::Logging
+  include DRbUndumped
+
+  # Check if a port is open on given ip address
+  # returns true if the port is open
+  # returns false if the ip address is not reachable
+  #                      or the port is not open
+  #
+  # ==== Attributes
+  #
+  # * +ipaddr+ - The ip address of the server
+  # * +port+ - The port number
+  # * +timeout+ - optional How long to wait to check for connection,
+  #               default is 10 seconds
+  #
+  # ==== Examples
+  #
+  # Check if the SSH port is open on the server with ip address of 1.1.1.94
+  #     utils = $evm.utils
+  #     utils.port_open('1.1.1.94', 22)
+  #
+  def port_open(ipaddr, port, timeout = 10)
+    PortScanner.portOpen(OpenStruct.new(:ipaddr => ipaddr, :timeout => timeout),
+                         port)
+  end
+end

--- a/spec/miq_ae_service_spec.rb
+++ b/spec/miq_ae_service_spec.rb
@@ -235,5 +235,18 @@ module MiqAeServiceSpec
         expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
       end
     end
+
+    context "#utils" do
+      let(:options) { {} }
+      let(:workspace) { double("MiqAeEngine::MiqAeWorkspaceRuntime", :root => options) }
+      let(:miq_ae_service) { MiqAeService.new(workspace) }
+
+      it "#port_open" do
+        allow(workspace).to receive(:persist_state_hash).and_return({})
+        allow(workspace).to receive(:disable_rbac)
+
+        expect(miq_ae_service.utils.respond_to?(:port_open)).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
**Purpose or Intent**

Added a utility instance that can be fetched from the service handle.
On that utility instance we can call the port_open method.

**Links**
Original PR https://github.com/ManageIQ/manageiq/pull/10526
PR #https://github.com/ManageIQ/manageiq/pull/10406
Steps for Testing/QA

Automate Method Script
-------------------------

open = $evm.utils.port_open('1.1.1.94', 22)
$evm.log(:info, "ssh port open on 1.1.1.94 #{open}")

or
utils = $evm.utils
open = utils.port_open('1.1.1.94', 22)
$evm.log(:info, "ssh port open on 1.1.1.94 #{open}")