### PR TITLE
Add a missing container manager service model

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-container_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-container_manager.rb
@@ -1,0 +1,6 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_ContainerManager < MiqAeServiceManageIQ_Providers_BaseManager
+    expose :container_image_registries, :association => true
+    expose :container_projects,         :association => true
+  end
+end


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1444484
If I understand this problem correctly, https://github.com/ManageIQ/manageiq/pull/13908 removed this model instead of renaming it.
@mzazrivec @blomquisg Please review, Im not sure how to test this one.
cc @simon3z @moolitayer 