### PR TITLE
Allow running specs using rspec on the cli

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,3 +2,4 @@
 --require spec_helper
 --color
 --order random
+--exclude-pattern "spec/manageiq/**/*_spec.rb"

--- a/.rspec_ci
+++ b/.rspec_ci
@@ -2,4 +2,5 @@
 --require spec_helper
 --color
 --order random
+--exclude-pattern "spec/manageiq/**/*_spec.rb"
 --profile 25

--- a/lib/tasks_private/spec.rake
+++ b/lib/tasks_private/spec.rake
@@ -7,5 +7,4 @@ desc "Run all specs"
 RSpec::Core::RakeTask.new(:spec => ["app:test:initialize", "app:evm:compile_sti_loader"]) do |t|
   spec_dir = File.expand_path("../../spec", __dir__)
   EvmTestHelper.init_rspec_task(t, ['--require', File.join(spec_dir, 'spec_helper')])
-  t.pattern = FileList[spec_dir + '/**/*_spec.rb'].exclude(spec_dir + '/manageiq/**/*_spec.rb')
 end


### PR DESCRIPTION
`bundle exec rspec` now works allowing you to run the whole test suite and does not include anything in `spec/manageiq`