### PR TITLE
Fix undefined local variable or method `ws' for MiqAeEngine:Module

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -298,7 +298,7 @@ module MiqAeEngine
     raise "User object not passed in" unless user_obj.kind_of?(User)
     uri = create_automation_object(uri, attr, options) if attr
     options[:uri] = uri
-    MiqAeWorkspaceRuntime.instantiate(uri, user_obj, :readonly => readonly).tap do
+    MiqAeWorkspaceRuntime.instantiate(uri, user_obj, :readonly => readonly).tap do |ws|
       $miq_ae_logger.debug { ws.to_expanded_xml }
     end
   end


### PR DESCRIPTION
Introduced by:50a47cd58cb543882e5212da6c01274590ae5993
or... ManageIQ/manageiq@360401dd2baa70aa9bdf8b3b17996f0d044df40f

```
Q-task_id([log_status]) MIQ(MiqQueue#deliver) Message id: [232], Error: [undefined local variable or method `ws' for MiqAeEngine:Module]
Q-task_id([log_status]) [NameError]: undefined local variable or method `ws' for MiqAeEngine:Module  Method:[block in method_missing]
Q-task_id([log_status]) /opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/bundler/gems/manageiq-automation_engine-03e06cd4cf1e/lib/miq_automation_engine/engine/miq_ae_engine.rb:302:in `block (2 levels) in resolve_automation_object'
/opt/rubies/ruby-2.3.1/lib/ruby/2.3.0/logger.rb:427:in `add'
/opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/activerecord-session_store-1.0.0/lib/active_record/session_store/extension/logger_silencer.rb:38:in `add_with_threadsafety'
/var/www/miq/vmdb/lib/vmdb/loggers/multicast_logger.rb:22:in `block in add'
/opt/rubies/ruby-2.3.1/lib/ruby/2.3.0/set.rb:306:in `each_key'
/opt/rubies/ruby-2.3.1/lib/ruby/2.3.0/set.rb:306:in `each'
/var/www/miq/vmdb/lib/vmdb/loggers/multicast_logger.rb:22:in `add'
/opt/rubies/ruby-2.3.1/lib/ruby/2.3.0/logger.rb:455:in `debug'
/opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/bundler/gems/manageiq-automation_engine-03e06cd4cf1e/lib/miq_automation_engine/engine/miq_ae_engine.rb:302:in `block in resolve_automation_object'
/opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/bundler/gems/manageiq-automation_engine-03e06cd4cf1e/lib/miq_automation_engine/engine/miq_ae_engine.rb:301:in `tap'
/opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/bundler/gems/manageiq-automation_engine-03e06cd4cf1e/lib/miq_automation_engine/engine/miq_ae_engine.rb:301:in `resolve_automation_object'
/opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/bundler/gems/manageiq-automation_engine-03e06cd4cf1e/lib/miq_automation_engine/engine/miq_ae_engine.rb:95:in `deliver'
/var/www/miq/vmdb/app/models/miq_queue.rb:387:in `block in deliver'
/opt/rubies/ruby-2.3.1/lib/ruby/2.3.0/timeout.rb:91:in `block in timeout'
/opt/rubies/ruby-2.3.1/lib/ruby/2.3.0/timeout.rb:33:in `block in catch'
/opt/rubies/ruby-2.3.1/lib/ruby/2.3.0/timeout.rb:33:in `catch'
/opt/rubies/ruby-2.3.1/lib/ruby/2.3.0/timeout.rb:33:in `catch'
/opt/rubies/ruby-2.3.1/lib/ruby/2.3.0/timeout.rb:106:in `timeout'
/var/www/miq/vmdb/app/models/miq_queue.rb:386:in `deliver'
/var/www/miq/vmdb/app/models/miq_queue_worker_base/runner.rb:108:in `deliver_queue_message'
/var/www/miq/vmdb/app/models/miq_queue_worker_base/runner.rb:137:in `deliver_message'
/var/www/miq/vmdb/app/models/miq_queue_worker_base/runner.rb:155:in `block in do_work'
/var/www/miq/vmdb/app/models/miq_queue_worker_base/runner.rb:149:in `loop'
/var/www/miq/vmdb/app/models/miq_queue_worker_base/runner.rb:149:in `do_work'
/var/www/miq/vmdb/app/models/miq_worker/runner.rb:344:in `block in do_work_loop'
/var/www/miq/vmdb/app/models/miq_worker/runner.rb:341:in `loop'
/var/www/miq/vmdb/app/models/miq_worker/runner.rb:341:in `do_work_loop'
/var/www/miq/vmdb/app/models/miq_worker/runner.rb:162:in `run'
/var/www/miq/vmdb/app/models/miq_worker/runner.rb:136:in `start'
/var/www/miq/vmdb/app/models/miq_worker/runner.rb:23:in `start_worker'
/var/www/miq/vmdb/app/models/miq_worker.rb:357:in `block in start_runner_via_fork'
/opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/nakayoshi_fork-0.0.3/lib/nakayoshi_fork.rb:24:in `fork'
/opt/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/nakayoshi_fork-0.0.3/lib/nakayoshi_fork.rb:24:in `fork'
/var/www/miq/vmdb/app/models/miq_worker.rb:355:in `start_runner_via_fork'
/var/www/miq/vmdb/app/models/miq_worker.rb:349:in `start_runner'
/var/www/miq/vmdb/app/models/miq_worker.rb:383:in `start'
/var/www/miq/vmdb/app/models/miq_worker.rb:274:in `start_worker'
/var/www/miq/vmdb/app/models/miq_worker.rb:154:in `block in sync_workers'
/var/www/miq/vmdb/app/models/miq_worker.rb:154:in `times'
/var/www/miq/vmdb/app/models/miq_worker.rb:154:in `sync_workers'
/var/www/miq/vmdb/app/models/miq_server/worker_management/monitor.rb:53:in `block in sync_workers'
/var/www/miq/vmdb/app/models/miq_server/worker_management/monitor.rb:50:in `each'
/var/www/miq/vmdb/app/models/miq_server/worker_management/monitor.rb:50:in `sync_workers'
/var/www/miq/vmdb/app/models/miq_server.rb:157:in `start'
/var/www/miq/vmdb/app/models/miq_server.rb:249:in `start'
/var/www/miq/vmdb/lib/workers/evm_server.rb:27:in `start'
/var/www/miq/vmdb/lib/workers/evm_server.rb:48:in `start'
/var/www/miq/vmdb/lib/workers/bin/evm_server.rb:4:in `\u003cmain\u003e'
```