### PR TITLE
Add zone to q_options in call_automate.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_event.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_event.rb
@@ -125,6 +125,7 @@ module MiqAeEvent
       :priority     => MiqQueue::HIGH_PRIORITY,
       :task_id      => nil          # Clear task_id to allow running synchronously under current worker process
     }
+    q_options[:zone] = options[:zone] if options[:zone].present?
 
     args = {
       :object_type      => obj.class.name,


### PR DESCRIPTION
Separate Manageiq change to pass zone_name required.

https://bugzilla.redhat.com/show_bug.cgi?id=1447625

Related PR https://github.com/ManageIQ/manageiq/pull/15026