### PR TITLE
Edit exposed methods for Cloud Tenant

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_cloud_tenant.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_cloud_tenant.rb
@@ -9,7 +9,7 @@ module MiqAeMethodService
     expose :floating_ips,          :association => true
     expose :cloud_resource_quotas, :association => true
 
-    expose :raw_update_cloud_tenant
-    expose :raw_delete_cloud_tenant
+    expose :update_cloud_tenant
+    expose :delete_cloud_tenant
   end
 end

--- a/spec/service_models/miq_ae_service_cloud_tenant_spec.rb
+++ b/spec/service_models/miq_ae_service_cloud_tenant_spec.rb
@@ -32,12 +32,12 @@ module MiqAeServiceCloudTenantSpec
       expect(described_class.instance_methods).to include(:cloud_resource_quotas)
     end
 
-    it "#raw_update_cloud_tenant" do
-      expect(described_class.instance_methods).to include(:raw_update_cloud_tenant)
+    it "#update_cloud_tenant" do
+      expect(described_class.instance_methods).to include(:update_cloud_tenant)
     end
 
-    it "#raw_delete_cloud_tenant" do
-      expect(described_class.instance_methods).to include(:raw_delete_cloud_tenant)
+    it "#delete_cloud_tenant" do
+      expect(described_class.instance_methods).to include(:delete_cloud_tenant)
     end
   end
 end


### PR DESCRIPTION
Changed exposed raw methods to non-raw. 
The pattern is: we want to have non-raw methods on a base class, in order to expose them instead of raw methods.