### PR TITLE
Remove the expose of manager to Embedded Ansible Job in service model.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-automation_manager-orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-automation_manager-orchestration_stack.rb
@@ -1,5 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_AutomationManager_OrchestrationStack < MiqAeServiceOrchestrationStack
-    expose :manager, :association => true
-  end
-end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_ansible-automation_manager-job.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_ansible-automation_manager-job.rb
@@ -1,5 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_EmbeddedAnsible_AutomationManager_Job < MiqAeServiceManageIQ_Providers_EmbeddedAutomationManager_OrchestrationStack
-    expose :manager, :association => true
-  end
-end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_automation_manager-orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-embedded_automation_manager-orchestration_stack.rb
@@ -1,5 +1,0 @@
-module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_EmbeddedAutomationManager_OrchestrationStack < MiqAeServiceManageIQ_Providers_AutomationManager_OrchestrationStack
-    expose :manager, :association => true
-  end
-end


### PR DESCRIPTION
The :manager association to Embedded Ansible Job does not exist in the model side.

https://bugzilla.redhat.com/show_bug.cgi?id=1465826

@miq-bot assign @gmcculloug
@miq-bot add_label bug, fine/yes