### PR TITLE
If no embedded methods skip writing empty array to YAML

### DIFF
--- a/app/models/miq_ae_yaml_export.rb
+++ b/app/models/miq_ae_yaml_export.rb
@@ -177,6 +177,9 @@ class MiqAeYamlExport
     envelope_hash = setup_envelope(method_obj, METHOD_OBJ_TYPE)
     envelope_hash['object']['inputs'] = method_obj.method_inputs
     envelope_hash['object']['attributes'].delete('data')
+    if method_obj.embedded_methods.empty?
+      envelope_hash['object']['attributes'].delete('embedded_methods')
+    end
     export_file_hash['output_filename'] = "#{method_obj.name}.yaml"
     export_file_hash['export_data']     = envelope_hash.to_yaml
     @counts['method_instances'] += 1

--- a/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -176,6 +176,17 @@ describe MiqAeDatastore do
     end
   end
 
+  context "embeded_methods" do
+    it "if no embedded methods the attribute should be missing" do
+      export_model(@manageiq_domain.name)
+      method_file = File.join(@export_dir, @manageiq_domain.name, @aen1.name,
+                              "manageiq_test_class_1.class/__methods__/test1.yaml")
+      data = YAML.load_file(method_file)
+
+      expect(data.fetch_path('object', 'attributes', 'embedded_methods')).to be_nil
+    end
+  end
+
   context "domain_only_attributes" do
     it "namespace should not contain domain only attributes" do
       domain_only_attrs = %w(source top_level_namespace)


### PR DESCRIPTION
With the new column 'embedded_methods' that we added to MiqAeMethod,
it gets exported even if there are no embedded methods. This PR only
writes out the embedded methods if they are present.

This allows for backward compatibility till we start using embedded methods in our export decks