### PR TITLE
Added support for embedded methods

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -215,7 +215,7 @@ module MiqAeEngine
     private_class_method :cleanup
 
     def self.get_bodies_and_line_numbers(obj, aem)
-      embeds = get_embeds(obj.workspace, aem) << {:data => aem.data, :fqname =>aem.fqname}
+      embeds = get_embeds(obj.workspace, aem) << {:data => aem.data, :fqname => aem.fqname}
       code_start = 0
       line_hash = {}
       bodies = []
@@ -245,7 +245,7 @@ module MiqAeEngine
     private_class_method :get_embeds
 
     def self.get_embed_method_name(fqname)
-      parts =  MiqAeUri.path(fqname).split('/')
+      parts = MiqAeUri.path(fqname).split('/')
       parts.shift # Remove the leading blank piece
       return parts.pop, parts.pop, parts.join('/')
     end

--- a/spec/engine/miq_ae_method_spec.rb
+++ b/spec/engine/miq_ae_method_spec.rb
@@ -306,7 +306,6 @@ describe MiqAeEngine::MiqAeMethod do
           expect { subject }.to raise_error(MiqAeException::UnknownMethodRc)
         end
       end
-
     end
   end
 end

--- a/spec/engine/miq_ae_method_spec.rb
+++ b/spec/engine/miq_ae_method_spec.rb
@@ -2,18 +2,22 @@ describe MiqAeEngine::MiqAeMethod do
   describe ".invoke_inline_ruby (private)" do
     let(:workspace) do
       Class.new do
-        attr_accessor :invoker
+        attr_accessor :invoker, :root
         # rubocop:disable Style/SingleLineMethods, Style/EmptyLineBetweenDefs
         def persist_state_hash; end
         def disable_rbac; end
         def current_method; "/my/automate/method"; end
+        def root
+          {}
+        end
         # rubocop:enable Style/SingleLineMethods, Style/EmptyLineBetweenDefs
       end.new
     end
 
-    let(:aem)    { double("AEM", :data => script, :fqname => "/my/automate/method") }
+    let(:aem)    { double("AEM", :data => script, :fqname => "/my/automate/method", :embedded_methods => embeds) }
     let(:obj)    { double("OBJ", :workspace => workspace) }
-    let(:inputs) { [] }
+    let(:inputs) { {} }
+    let(:embeds) { [] }
 
     subject { described_class.send(:invoke_inline_ruby, aem, obj, inputs) }
 
@@ -208,7 +212,7 @@ describe MiqAeEngine::MiqAeMethod do
         end.new
 
         svc = MiqAeMethodService::MiqAeService.new(workspace, [], logger_stub)
-        expect(MiqAeMethodService::MiqAeService).to receive(:new).with(workspace, []).and_return(svc)
+        expect(MiqAeMethodService::MiqAeService).to receive(:new).with(workspace, inputs).and_return(svc)
 
         expect($miq_ae_logger).to receive(:info).with("<AEMethod [/my/automate/method]> Starting ").ordered
         expect(logger_stub).to    receive(:sleep).and_call_original.ordered
@@ -218,6 +222,91 @@ describe MiqAeEngine::MiqAeMethod do
         expect(subject).to eq(0)
         expect(logger_stub.expected_messages).to eq([])
       end
+    end
+
+    context "embed other methods into a method" do
+      let(:script) do
+        <<-RUBY
+          Shared::Methods.new.some_method('barney', "Bamm-Bamm Ruble")
+          exit MIQ_OK
+        RUBY
+      end
+
+      let(:shared_script) do
+        <<-RUBY
+          module Shared
+            class Methods
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def some_method(var, value)
+                @handle.log(:info, "Stuff method called \#{var} => \#{value}")
+                @handle.log(:info, "Stuff method ended")
+              end
+            end
+          end
+        RUBY
+      end
+
+      let(:exception_script) do
+        <<-RUBY
+          module Shared
+            class Methods
+              def initialize(handle = $evm)
+                @handle = handle
+              end
+
+              def some_method(var, value)
+                raise
+              end
+            end
+          end
+        RUBY
+      end
+
+      let(:embeds) { ['/Shared/Methods/TopMethod'] }
+      let(:klass)    { double("Klass", :id => 10) }
+      let(:embed_method) do
+        double("Method", :fqname => 'Shared/Methods/TopMethod', :data => shared_script)
+      end
+
+      let(:exception_method) do
+        double("Method", :fqname => 'Shared/Methods/RaiseException', :data => exception_script)
+      end
+
+      it 'can properly call functions in embedded methods' do
+        allow(::MiqAeClass).to receive(:find_by_fqname).with('Shared/Methods').and_return(klass)
+        allow(::MiqAeMethod).to receive(:find_by).with(:class_id => klass.id, :name => 'TopMethod').and_return(embed_method)
+        allow($miq_ae_logger).to receive(:info).and_call_original
+        allow(workspace).to receive(:overlay_method).with('Shared', 'Methods', 'TopMethod').and_return('Shared')
+        expect($miq_ae_logger).to receive(:info).with("Method exited with rc=MIQ_OK").at_least(:once)
+        expect($miq_ae_logger).to_not receive(:error)
+
+        expect(subject).to eq(0)
+      end
+
+      it 'raises error when a embeded method is not found' do
+        allow(::MiqAeClass).to receive(:find_by_fqname).with('Shared/Methods').and_return(nil)
+        allow($miq_ae_logger).to receive(:info).and_call_original
+        allow(workspace).to receive(:overlay_method).with('Shared', 'Methods', 'TopMethod').and_return('Shared')
+
+        expect { subject }.to raise_error(MiqAeException::MethodNotFound)
+      end
+
+      context "exception" do
+        let(:embeds) { ['/Shared/Methods/RaiseException'] }
+        it 'can log stack trace in embedded methods' do
+          allow(::MiqAeClass).to receive(:find_by_fqname).with('Shared/Methods').and_return(klass)
+          allow(::MiqAeMethod).to receive(:find_by).with(:class_id => klass.id, :name => 'RaiseException').and_return(exception_method)
+          allow($miq_ae_logger).to receive(:info).and_call_original
+          allow($miq_ae_logger).to receive(:error).and_call_original
+          allow(workspace).to receive(:overlay_method).with('Shared', 'Methods', 'RaiseException').and_return('Shared')
+          expect($miq_ae_logger).to receive(:error).with("<AEMethod /my/automate/method>   Shared/Methods/RaiseException:8:in `some_method'").at_least(:once)
+          expect { subject }.to raise_error(MiqAeException::UnknownMethodRc)
+        end
+      end
+
     end
   end
 end

--- a/spec/engine/miq_ae_method_spec.rb
+++ b/spec/engine/miq_ae_method_spec.rb
@@ -227,8 +227,7 @@ describe MiqAeEngine::MiqAeMethod do
     context "embed other methods into a method" do
       let(:script) do
         <<-RUBY
-          Shared::Methods.new.some_method('barney', "Bamm-Bamm Ruble")
-          exit MIQ_OK
+          Shared::Methods.new.some_method('barney', "Bamm-Bamm Ruble"); exit MIQ_OK
         RUBY
       end
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1418374

This optional backend feature allows you to embed Automate Methods into other Automate Methods.

There is no UI support for it yet.

We collect all the embedded method bodies into a single script before execution. If the methods throws any errors we correctly log the line number from the offending methods.

