### PR TITLE
Expose operations for NetworkPort

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_network_port.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_network_port.rb
@@ -6,5 +6,7 @@ module MiqAeMethodService
     expose :ext_management_system, :association => true
     expose :public_network,        :association => true
     expose :public_networks,       :association => true
+    expose :update_network_port
+    expose :delete_network_port
   end
 end


### PR DESCRIPTION
Exposed `update` and `delete` methods for NetworkPort
Depends on https://github.com/ManageIQ/manageiq/pull/15691