### PR TITLE
Add MiqAeService model for service template catalogs

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_catalog.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_catalog.rb
@@ -1,0 +1,6 @@
+module MiqAeMethodService
+  class MiqAeServiceServiceTemplateCatalog < MiqAeServiceModelBase
+    expose :service_templates,         :association => true
+    expose :tenant,                    :association => true
+  end
+end

--- a/spec/service_models/miq_ae_service_service_template_catalog_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_catalog_spec.rb
@@ -1,0 +1,18 @@
+module MiqAeServiceServiceTemplateCatalogSpec
+  describe MiqAeMethodService::MiqAeServiceServiceTemplateCatalog do
+    context "associations" do
+      before do
+        service_template_catalog = FactoryGirl.create(:service_template_catalog)
+        @service_service_template_catalog = MiqAeMethodService::MiqAeServiceServiceTemplateCatalog.find(service_template_catalog.id)
+      end
+
+      it "#service_templates" do
+        service_template = FactoryGirl.create(:service_template, :service_template_catalog_id => @service_service_template_catalog.id)
+        first_service_template = @service_service_template_catalog.service_templates.first
+
+        expect(first_service_template).to be_kind_of(MiqAeMethodService::MiqAeServiceServiceTemplate)
+        expect(first_service_template.id).to eq(service_template.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, it is not possible to explore service catalogs from Automate, while it is to explore service templates. This pull request closes the gap.