### PR TITLE
[WIP]Edit exposed methods for LoadBalancer

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_load_balancer.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_load_balancer.rb
@@ -8,8 +8,8 @@ module MiqAeMethodService
     expose :cloud_subnets, :association => true
     expose :vms, :association => true
     expose :ems_ref
-    expose :raw_delete_load_balancer
-    expose :raw_update_load_balancer
+    expose :delete_load_balancer
+    expose :update_load_balancer
     expose :raw_exists?
 
     def add_to_service(service)


### PR DESCRIPTION
Changed exposed `raw` methods to `non-raw`, according to pattern, where we use `non-raw` methods in `MiqAeService` modules
Depends on https://github.com/ManageIQ/manageiq/pull/15720