### PR TITLE
Allows expressions to be exported and imported

### DIFF
--- a/app/models/miq_ae_yaml_export.rb
+++ b/app/models/miq_ae_yaml_export.rb
@@ -168,7 +168,9 @@ class MiqAeYamlExport
     class_obj.ae_methods.sort_by(&:fqname).each do |meth_obj|
       export_file_hash['created_on'] = meth_obj.created_on
       export_file_hash['updated_on'] = meth_obj.updated_on
-      write_method_file(meth_obj, export_file_hash) unless meth_obj.location == 'builtin'
+      if meth_obj.location == 'inline'
+        write_method_file(meth_obj, export_file_hash)
+      end
       write_method_attributes(meth_obj, export_file_hash)
     end
   end
@@ -176,7 +178,9 @@ class MiqAeYamlExport
   def write_method_attributes(method_obj, export_file_hash)
     envelope_hash = setup_envelope(method_obj, METHOD_OBJ_TYPE)
     envelope_hash['object']['inputs'] = method_obj.method_inputs
-    envelope_hash['object']['attributes'].delete('data')
+    if method_obj.location == "inline"
+      envelope_hash['object']['attributes'].delete('data')
+    end
     if method_obj.embedded_methods.empty?
       envelope_hash['object']['attributes'].delete('embedded_methods')
     end

--- a/app/models/miq_ae_yaml_import.rb
+++ b/app/models/miq_ae_yaml_import.rb
@@ -217,7 +217,8 @@ class MiqAeYamlImport
   def process_method(class_obj, ruby_method_file_name, method_yaml)
     method_attributes = method_yaml.fetch_path('object', 'attributes')
     if method_attributes['location'] == 'inline'
-      method_yaml.store_path('object', 'attributes', 'data', load_method_ruby(ruby_method_file_name))
+      data = load_method_ruby(ruby_method_file_name)
+      method_yaml.store_path('object', 'attributes', 'data', data) if data
     end
     method_obj = MiqAeMethod.find_by(:name => method_attributes['name'], :class_id => class_obj.id) unless class_obj.nil?
     track_stats('method', method_obj)


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1613499/stories/148625717

Expressions are imported in the data section of the method yaml file

``` yaml
---
object_type: method
version: 1.0 
object:
  attributes:
    name: ExpTest
    display_name: 
    description: 
    scope: instance
    language: ruby
    location: expression
    data: |
      --- 
      :db: AvailabilityZone
      :expression:
        "=":
          field: AvailabilityZone-href_slug
          value: :user_input
  inputs:
  - field:
      aetype: 
      name: arg1
      display_name: 
      datatype: 
      priority: 1
      owner: 
      default_value: "${/#prefix}"
      substitute: false
      message: create
      visibility: 
      collect: 
      scope: 
      description: 
      condition: 
      on_entry: 
      on_exit: 
      on_error: 
      max_retries: 
      max_time: 
```