### PR TITLE
[WIP] Server side of GRPC

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_grpc_dialog_server.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_grpc_dialog_server.rb
@@ -1,0 +1,84 @@
+require 'grpc'
+require 'dialog_field_services_pb'
+
+class MiqAeGrpcDialogServer < Manageiq::Dialog::AutomateDialog::Service
+  def get_dialog_field_date_control(input, _unused_call)
+    attributes = call_automate(input).root.attributes
+    result =  Manageiq::Dialog::DialogFieldDateControlResult.new
+    result.show_past_dates = attributes[:show_past_dates] || false
+    result.read_only       = attributes[:read_only]       || false
+    result.visible         = attributes[:visible]         || true
+    result.value           = attributes[:value]           || ""
+    result
+  end
+
+  def get_dialog_field_date_time_control(input, _unused_call)
+    attributes = call_automate(input).root.attributes
+    result =  Manageiq::Dialog::DialogFieldDateTimeControlResult.new
+    result.show_past_dates = attributes[:show_past_dates] || false
+    result.read_only       = attributes[:read_only]       || false
+    result.visible         = attributes[:visible]         || true
+    result.value           = attributes[:value]           || ""
+    result
+  end
+
+  def get_dialog_field_sorted_item(input, _unused_call)
+    attributes = call_automate(input).root.attributes
+    valuesMap = Google::Protobuf::Map.new(:int64, :string)
+    attributes['values'].each { |k, v| valuesMap[k] = v }
+    result = Manageiq::Dialog::DialogFieldSortedItemResult.new
+    result.sort_by       = attributes[:sort_by] || 'description'
+    result.data_type     = attributes[:data_type] || 'string'
+    result.required      = attributes[:required]  || false
+    result.sort_order    = attributes[:sort_order] || 'ascending'
+    result.values        = valuesMap
+    result.default_value = ""
+    result
+  end
+
+  def get_dialog_field_text_area_box(input, _unused_call)
+    puts "Method called #{input.to_h}"
+    attributes = call_automate(input).root.attributes
+    result =  Manageiq::Dialog::DialogFieldTextAreaBoxResult.new
+    result.required        = attributes[:required]  || false
+    result.read_only       = attributes[:read_only] || false
+    result.visible         = attributes[:visible]   || true
+    result.value           = attributes[:value]     || ""
+    result
+  end
+
+  def get_dialog_field_text_box(input, _unused_call)
+    attributes = call_automate(input).root.attributes
+    result =  Manageiq::Dialog::DialogFieldTextBoxResult.new
+    result.data_type       = attributes[:data_type] || 'string'
+    result.protected       = attributes[:protected] || false
+    result.required        = attributes[:required]  || false
+    result.validator_rule  = attributes[:validator_rule] || ""
+    result.validator_type  = attributes[:validator_type] || ""
+    result.read_only       = attributes[:read_only] || false
+    result.visible         = attributes[:visible]   || true
+    result.value           = attributes[:value]     || ""
+    result
+  end
+
+  def get_dialog_field_check_box(input, _unused_call)
+    attributes = call_automate(input).root.attributes
+    result =  Manageiq::Dialog::DialogFieldCheckBoxResult.new
+    result.required        = attributes[:required]  || true
+    result.read_only       = attributes[:read_only] || false
+    result.visible         = attributes[:visible]   || true
+    result.value           = attributes[:value]     || ""
+    result
+  end
+
+  def call_automate(input_map)
+    MiqAeEngine.deliver(input_map.to_h)
+  end
+
+  def self.start_grpc_server
+    s = GRPC::RpcServer.new
+    s.add_http2_port('0.0.0.0:50051', :this_port_is_insecure)
+    s.handle(self)
+    s.run_till_terminated
+  end
+end

--- a/lib/miq_automation_engine/engine/miq_ae_grpc_dialog_server.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_grpc_dialog_server.rb
@@ -14,7 +14,7 @@ class MiqAeGrpcDialogServer < Manageiq::Dialog::AutomateDialog::Service
 
   def get_dialog_field_date_time_control(input, _unused_call)
     attributes = call_automate(input).root.attributes
-    result =  Manageiq::Dialog::DialogFieldDateTimeControlResult.new
+    result = Manageiq::Dialog::DialogFieldDateTimeControlResult.new
     result.show_past_dates = attributes[:show_past_dates] || false
     result.read_only       = attributes[:read_only]       || false
     result.visible         = attributes[:visible]         || true
@@ -24,14 +24,14 @@ class MiqAeGrpcDialogServer < Manageiq::Dialog::AutomateDialog::Service
 
   def get_dialog_field_sorted_item(input, _unused_call)
     attributes = call_automate(input).root.attributes
-    valuesMap = Google::Protobuf::Map.new(:int64, :string)
-    attributes['values'].each { |k, v| valuesMap[k] = v }
+    values_map = Google::Protobuf::Map.new(:int64, :string)
+    attributes['values'].each { |k, v| values_map[k] = v }
     result = Manageiq::Dialog::DialogFieldSortedItemResult.new
     result.sort_by       = attributes[:sort_by] || 'description'
     result.data_type     = attributes[:data_type] || 'string'
     result.required      = attributes[:required]  || false
     result.sort_order    = attributes[:sort_order] || 'ascending'
-    result.values        = valuesMap
+    result.values        = values_map
     result.default_value = ""
     result
   end
@@ -39,7 +39,7 @@ class MiqAeGrpcDialogServer < Manageiq::Dialog::AutomateDialog::Service
   def get_dialog_field_text_area_box(input, _unused_call)
     puts "Method called #{input.to_h}"
     attributes = call_automate(input).root.attributes
-    result =  Manageiq::Dialog::DialogFieldTextAreaBoxResult.new
+    result = Manageiq::Dialog::DialogFieldTextAreaBoxResult.new
     result.required        = attributes[:required]  || false
     result.read_only       = attributes[:read_only] || false
     result.visible         = attributes[:visible]   || true
@@ -49,7 +49,7 @@ class MiqAeGrpcDialogServer < Manageiq::Dialog::AutomateDialog::Service
 
   def get_dialog_field_text_box(input, _unused_call)
     attributes = call_automate(input).root.attributes
-    result =  Manageiq::Dialog::DialogFieldTextBoxResult.new
+    result = Manageiq::Dialog::DialogFieldTextBoxResult.new
     result.data_type       = attributes[:data_type] || 'string'
     result.protected       = attributes[:protected] || false
     result.required        = attributes[:required]  || false
@@ -63,7 +63,7 @@ class MiqAeGrpcDialogServer < Manageiq::Dialog::AutomateDialog::Service
 
   def get_dialog_field_check_box(input, _unused_call)
     attributes = call_automate(input).root.attributes
-    result =  Manageiq::Dialog::DialogFieldCheckBoxResult.new
+    result = Manageiq::Dialog::DialogFieldCheckBoxResult.new
     result.required        = attributes[:required]  || true
     result.read_only       = attributes[:read_only] || false
     result.visible         = attributes[:visible]   || true

--- a/protos/dialog_field.proto
+++ b/protos/dialog_field.proto
@@ -1,0 +1,76 @@
+syntax = "proto3";
+
+package manageiq.dialog;
+
+message Input {
+  string               namespace        = 1;
+  string               class_name       = 2;
+  string               instance_name    = 3;
+  string               automate_message = 4;
+  string               user_id          = 5;
+  string               miq_group_id     = 6;
+  string               tenant_id        = 7;
+  string               object_type      = 8;
+  string               object_id        = 9;
+  map <string, string> attrs            = 10;
+}
+
+message DialogFieldCheckBoxResult {
+  bool                required           = 1;
+  bool                read_only          = 2;
+  bool                visible            = 3;
+  string              value              = 4;
+}
+
+message DialogFieldTextBoxResult {
+  string              data_type          = 1;
+  bool                protected          = 2;
+  bool                required           = 3;
+  string              validator_rule     = 4;
+  string              validator_type     = 5;
+  bool                read_only          = 6;
+  bool                visible            = 7;
+  string              value              = 8;
+}
+
+message DialogFieldTextAreaBoxResult {
+  bool                required           = 1;
+  bool                read_only          = 2;
+  bool                visible            = 3;
+  string              value              = 4;
+}
+
+
+message DialogFieldSortedItemResult {
+  string              sort_by       = 1;
+  string              sort_order    = 2;
+  string              data_type     = 3;
+  string              default_value = 4; 
+  bool                required      = 5;
+  map <int64, string> values        = 6;
+}
+
+message DialogFieldDateTimeControlResult {
+  bool                show_past_dates = 1;
+  bool                read_only       = 2;
+  bool                visible         = 3;
+  string              value           = 4;
+}
+
+message DialogFieldDateControlResult {
+  bool                show_past_dates = 1;
+  bool                read_only       = 2;
+  bool                visible         = 3;
+  string              value           = 4;
+}
+
+// The Dialog service definition.
+service AutomateDialog {
+  // Sends back the result of a dialog field method
+  rpc GetDialogFieldDateControl(Input) returns (DialogFieldDateControlResult) {}
+  rpc GetDialogFieldDateTimeControl(Input) returns (DialogFieldDateTimeControlResult) {}
+  rpc GetDialogFieldSortedItem(Input) returns (DialogFieldSortedItemResult) {}
+  rpc GetDialogFieldTextAreaBox(Input) returns (DialogFieldTextAreaBoxResult) {}
+  rpc GetDialogFieldTextBox(Input) returns (DialogFieldTextBoxResult) {}
+  rpc GetDialogFieldCheckBox(Input) returns (DialogFieldCheckBoxResult) {}
+}


### PR DESCRIPTION
This WIP PR demonstrates the use of gRPC to communicate between the UI dialog controller and Automate Engine. Today the automate engine is called directly from the UI controller. This PR allows the Automate to be running on a separate server and communicate using the gRPC. gRPC is built on top of protocol buffers, which requires that the request/response data structures be well defined in proto files, which can be compiled to be used in different programming languages. 


The Server side of GRPC inside of Automate Engine. To start the Server run
```
MiqAeGrpcDialogServer.start_grpc_server
```

To compile the protocol buffer files you need the grpc-tools gem and run the following command
```
grpc_tools_ruby_protoc -I protos --ruby_out=../manageiq/app/models --grpc_out=../manageiq/app/models protos/dialog_field.proto
```

The Client side is in PR https://github.com/ManageIQ/manageiq/pull/15328
