### PR TITLE
Add ae_state_max_retries to root object.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
@@ -8,14 +8,16 @@ module MiqAeEngine
       true
     end
 
-    def initialize_state_maxima_metadata
+    def initialize_state_maxima_metadata(field)
       @workspace.root['ae_state_started'] = Time.zone.now.utc.to_s  if @workspace.root['ae_state_started'].blank?
       @workspace.root['ae_state_retries'] = 0                  if @workspace.root['ae_state_retries'].blank?
+      @workspace.root['ae_state_max_retries'] = field['max_retries'].to_i if @workspace.root['ae_state_max_retries'].to_i.zero?
     end
 
     def reset_state_maxima_metadata
       @workspace.root['ae_state_started'] = ''
       @workspace.root['ae_state_retries'] = 0
+      @workspace.root['ae_state_max_retries'] = 0
     end
 
     def increment_state_retries
@@ -67,7 +69,7 @@ module MiqAeEngine
         return unless state_runnable?(f)
 
         # Ensure the metadata to deal with retries and timeouts is initialized
-        initialize_state_maxima_metadata
+        initialize_state_maxima_metadata(f)
 
         # Process on_entry method
         process_state_step_with_error_handling(f, 'on_entry') { process_state_method(f, 'on_entry') }

--- a/spec/engine/miq_ae_state_machine_steps_spec.rb
+++ b/spec/engine/miq_ae_state_machine_steps_spec.rb
@@ -91,9 +91,9 @@ describe "MiqAeStateMachineSteps" do
     all_steps = {'on_entry' => "common_state_method",
                  'on_exit'  => "common_state_method",
                  'on_error' => "common_state_method"}
-    ae_fields = {'state1' => {:aetype => 'state', :datatype => 'string', :priority => 1},
-                 'state2' => {:aetype => 'state', :datatype => 'string', :priority => 2},
-                 'state3' => {:aetype => 'state', :datatype => 'string', :priority => 3}}
+    ae_fields = {'state1' => {:aetype => 'state', :datatype => 'string', :priority => 1, :max_retries => 100},
+                 'state2' => {:aetype => 'state', :datatype => 'string', :priority => 2, :max_retries => 100},
+                 'state3' => {:aetype => 'state', :datatype => 'string', :priority => 3, :max_retries => 100}}
     state1_value = "/#{@domain}/#{@namespace}/#{@method_class}/#{@instance1}"
     state2_value = "/#{@domain}/#{@namespace}/#{@method_class}/#{@instance2}"
     state3_value = "/#{@domain}/#{@namespace}/#{@method_class}/#{@instance3}"
@@ -297,6 +297,7 @@ describe "MiqAeStateMachineSteps" do
     expect(ws.root.attributes['step_on_exit']).to match_array(%w(state1 state2))
     expect(ws.root.attributes['step_on_error']).to be_nil
     expect(ws.root.attributes['ae_state_retries']).to eq(1)
+    expect(ws.root.attributes['ae_state_max_retries']).to eq(100)
   end
 
   it "allow for retry to be set on on_exit method" do
@@ -308,6 +309,7 @@ describe "MiqAeStateMachineSteps" do
     expect(ws.root.attributes['step_on_exit']).to match_array(%w(state1 state2))
     expect(ws.root.attributes['step_on_error']).to be_nil
     expect(ws.root.attributes['ae_state_retries']).to eq(1)
+    expect(ws.root.attributes['ae_state_max_retries']).to eq(100)
   end
 
   it "non existent on_error method" do


### PR DESCRIPTION
Adding ae_state_max_retries to the root object will enable us to calculate the state machine ae_retry_interval based on the new Service Template value ttl(time to live) divided by the ae_state_max_retries.

https://www.pivotaltracker.com/n/projects/1937537/stories/147361947