### PR TITLE
Move SyntaxChecker from manageiq-gems-pending

### DIFF
--- a/lib/manageiq-automation_engine.rb
+++ b/lib/manageiq-automation_engine.rb
@@ -1,2 +1,5 @@
 require 'manageiq/automation_engine/engine'
+require 'manageiq/automation_engine/syntax_check_result'
+require 'manageiq/automation_engine/syntax_checker'
+
 require 'miq_automation_engine/miq_ae_exception'

--- a/lib/manageiq/automation_engine/syntax_check_result.rb
+++ b/lib/manageiq/automation_engine/syntax_check_result.rb
@@ -1,0 +1,26 @@
+module ManageIQ
+  module AutomationEngine
+    class SyntaxCheckResult
+      attr_reader :error_line, :error_text
+
+      def initialize(output)
+        @valid = (output == "Syntax OK\n")
+        @output = output
+        unless @valid
+          match = /^-:(\d+):(.*)/.match(output)
+          if match.nil?
+            @error_line = 0
+            @error_text = output
+          else
+            @error_line = match[1].to_i
+            @error_text = match[2]
+          end
+        end
+      end
+
+      def valid?
+        @valid
+      end
+    end
+  end
+end

--- a/lib/manageiq/automation_engine/syntax_checker.rb
+++ b/lib/manageiq/automation_engine/syntax_checker.rb
@@ -1,0 +1,17 @@
+require "open3"
+
+module ManageIQ
+  module AutomationEngine
+    class SyntaxChecker
+      def self.check(ruby)
+        Open3.popen3 "ruby -wc" do |stdin, stdout, stderr|
+          stdin.write ruby
+          stdin.close
+          output = stdout.read
+          errors = stderr.read
+          SyntaxCheckResult.new(output && !output.empty? ? output : errors)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/manageiq/automation_engine/syntax_checker_spec.rb
+++ b/spec/lib/manageiq/automation_engine/syntax_checker_spec.rb
@@ -1,0 +1,22 @@
+describe ManageIQ::AutomationEngine::SyntaxChecker do
+  describe "#check" do
+    it "valid" do
+      result = described_class.check "this.is.valid.syntax"
+      expect(result).to be_valid
+
+      result = described_class.check "i = 1"
+      expect(result).to be_valid
+    end
+
+    it "invalid" do
+      result = described_class.check "this.is -> not -> valid $ruby:syntax"
+      expect(result).not_to be_valid
+    end
+  end
+
+  it "#error_line, #error_text" do
+    result = described_class.check "line(1).is.okay\nline(2) is not :("
+    expect(result.error_line).to eq(2)
+    expect(result.error_text).to match(/syntax error/)
+  end
+end


### PR DESCRIPTION
The only consumer of this class is automate (specifically the MiqAeMethod model), however I feel that the engine should be the thing that provides the class, and the model should just use it, hence why I am moving here.