### PR TITLE
[Depends on ManageIQ/manageiq#15615] Expose delete method for NetworkRouter

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_network_router.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_network_router.rb
@@ -8,5 +8,6 @@ module MiqAeMethodService
     expose :network_ports,         :association => true
     expose :vms,                   :association => true
     expose :private_networks,      :association => true
+    expose :delete_network_router
   end
 end


### PR DESCRIPTION
This exposes the `delete` method for Network Router
Depends on https://github.com/ManageIQ/manageiq/pull/15615