### PR TITLE
Need to pass the user's group in to automate when the provision starts.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -305,9 +305,11 @@ module MiqAeEngine
 
   def self.ae_user_object(options = {})
     raise "user_id not specified in Automation request" if options[:user_id].blank?
-    # raise "group_id not specified in Automation request" if options[:miq_group_id].blank?
+    # raise "miq_group_id not specified in Automation request" if options[:miq_group_id].blank?
+
     User.find_by!(:id => options[:user_id]).tap do |obj|
-      # obj.current_group = MiqGroup.find_by!(:id => options[:miq_group_id])
+      obj.current_group = MiqGroup.find_by!(:id => options[:miq_group_id]) unless options[:miq_group_id] == obj.current_group.id
+      $miq_ae_logger.info("User [#{obj.userid}] with current group ID [#{obj.current_group.id}] name [#{obj.current_group.description}]")
     end
   end
 end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -250,7 +250,7 @@ module MiqAeEngine
 
     def user_info_attributes(user)
       {'user' => user, 'tenant' => user.current_tenant, 'miq_group' => user.current_group}.each do |k, v|
-        value = MiqAeObject.convert_value_based_on_datatype(v.id, v.class.name)
+        value = MiqAeMethodService::MiqAeServiceModelBase.wrap_results(v)
         @attributes[k] = value unless value.nil?
       end
     end


### PR DESCRIPTION
User's current group might have changed before the provision finishes.
So the user's current group from DB may be different from the user's group when the request is sent into automate.

Part of https://github.com/ManageIQ/manageiq/pull/15696.
~~Blocks https://github.com/ManageIQ/manageiq-content/pull/156.~~
Includes https://github.com/ManageIQ/manageiq/pull/15760.

https://bugzilla.redhat.com/show_bug.cgi?id=1467364

@miq-bot add_label bug, euwe/yes, fine/yes