### PR TITLE
Change Openstack_InfraManager service model use real model for subclass

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-infra_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-infra_manager.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Openstack_InfraManager < MiqAeServiceEmsInfra
+  class MiqAeServiceManageIQ_Providers_Openstack_InfraManager < MiqAeServiceManageIQ_Providers_InfraManager
     expose :orchestration_stacks, :association => true
     expose :direct_orchestration_stacks, :association => true
   end


### PR DESCRIPTION
The Openstack_InfraManager service model was using [alias EmsInfra](https://github.com/ManageIQ/manageiq/blob/master/app/models/aliases/ems_infra.rb) instead of the real subclass `ManageIQ::Providers::InfraManager`

Fixes issues #20 