### PR TITLE
remove global variable _miq_worker_current_msg

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -24,19 +24,7 @@ module MiqAeEngine
       :msg_timeout => 60.minutes
     }.merge(options)
 
-    static_keys = [:class_name, :method_name, :zone, :msg_timeout]
-
-    ##############################################
-    # IF there is no current message
-    # OR any of the static keys in the current message do NOT match the value in the options for the same key,
-    # THEN create a new message
-    # ELSE requeue the current message with the new options
-    ##############################################
-    if $_miq_worker_current_msg.nil? || options.any? { |key, value| static_keys.include?(key) ? ($_miq_worker_current_msg.send(key) != value) : false }
-      MiqQueue.put(options)
-    else
-      $_miq_worker_current_msg.requeue(options)
-    end
+    MiqQueue.put(options)
   end
 
   def self.deliver(*args)

--- a/spec/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
@@ -13,12 +13,6 @@ module MiqAeServiceManageIQ_Providers_Vmware_InfraManager_VmSpec
         :role        => 'ems_operations',
         :task_id     => nil
       }
-
-      $_miq_worker_current_msg = FactoryGirl.build(:miq_queue, :task_id => '1234')
-    end
-
-    after do
-      $_miq_worker_current_msg = nil
     end
 
     it "#set_number_of_cpus" do


### PR DESCRIPTION
Trying to get away from using `$_miq_worker_current_msg` global variable

This will get us closer to using any queuing system.

/cc @mkanoor 