### PR TITLE
Support for expression methods

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
@@ -36,10 +36,10 @@ module MiqAeEngine
     end
 
     def process_filter
-      exp_table = exp_build_table(@exp)
+      exp_table = exp_build_table(@exp, true)
       qs_tokens = create_tokens(exp_table, @exp)
       values = get_args(qs_tokens.keys.length)
-      values.each_with_index { |v, index| qs_tokens[index + 1][:value] = v }
+      qs_tokens.keys.each_with_index { |token_at, index| qs_tokens[token_at][:value] = values[index] } 
       exp_replace_qs_tokens(@exp, qs_tokens)
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
@@ -39,7 +39,7 @@ module MiqAeEngine
       exp_table = exp_build_table(@exp, true)
       qs_tokens = create_tokens(exp_table, @exp)
       values = get_args(qs_tokens.keys.length)
-      qs_tokens.keys.each_with_index { |token_at, index| qs_tokens[token_at][:value] = values[index] } 
+      qs_tokens.keys.each_with_index { |token_at, index| qs_tokens[token_at][:value] = values[index] }
       exp_replace_qs_tokens(@exp, qs_tokens)
     end
 
@@ -65,8 +65,7 @@ module MiqAeEngine
     end
 
     def result_simple(obj, attr)
-      raise MiqAeException::MethodNotDefined,
-            "Undefined method #{attr} in class #{obj.class}" unless obj.respond_to?(attr.to_sym)
+      raise MiqAeException::MethodNotDefined, "Undefined method #{attr} in class #{obj.class}" unless obj.respond_to?(attr.to_sym)
       obj.send(attr.to_sym)
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
@@ -1,0 +1,147 @@
+module MiqAeEngine
+  class MiqAeExpressionMethod
+    include ApplicationController::Filter::SubstMixin
+    def initialize(method_obj, obj, inputs)
+      @edit = {}
+      @name = method_obj.name
+      @workspace = obj.workspace
+      @inputs = inputs
+      @attributes = inputs['distinct'] || inputs['attributes'] || %w(name)
+      load_expression(method_obj.data)
+      process_filter
+    end
+
+    def run
+      @search_objects = Rbac.search(:filter         => MiqExpression.new(@exp),
+                                    :class          => @exp_object,
+                                    :results_format => :objects).first
+      @search_objects.empty? ? error_handler : set_result
+    end
+
+    private
+
+    def load_expression(data)
+      raise MiqAeException::MethodExpressionEmpty, "Empty expression" if data.blank?
+      begin
+        hash = YAML.load(data)
+        if hash[:expression] && hash[:db]
+          @exp = hash[:expression]
+          @exp_object = hash[:db]
+        else
+          raise MiqAeException::MethodExpressionInvalid, "Invalid expression #{data}"
+        end
+      rescue
+        raise MiqAeException::MethodExpressionInvalid, "Invalid expression #{data}"
+      end
+    end
+
+    def process_filter
+      exp_table = exp_build_table(@exp)
+      qs_tokens = create_tokens(exp_table, @exp)
+      values = get_args(qs_tokens.keys.length)
+      values.each_with_index { |v, index| qs_tokens[index + 1][:value] = v }
+      exp_replace_qs_tokens(@exp, qs_tokens)
+    end
+
+    def result_hash(obj)
+      @attributes.each_with_object({}) do |attr, hash|
+        hash[attr] = result_simple(obj, attr)
+      end
+    end
+
+    def result_array
+      multiple = @attributes.count > 1
+      result = @search_objects.collect do |obj|
+        multiple ? @attributes.collect { |attr| result_simple(obj, attr) } : result_simple(obj, @attributes.first)
+      end
+      @inputs['distinct'].blank? ? result : result.uniq
+    end
+
+    def result_dialog_hash
+      key = @inputs['key'] || 'id'
+      @search_objects.each_with_object({}) do |obj, hash|
+        hash[result_simple(obj, key)] = result_simple(obj, @attributes.first)
+      end
+    end
+
+    def result_simple(obj, attr)
+      raise MiqAeException::MethodNotDefined,
+            "Undefined method #{attr} in class #{obj.class}" unless obj.respond_to?(attr.to_sym)
+      obj.send(attr.to_sym)
+    end
+
+    def set_result
+      target_object.attributes[attribute_name] = exp_value
+      @workspace.root['ae_result'] = 'ok'
+    end
+
+    def error_handler
+      disposition = @inputs['on_empty'] || 'error'
+      case disposition.to_sym
+      when :error
+        set_error
+      when :warn
+        set_warn
+      when :abort
+        set_abort
+      end
+    end
+
+    def set_error
+      $miq_ae_logger.error("Expression method ends")
+      @workspace.root['ae_result'] = 'error'
+    end
+
+    def set_abort
+      $miq_ae_logger.error("Expression method aborted")
+      raise MiqAeException::AbortInstantiation, "Expression method #{@name} aborted"
+    end
+
+    def set_warn
+      $miq_ae_logger.warn("Expression method ends")
+      @workspace.root['ae_result'] = 'warn'
+      set_default_value
+    end
+
+    def set_default_value
+      return unless @inputs.key?('default')
+      target_object.attributes[attribute_name] = @inputs['default']
+    end
+
+    def attribute_name
+      @inputs['result_attr'] || 'values'
+    end
+
+    def target_object
+      @workspace.get_obj_from_path(@inputs['result_obj'] || '.').tap do |obj|
+        raise MiqAeException::MethodExpressionTargetObjectMissing, @inputs['result_obj'] unless obj
+      end
+    end
+
+    def exp_value
+      type = @inputs['result_type'] || 'dialog_hash'
+      case type.downcase.to_sym
+      when :hash
+        result_hash(@search_objects.first)
+      when :dialog_hash
+        result_dialog_hash
+      when :array
+        result_array
+      when :simple
+        result_simple(@search_objects.first, @inputs['attributes'].first)
+      else
+        raise MiqAeException::MethodExpressionResultTypeInvalid, "Invalid Result type, should be hash, array or dialog_hash"
+      end
+    end
+
+    def get_args(num_token)
+      params = []
+      (1..num_token).each do |i|
+        key = "arg#{i}"
+        raise MiqAeException::MethodParameterNotFound, key unless @inputs.key?(key)
+        params[i - 1] = @inputs[key]
+      end
+      params
+    end
+  end
+end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
@@ -23,7 +23,7 @@ module MiqAeEngine
     def load_expression(data)
       raise MiqAeException::MethodExpressionEmpty, "Empty expression" if data.blank?
       begin
-        hash = YAML.load(data)
+        hash = YAML.safe_load(data)
         if hash[:expression] && hash[:db]
           @exp = hash[:expression]
           @exp_object = hash[:db]

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
@@ -23,7 +23,7 @@ module MiqAeEngine
     def load_expression(data)
       raise MiqAeException::MethodExpressionEmpty, "Empty expression" if data.blank?
       begin
-        hash = YAML.safe_load(data)
+        hash = YAML.load(data)
         if hash[:expression] && hash[:db]
           @exp = hash[:expression]
           @exp_object = hash[:db]

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -65,7 +65,7 @@ module MiqAeEngine
 
       if obj.workspace.readonly?
         $miq_ae_logger.info("Workspace Instantiation is READONLY -- skipping method [#{aem.fqname}] with inputs [#{inputs.inspect}]")
-      elsif ["inline", "builtin", "uri", "expression"].include?(aem.location.downcase.strip)
+      elsif %w(inline builtin uri expression).include?(aem.location.downcase.strip)
         $miq_ae_logger.info("Invoking [#{aem.location}] method [#{aem.fqname}] with inputs [#{inputs.inspect}]")
         return MiqAeEngine::MiqAeMethod.send("invoke_#{aem.location.downcase.strip}", aem, obj, inputs)
       end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -11,6 +11,11 @@ module MiqAeEngine
       raise  MiqAeException::InvalidMethod, "Inline Method Language [#{aem.language}] not supported"
     end
 
+    def self.invoke_expression(aem, obj, inputs)
+      exp_method = MiqAeEngine::MiqAeExpressionMethod.new(aem, obj, inputs)
+      exp_method.run
+    end
+
     def self.invoke_uri(aem, obj, _inputs)
       scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(aem.data)
       raise  MiqAeException::MethodNotFound, "Specified URI [#{aem.data}] in Method [#{aem.name}] has unsupported scheme of #{scheme}; supported scheme is file" unless scheme.downcase == "file"
@@ -45,7 +50,7 @@ module MiqAeEngine
       aem.inputs.each do |f|
         key   = f.name
         value = args[key]
-        value = obj.attributes[key] || f.default_value if value.nil?
+        value = obj.attributes[key] || obj.substitute_value(f.default_value) if value.nil?
         inputs[key] = MiqAeObject.convert_value_based_on_datatype(value, f["datatype"])
 
         if obj.attributes[key] && f["datatype"] != "string"
@@ -60,7 +65,7 @@ module MiqAeEngine
 
       if obj.workspace.readonly?
         $miq_ae_logger.info("Workspace Instantiation is READONLY -- skipping method [#{aem.fqname}] with inputs [#{inputs.inspect}]")
-      elsif ["inline", "builtin", "uri"].include?(aem.location.downcase.strip)
+      elsif ["inline", "builtin", "uri", "expression"].include?(aem.location.downcase.strip)
         $miq_ae_logger.info("Invoking [#{aem.location}] method [#{aem.fqname}] with inputs [#{inputs.inspect}]")
         return MiqAeEngine::MiqAeMethod.send("invoke_#{aem.location.downcase.strip}", aem, obj, inputs)
       end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -427,6 +427,23 @@ module MiqAeEngine
       uri  # if it was not processed, return the original uri
     end
 
+    def substitute_value(value, _type = nil, required = false)
+      Benchmark.current_realtime[:substitution_count] += 1
+      Benchmark.realtime_block(:substitution_time) do
+        value = value.gsub(RE_SUBST) do |_s|
+          subst   = uri2value($1, required)
+          subst &&= subst.to_s
+          # This encoding of relationship is not needed, until we can get a valid use case
+          # Based on RFC 3986 Section 2.4 "When to Encode or Decode"
+          # We are properly encoding when we send URL requests to external systems
+          # or building an automate request
+          # subst &&= URI.escape(subst, RE_URI_ESCAPE)  if type == :aetype_relationship
+          subst
+        end unless value.nil?
+        return value
+      end
+    end
+
     private
 
     def call_method(obj, method)
@@ -539,23 +556,6 @@ module MiqAeEngine
 
       # default datatype => 'string'
       value
-    end
-
-    def substitute_value(value, _type = nil, required = false)
-      Benchmark.current_realtime[:substitution_count] += 1
-      Benchmark.realtime_block(:substitution_time) do
-        value = value.gsub(RE_SUBST) do |_s|
-          subst   = uri2value($1, required)
-          subst &&= subst.to_s
-          # This encoding of relationship is not needed, until we can get a valid use case
-          # Based on RFC 3986 Section 2.4 "When to Encode or Decode"
-          # We are properly encoding when we send URL requests to external systems
-          # or building an automate request
-          # subst &&= URI.escape(subst, RE_URI_ESCAPE)  if type == :aetype_relationship
-          subst
-        end unless value.nil?
-        return value
-      end
     end
 
     def process_assertion(f, message, args)

--- a/lib/miq_automation_engine/miq_ae_exception.rb
+++ b/lib/miq_automation_engine/miq_ae_exception.rb
@@ -39,6 +39,14 @@ module MiqAeException
   class DomainNotAccessible < MiqAeDatastoreError; end
   class CannotLock < MiqAeDatastoreError; end
   class CannotUnlock < MiqAeDatastoreError; end
+
+  class MethodExpressionNotFound < MiqAeEngineError; end
+  class MethodExpressionEmpty < MiqAeEngineError; end
+  class MethodExpressionInvalid < MiqAeEngineError; end
+  class MethodExpressionTargetObjectMissing < MiqAeEngineError; end
+  class MethodExpressionResultTypeInvalid < MiqAeEngineError; end
+  class MethodParameterNotFound < MiqAeEngineError; end
+  class MethodNotDefined < MiqAeEngineError; end
 end
 
 module MiqException

--- a/spec/miq_ae_expression_method_spec.rb
+++ b/spec/miq_ae_expression_method_spec.rb
@@ -1,0 +1,197 @@
+module MiqAeExpressionMethodSpec
+  include MiqAeEngine
+  describe MiqAeExpressionMethod do
+    include Spec::Support::AutomationHelper
+    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:vm1) { FactoryGirl.create(:vm, :name => 'test_2.1', :cpu_shares => 400) }
+    let(:vm2) { FactoryGirl.create(:vm, :name => 'test_3.1', :cpu_shares => 400) }
+    let(:vm3) { FactoryGirl.create(:vm, :name => 'test_4.2', :cpu_shares => 11) }
+    let(:complex_qs_exp) do
+      {"and" => [{"STARTS WITH" => {"field" => "Vm-name", "value" => :user_input}},
+                 {"ENDS WITH"   => {"field" => "Vm-name", "value" => :user_input}}]
+      }
+    end
+
+    let(:m_params) do
+      {'arg1'       => {'datatype' => 'string', 'default_value' => 'test'},
+       'arg2'       => {'datatype' => 'string', 'default_value' => '1'},
+       'attributes' => {'datatype' => 'array',  'default_value' => 'name'}
+      }
+    end
+
+    let(:vm_search) do
+      {:db         => 'Vm',
+       :expression => complex_qs_exp}.to_yaml
+    end
+
+    before do
+      allow(User).to receive(:server_timezone).and_return("UTC")
+    end
+
+    it "expression_method" do
+      vm1
+      vm2
+      vm3
+      m_params['result_type'] = {'datatype' => 'string', 'default_value' => 'array'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search)
+      ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+
+      expect(ws.root.attributes['values']).to match_array(%w(test_2.1 test_3.1))
+    end
+
+    it "expression_method dialog_hash" do
+      vm1
+      vm2
+      vm3
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search)
+      ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+
+      expect(ws.root.attributes['values'].keys).to match_array([vm1.id, vm2.id])
+      expect(ws.root.attributes['values'].values).to match_array([vm1.name, vm2.name])
+    end
+
+    it "expression_method no result" do
+      vm1
+      vm2
+      vm3
+      m_params['arg1'] = {'datatype' => 'string',  'default_value' => 'nada'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search)
+      ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+
+      expect(ws.root.attributes['ae_result']).to eq('error')
+    end
+
+    it "expression_method no result use default value" do
+      vm1
+      vm2
+      vm3
+      m_params['arg1'] = {'datatype' => 'string', 'default_value' => 'nada'}
+      m_params['default'] = {'datatype' => 'array', 'default_value' => 'nada'}
+      m_params['on_empty'] = {'datatype' => 'string', 'default_value' => 'warn'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search)
+      ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+
+      expect(ws.root.attributes['ae_result']).to eq('warn')
+      expect(ws.root.attributes['values']).to match_array(%w(nada))
+    end
+
+    it "expression_method result attr" do
+      vm1
+      vm2
+      vm3
+      m_params['result_attr'] = {'datatype' => 'string', 'default_value' => 'vitalstatistix'}
+      m_params['result_type'] = {'datatype' => 'string', 'default_value' => 'array'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search)
+      ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+
+      expect(ws.root.attributes['vitalstatistix']).to match_array(%w(test_2.1 test_3.1))
+    end
+
+    it "expression_method distinct" do
+      vm1
+      vm2
+      vm3
+      m_params['distinct'] = {'datatype' => 'array', 'default_value' => 'cpu_shares'}
+      m_params['result_type'] = {'datatype' => 'string', 'default_value' => 'array'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search)
+      ws = MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+
+      expect(ws.root.attributes['values']).to match_array([400])
+    end
+
+    it "expression_method undefined function" do
+      vm1
+      vm2
+      m_params['attributes'] = {'datatype' => 'array', 'default_value' => 'nada'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search)
+
+      expect do
+        MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      end.to raise_error(MiqAeException::MethodNotDefined)
+    end
+
+    it "expression_method target object missing" do
+      vm1
+      vm2
+      vm3
+      m_params['result_obj'] = {'datatype' => 'string',  'default_value' => 'nada'}
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search)
+
+      expect do
+        MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      end.to raise_error(MiqAeException::MethodExpressionTargetObjectMissing)
+    end
+
+    it "expression_method invalid result type" do
+      vm1
+      vm2
+      vm3
+      m_params['result_type'] = {'datatype' => 'string', 'default_value' => 'nada'}
+
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => m_params,
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search)
+      expect do
+        MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      end.to raise_error(MiqAeException::MethodExpressionResultTypeInvalid)
+    end
+
+    it "not all parameters provided" do
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => {},
+                                  :method_loc  => 'expression',
+                                  :method_script => vm_search)
+
+      expect do
+        MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      end.to raise_error(MiqAeException::MethodParameterNotFound)
+    end
+
+    it "invalid search name" do
+      create_ae_model_with_method(:ae_namespace => 'GAULS',
+                                  :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
+                                  :method_name => 'OBELIX', :method_params => {},
+                                  :method_loc  => 'expression',
+                                  :method_script => "nada")
+
+      expect do
+        MiqAeEngine.instantiate('/GAULS/ASTERIX/DOGMATIX', user)
+      end.to raise_error(MiqAeException::MethodExpressionInvalid)
+    end
+  end
+end

--- a/spec/miq_ae_expression_method_spec.rb
+++ b/spec/miq_ae_expression_method_spec.rb
@@ -3,9 +3,9 @@ module MiqAeExpressionMethodSpec
   describe MiqAeExpressionMethod do
     include Spec::Support::AutomationHelper
     let(:user) { FactoryGirl.create(:user_with_group) }
-    let(:vm1) { FactoryGirl.create(:vm, :name => 'test_2.1', :cpu_shares => 400) }
-    let(:vm2) { FactoryGirl.create(:vm, :name => 'test_3.1', :cpu_shares => 400) }
-    let(:vm3) { FactoryGirl.create(:vm, :name => 'test_4.2', :cpu_shares => 11) }
+    let!(:vm1) { FactoryGirl.create(:vm, :name => 'test_2.1', :cpu_shares => 400) }
+    let!(:vm2) { FactoryGirl.create(:vm, :name => 'test_3.1', :cpu_shares => 400) }
+    let!(:vm3) { FactoryGirl.create(:vm, :name => 'test_4.2', :cpu_shares => 11) }
     let(:complex_qs_exp) do
       {"and" => [{"STARTS WITH" => {"field" => "Vm-name", "value" => :user_input}},
                  {"ENDS WITH"   => {"field" => "Vm-name", "value" => :user_input}}]}
@@ -27,9 +27,6 @@ module MiqAeExpressionMethodSpec
     end
 
     it "expression_method" do
-      vm1
-      vm2
-      vm3
       m_params['result_type'] = {'datatype' => 'string', 'default_value' => 'array'}
       create_ae_model_with_method(:ae_namespace => 'GAULS',
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
@@ -42,9 +39,6 @@ module MiqAeExpressionMethodSpec
     end
 
     it "expression_method dialog_hash" do
-      vm1
-      vm2
-      vm3
       create_ae_model_with_method(:ae_namespace => 'GAULS',
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
                                   :method_name => 'OBELIX', :method_params => m_params,
@@ -57,9 +51,6 @@ module MiqAeExpressionMethodSpec
     end
 
     it "expression_method no result" do
-      vm1
-      vm2
-      vm3
       m_params['arg1'] = {'datatype' => 'string',  'default_value' => 'nada'}
       create_ae_model_with_method(:ae_namespace => 'GAULS',
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
@@ -72,9 +63,6 @@ module MiqAeExpressionMethodSpec
     end
 
     it "expression_method no result use default value" do
-      vm1
-      vm2
-      vm3
       m_params['arg1'] = {'datatype' => 'string', 'default_value' => 'nada'}
       m_params['default'] = {'datatype' => 'array', 'default_value' => 'nada'}
       m_params['on_empty'] = {'datatype' => 'string', 'default_value' => 'warn'}
@@ -90,9 +78,6 @@ module MiqAeExpressionMethodSpec
     end
 
     it "expression_method result attr" do
-      vm1
-      vm2
-      vm3
       m_params['result_attr'] = {'datatype' => 'string', 'default_value' => 'vitalstatistix'}
       m_params['result_type'] = {'datatype' => 'string', 'default_value' => 'array'}
       create_ae_model_with_method(:ae_namespace => 'GAULS',
@@ -106,9 +91,6 @@ module MiqAeExpressionMethodSpec
     end
 
     it "expression_method distinct" do
-      vm1
-      vm2
-      vm3
       m_params['distinct'] = {'datatype' => 'array', 'default_value' => 'cpu_shares'}
       m_params['result_type'] = {'datatype' => 'string', 'default_value' => 'array'}
       create_ae_model_with_method(:ae_namespace => 'GAULS',
@@ -122,8 +104,6 @@ module MiqAeExpressionMethodSpec
     end
 
     it "expression_method undefined function" do
-      vm1
-      vm2
       m_params['attributes'] = {'datatype' => 'array', 'default_value' => 'nada'}
       create_ae_model_with_method(:ae_namespace => 'GAULS',
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
@@ -137,9 +117,6 @@ module MiqAeExpressionMethodSpec
     end
 
     it "expression_method target object missing" do
-      vm1
-      vm2
-      vm3
       m_params['result_obj'] = {'datatype' => 'string',  'default_value' => 'nada'}
       create_ae_model_with_method(:ae_namespace => 'GAULS',
                                   :ae_class => 'ASTERIX', :instance_name => 'DOGMATIX',
@@ -153,9 +130,6 @@ module MiqAeExpressionMethodSpec
     end
 
     it "expression_method invalid result type" do
-      vm1
-      vm2
-      vm3
       m_params['result_type'] = {'datatype' => 'string', 'default_value' => 'nada'}
 
       create_ae_model_with_method(:ae_namespace => 'GAULS',

--- a/spec/miq_ae_expression_method_spec.rb
+++ b/spec/miq_ae_expression_method_spec.rb
@@ -8,15 +8,13 @@ module MiqAeExpressionMethodSpec
     let(:vm3) { FactoryGirl.create(:vm, :name => 'test_4.2', :cpu_shares => 11) }
     let(:complex_qs_exp) do
       {"and" => [{"STARTS WITH" => {"field" => "Vm-name", "value" => :user_input}},
-                 {"ENDS WITH"   => {"field" => "Vm-name", "value" => :user_input}}]
-      }
+                 {"ENDS WITH"   => {"field" => "Vm-name", "value" => :user_input}}]}
     end
 
     let(:m_params) do
       {'arg1'       => {'datatype' => 'string', 'default_value' => 'test'},
        'arg2'       => {'datatype' => 'string', 'default_value' => '1'},
-       'attributes' => {'datatype' => 'array',  'default_value' => 'name'}
-      }
+       'attributes' => {'datatype' => 'array',  'default_value' => 'name'}}
     end
 
     let(:vm_search) do


### PR DESCRIPTION
Expression Methods
https://www.pivotaltracker.com/n/projects/1613499/stories/148625717

Expression Methods allow you to use Advance Search Filters as Automate Methods, substituting the user_input from Automate Objects. The advantages of this approach is that the methods run directly in the worker and don't have the overhead of forking a DRb process to run the Automate Methods.

Related PR https://github.com/ManageIQ/manageiq-automation_engine/pull/50

# Steps
1. Create a new Automate Method and set the Location to expression
2. Select the Expression object to use for the expression builder from the drop down list
3. Create an expression using the expression editor controls and any values that need to be set at runtime from automate, mark then as user input. These are positional arguments.
4. In the input parameters section  create arg1,arg2,arg3... for each of the user input fields from Step 3. When specifying the default value for arg1,arg2,... you can use substitution. e.g. _${/#vm_suffix}_

5. Create a field called attributes with the list of attributes that you would like to collect from the search objects. e.g (name, id)


## Input Parameters
* **arg1** The first argument in the expression
* **arg2** The second argument in the expression
* **argn** The nth argument in the expression

### Optional Input Parameters
* **attributes** A comma delimited list of attributes to select from the resultant objects
or
* **distinct** A comma delimited list of attributes which are distinct in the resultant objects

If attributes and distinct are not specified we try to store the result in a variable called
**values** with a hash consisting of **id** and **name**. This makes it compatible with our existing dynamic dialog result set.

* **result_obj** The object where the result data should be stored (default: **current object**)
* **result_attr** The name of the attribute which stores the result (default: **values**)
* **result_type** The result type hash or array (default: **dialog_hash** which matches to our dynamic dialog hash. Valid values are 'hash', 'dialog_hash', 'array', 'simple'
* **on_empty** The method behavior when the search returns an empty list
warn | error | abort (default: **error**)
* **default** The default value in case the result is empty and you select warn

* UI PR https://github.com/ManageIQ/manageiq-ui-classic/pull/1668
* ManageIQ PR: https://github.com/ManageIQ/manageiq/pull/15537

### The Expression Method in Edit Mode

<img width="895" alt="screen shot 2017-07-11 at 2 55 32 pm" src="https://user-images.githubusercontent.com/6452699/28085247-179bfe6a-6649-11e7-967b-ef72204ca959.png">

### The Expression Method in Display Mode

<img width="902" alt="screen shot 2017-07-11 at 2 54 58 pm" src="https://user-images.githubusercontent.com/6452699/28085248-17a49e3a-6649-11e7-8cd6-f9cc32f89f66.png">



### Dynamic Dialog Instance

The instance below shows how to setup for Dynamic Dialogs, the default properties can be set in the instance and the method will fill in the **values** field. In the examples below the AvailableVMsInternal is an expression method.

<img width="850" alt="screen shot 2017-07-11 at 2 51 21 pm" src="https://user-images.githubusercontent.com/6452699/28085114-af6a3028-6648-11e7-8a7d-7701a9017cfb.png">
