### PR TITLE
[WIP] Add MiqAeService model for service template catalogs

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -94,11 +94,6 @@ module MiqAeMethodService
       return nil
     end
 
-    def create_service_provision_request(svc_template, options = nil)
-      result = ar_object(svc_template).provision_request(@workspace.ae_user, options)
-      MiqAeServiceModelBase.wrap_results(result)
-    end
-
     def object(path = nil)
       obj = @workspace.get_obj_from_path(path)
       return nil if obj.nil?

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -110,6 +110,11 @@ module MiqAeMethodService
       MiqAeServiceModelBase.wrap_results(AutomationRequest.create_request(options, user, auto_approve))
     end
 
+    def self.create_service_provision_request(svc_template, options = nil)
+      result = ar_object(svc_template).provision_request(@workspace.ae_user, options)
+      MiqAeServiceModelBase.wrap_results(result)
+    end
+
     def self.drb_undumped(klass)
       _log.info "Entered: klass=#{klass.name}"
       klass.include(DRbUndumped) unless klass.ancestors.include?(DRbUndumped)

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -111,7 +111,7 @@ module MiqAeMethodService
     end
 
     def self.create_service_provision_request(svc_template, options = nil)
-      result = ar_object(svc_template).provision_request(@workspace.ae_user, options)
+      result = svc_template.object_send(:provision_request, User.current_user, options)
       MiqAeServiceModelBase.wrap_results(result)
     end
 

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_catalog.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_catalog.rb
@@ -1,0 +1,7 @@
+module MiqAeMethodService
+  class MiqAeServiceServiceTemplateCatalog < MiqAeServiceModelBase
+    expose :service_template_catalogs, :association => true
+    expose :service_templates,         :association => true
+    expose :tenant,                    :association => true
+  end
+end

--- a/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
@@ -162,5 +162,32 @@ module MiqAeServiceMethodsSpec
       ct.reload
       expect(ct.entries.collect(&:name).include?('fred')).to be_truthy
     end
+
+    context "#create_service_provision_request" do
+      let(:options) { {:fred => :flintstone} }
+      let(:svc_options) { {:dialog_style => "medium"} }
+      let(:user) { FactoryGirl.create(:user_with_group) }
+      let(:template) { FactoryGirl.create(:service_template_ansible_playbook) }
+      let(:miq_request) { FactoryGirl.create(:service_template_provision_request) }
+      let(:svc_template) do
+        MiqAeMethodService::MiqAeServiceServiceTemplate.find(template.id)
+      end
+      let(:workspace) do
+        double("MiqAeEngine::MiqAeWorkspaceRuntime",
+               :root               => options,
+               :persist_state_hash => {},
+               :ae_user            => user)
+      end
+      let(:miq_ae_service) { MiqAeService.new(workspace) }
+
+      it "create service request" do
+        allow(workspace).to receive(:disable_rbac)
+        expect(svc_template).to receive(:instance_variable_get).with('@object').and_return(template)
+        expect(template).to receive(:provision_request).with(user, svc_options).and_return(miq_request)
+
+        result = miq_ae_service.execute(:create_service_provision_reques, svc_template, svc_options)
+        expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
+      end
+    end
   end
 end

--- a/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
@@ -178,14 +178,13 @@ module MiqAeServiceMethodsSpec
                :persist_state_hash => {},
                :ae_user            => user)
       end
-      let(:miq_ae_service) { MiqAeService.new(workspace) }
+      let(:miq_ae_service) { MiqAeMethodService::MiqAeService.new(workspace) }
 
       it "create service request" do
         allow(workspace).to receive(:disable_rbac)
-        expect(svc_template).to receive(:instance_variable_get).with('@object').and_return(template)
-        expect(template).to receive(:provision_request).with(user, svc_options).and_return(miq_request)
+        expect_any_instance_of(ServiceTemplate).to receive(:provision_request).with(user, svc_options).and_return(miq_request)
 
-        result = miq_ae_service.execute(:create_service_provision_reques, svc_template, svc_options)
+        result = miq_ae_service.execute(:create_service_provision_request, svc_template, svc_options)
         expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
       end
     end

--- a/spec/miq_ae_service_spec.rb
+++ b/spec/miq_ae_service_spec.rb
@@ -208,32 +208,5 @@ module MiqAeServiceSpec
         end
       end
     end
-
-    context "#create_service_provision_request" do
-      let(:options) { {:fred => :flintstone} }
-      let(:svc_options) { {:dialog_style => "medium"} }
-      let(:user) { FactoryGirl.create(:user_with_group) }
-      let(:template) { FactoryGirl.create(:service_template_ansible_playbook) }
-      let(:miq_request) { FactoryGirl.create(:service_template_provision_request) }
-      let(:svc_template) do
-        MiqAeMethodService::MiqAeServiceServiceTemplate.find(template.id)
-      end
-      let(:workspace) do
-        double("MiqAeEngine::MiqAeWorkspaceRuntime",
-               :root               => options,
-               :persist_state_hash => {},
-               :ae_user            => user)
-      end
-      let(:miq_ae_service) { MiqAeService.new(workspace) }
-
-      it "create service request" do
-        allow(workspace).to receive(:disable_rbac)
-        expect(svc_template).to receive(:instance_variable_get).with('@object').and_return(template)
-        expect(template).to receive(:provision_request).with(user, svc_options).and_return(miq_request)
-
-        result = miq_ae_service.create_service_provision_request(svc_template, svc_options)
-        expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
-      end
-    end
   end
 end

--- a/spec/service_models/miq_ae_service_service_template_catalog_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_catalog_spec.rb
@@ -5,18 +5,18 @@ module MiqAeServiceServiceTemplateCatalogSpec
         Spec::Support::MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM', 'AUTOMATE', 'test1', 'test')
         @ae_method     = ::MiqAeMethod.first
         @ae_result_key = 'foo'
-        @service_template   = FactoryGirl.create(:service_template_catalog)
+        @service_template_catalog = FactoryGirl.create(:service_template_catalog)
         @user = FactoryGirl.create(:user_with_group)
       end
 
       def invoke_ae
-        MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?ServiceTemplateCatalog::service_template_catalog=#{@service_template.id}", @user)
+        MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?ServiceTemplateCatalog::service_template_catalog=#{@service_template_catalog.id}", @user)
       end
     end
 
     context "associations" do
       before do
-        service_template          = FactoryGirl.create(:service_template)
+        service_template_catalog          = FactoryGirl.create(:service_template_catalog)
         @service_service_template_catalog  = MiqAeMethodService::MiqAeServiceServiceTemplateCatalog.find(service_template_catalog.id)
       end
 

--- a/spec/service_models/miq_ae_service_service_template_catalog_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_catalog_spec.rb
@@ -1,0 +1,33 @@
+module MiqAeServiceServiceTemplateCatalogSpec
+  describe MiqAeMethodService::MiqAeServiceServiceTemplateCatalog do
+    context "through an automation method" do
+      before(:each) do
+        Spec::Support::MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM', 'AUTOMATE', 'test1', 'test')
+        @ae_method     = ::MiqAeMethod.first
+        @ae_result_key = 'foo'
+        @service_template   = FactoryGirl.create(:service_template_catalog)
+        @user = FactoryGirl.create(:user_with_group)
+      end
+
+      def invoke_ae
+        MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?ServiceTemplateCatalog::service_template_catalog=#{@service_template.id}", @user)
+      end
+    end
+
+    context "associations" do
+      before do
+        service_template          = FactoryGirl.create(:service_template)
+        @service_service_template_catalog  = MiqAeMethodService::MiqAeServiceServiceTemplateCatalog.find(service_template_catalog.id)
+      end
+
+      it "#service_templates" do
+        service_template = FactoryGirl.create(:service_template, :service_template_catalog_id => @service_service_template_catalog.id)
+        first_service_template = @service_service_template_catalog.service_templates.first
+
+        expect(first_service_template).to    be_kind_of(MiqAeMethodService::MiqAeServiceService)
+        expect(first_service_template.id).to eq(service_template.id)
+      end
+
+    end
+  end
+end

--- a/spec/service_models/miq_ae_service_service_template_catalog_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_catalog_spec.rb
@@ -24,7 +24,7 @@ module MiqAeServiceServiceTemplateCatalogSpec
         service_template = FactoryGirl.create(:service_template, :service_template_catalog_id => @service_service_template_catalog.id)
         first_service_template = @service_service_template_catalog.service_templates.first
 
-        expect(first_service_template).to be_kind_of(MiqAeMethodService::MiqAeServiceService)
+        expect(first_service_template).to be_kind_of(MiqAeMethodService::MiqAeServiceServiceTemplate)
         expect(first_service_template.id).to eq(service_template.id)
       end
     end

--- a/spec/service_models/miq_ae_service_service_template_catalog_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_catalog_spec.rb
@@ -3,7 +3,7 @@ module MiqAeServiceServiceTemplateCatalogSpec
     context "through an automation method" do
       before(:each) do
         Spec::Support::MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM', 'AUTOMATE', 'test1', 'test')
-        @ae_method     = ::MiqAeMethod.first
+        @ae_method = ::MiqAeMethod.first
         @ae_result_key = 'foo'
         @service_template_catalog = FactoryGirl.create(:service_template_catalog)
         @user = FactoryGirl.create(:user_with_group)
@@ -16,18 +16,17 @@ module MiqAeServiceServiceTemplateCatalogSpec
 
     context "associations" do
       before do
-        service_template_catalog          = FactoryGirl.create(:service_template_catalog)
-        @service_service_template_catalog  = MiqAeMethodService::MiqAeServiceServiceTemplateCatalog.find(service_template_catalog.id)
+        service_template_catalog = FactoryGirl.create(:service_template_catalog)
+        @service_service_template_catalog = MiqAeMethodService::MiqAeServiceServiceTemplateCatalog.find(service_template_catalog.id)
       end
 
       it "#service_templates" do
         service_template = FactoryGirl.create(:service_template, :service_template_catalog_id => @service_service_template_catalog.id)
         first_service_template = @service_service_template_catalog.service_templates.first
 
-        expect(first_service_template).to    be_kind_of(MiqAeMethodService::MiqAeServiceService)
+        expect(first_service_template).to be_kind_of(MiqAeMethodService::MiqAeServiceService)
         expect(first_service_template.id).to eq(service_template.id)
       end
-
     end
   end
 end


### PR DESCRIPTION
Currently, it is not possible to explore service catalogs from Automate, while it is to explore service templates. This pull request closes the gap.

This is my first pull request ever, so please be gentle and guide me :)