### PR TITLE
Serialize/Deserialize a workspace

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_deserialize_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_deserialize_workspace.rb
@@ -1,7 +1,6 @@
 module MiqAeEngine
   module MiqAeDeserializeWorkspace
-    def update_workspace(json)
-      hash = JSON.parse(json)
+    def update_workspace(hash)
       hash['workspace'].each { |path, attrs| update_object(path, attrs, ae_user) }
       hash['state_vars'].each { |k, v| @persist_state_hash[k] = MiqAeReference.decode(v, ae_user) }
     end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_deserialize_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_deserialize_workspace.rb
@@ -1,0 +1,30 @@
+module MiqAeEngine
+  module MiqAeDeserializeWorkspace
+    def update_workspace(json)
+      hash = JSON.parse(json)
+      hash['workspace'].each { |path, attrs| update_object(path, attrs, ae_user) }
+      hash['state_vars'].each { |k, v| @persist_state_hash[k] = MiqAeReference.decode(v, ae_user) }
+    end
+
+    def update_object(path, attributes, user)
+      obj = path == "root" ? root : find_object(root, path)
+      $miq_ae_logger.error("Object #{path} not found in workspace") unless obj
+      raise MiqAeException::Error, "object not found #{path}" unless obj
+      update_obj_attributes(obj, attributes, user)
+    end
+
+    def update_obj_attributes(obj, updated_attributes, user)
+      updated_attributes.each do |name, value|
+        obj[name] = MiqAeReference.decode(value, user)
+      end
+    end
+
+    def find_object(obj, object_name)
+      return obj if obj.object_name == object_name
+      obj.children.each do |child|
+        found = find_object(child, object_name)
+        return found if found
+      end
+    end
+  end
+end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_deserialize_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_deserialize_workspace.rb
@@ -24,6 +24,7 @@ module MiqAeEngine
         found = find_object(child, object_name)
         return found if found
       end
+      nil
     end
   end
 end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_reference.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_reference.rb
@@ -1,0 +1,28 @@
+module MiqAeEngine
+  module MiqAeReference
+    def self.encode(value)
+      if value.kind_of?(Array)
+        value.map { |v| encode(v) }
+      elsif value.kind_of?(Hash)
+        value.each_with_object({}) { |(k, v), hash| hash[k] = encode(v) }
+      elsif /MiqAeMethodService::/ =~ value.class.to_s
+        "vmdb_reference::#{value.href_slug}"
+      else
+        value
+      end
+    end
+
+    def self.decode(value, user)
+      if value.kind_of?(Array)
+        value.map { |v| decode(v, user) }
+      elsif value.kind_of?(Hash)
+        value.each_with_object({}) { |(k, v), hash| hash[k] = decode(v, user) }
+      elsif value.kind_of?(String) && /vmdb_reference::(.*)/.match(value)
+        obj = Api::Utils.resource_search_by_href_slug($1, user)
+        MiqAeMethodService::MiqAeServiceModelBase.wrap_results(obj)
+      else
+        value
+      end
+    end
+  end
+end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_reference.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_reference.rb
@@ -7,6 +7,8 @@ module MiqAeEngine
         value.each_with_object({}) { |(k, v), hash| hash[k] = encode(v) }
       elsif /MiqAeMethodService::/ =~ value.class.to_s
         "vmdb_reference::#{value.href_slug}"
+      elsif /MiqAePassword/ =~ value.class.to_s
+        "miq_password::#{value}"
       else
         value
       end
@@ -20,6 +22,8 @@ module MiqAeEngine
       elsif value.kind_of?(String) && /vmdb_reference::(.*)/.match(value)
         obj = Api::Utils.resource_search_by_href_slug($1, user)
         MiqAeMethodService::MiqAeServiceModelBase.wrap_results(obj)
+      elsif value.kind_of?(String) && /miq_password::(.*)/.match(value)
+        MiqAePassword.new(value)
       else
         value
       end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_serialize_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_serialize_workspace.rb
@@ -8,7 +8,7 @@ module MiqAeEngine
     end
 
     def to_hash_with_refs(obj, parent, result)
-      key = parent ? "/#{obj.namespace}/#{obj.klass}/#{obj.instance}" : "root"
+      key = parent ? obj.object_name : "root"
       system_attrs = parent ? {"::miq::parent" => parent } : {}
       result[key] = process_attributes(obj).merge(system_attrs)
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_serialize_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_serialize_workspace.rb
@@ -1,0 +1,25 @@
+module MiqAeEngine
+  module MiqAeSerializeWorkspace
+    def hash_workspace(path = nil)
+      objs = path.nil? ? roots : get_obj_from_path(path)
+      result = {}
+      objs.each { |obj| to_hash_with_refs(obj, nil, result) }
+      result
+    end
+
+    def to_hash_with_refs(obj, parent, result)
+      key = parent ? "/#{obj.namespace}/#{obj.klass}/#{obj.instance}" : "root"
+      system_attrs = parent ? {"::miq::parent" => parent } : {}
+      result[key] = process_attributes(obj).merge(system_attrs)
+
+      obj.children.each { |c| to_hash_with_refs(c, key, result) }
+    end
+
+    def process_attributes(obj)
+      obj.attributes.each_with_object({}) do |(k, v), hash|
+        next if v.nil?
+        hash[k.to_s] = MiqAeReference.encode(v)
+      end
+    end
+  end
+end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -5,6 +5,8 @@ module MiqAeEngine
     attr_accessor :datastore_cache, :persist_state_hash, :current_state_info
     attr_accessor :ae_user
     include MiqAeStateInfo
+    include MiqAeSerializeWorkspace
+    include MiqAeDeserializeWorkspace
 
     attr_reader :nodes
 

--- a/spec/miq_ae_deserialize_workspace_spec.rb
+++ b/spec/miq_ae_deserialize_workspace_spec.rb
@@ -1,0 +1,84 @@
+describe "MiqAeDeserializeWorkspace" do
+  let(:test_class) do
+    Class.new do
+      include MiqAeEngine::MiqAeDeserializeWorkspace
+      attr_reader :persist_state_hash
+      def initialize(workspace)
+        @workspace = workspace
+        @persist_state_hash = {}
+      end
+
+      def root
+        @workspace.root
+      end
+
+      def ae_user
+        @workspace.ae_user
+      end
+    end
+  end
+
+  let(:user) do
+    FactoryGirl.create(:user_with_group,
+                       :userid   => "admin",
+                       :settings => {:display => { :timezone => "UTC"}})
+  end
+
+  let(:workspace) do
+    double("MiqAeEngine::MiqAeWorkspaceRuntime", :root => root_object, :ae_user => user)
+  end
+
+  let(:test_class_instance) { test_class.new(workspace) }
+  let(:host) { FactoryGirl.create(:host) }
+  let(:vm_name) { "Freddy Krueger" }
+  let(:vm) { FactoryGirl.create(:vm_vmware, :host => host, :name => vm_name) }
+
+  describe "#update_workspace" do
+    context "caller adds a vm object as attribute" do
+      let(:root_hash) { { 'a' => 1, 'b' => '2'} }
+      let(:updated_hash) do
+        {
+          'state_vars' => { 'x' => 1 },
+          'workspace'  => {
+            'root'                => {
+              'a'     => 9,
+              'my_vm' => "vmdb_reference::#{vm.href_slug}",
+              'd'     => '2'
+            },
+            '/miq/demo/test/ins1' => {
+              'z' => 42
+            }
+          }
+        }
+      end
+
+      let(:invalid_obj_name_hash) do
+        {'workspace' => { 'frooti' => {} }}
+      end
+
+      let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+      let(:child_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+
+      it "check updated values" do
+        child_object.namespace = "miq/demo"
+        child_object.klass     = 'test'
+        child_object.instance  = 'ins1'
+        child_object.link_parent_child(root_object, child_object)
+
+        test_class_instance.update_workspace(updated_hash)
+
+        expect(root_object['a']).to eq(9)
+        expect(root_object['d']).to eq('2')
+        expect(root_object['my_vm'].name).to eq(vm_name)
+        expect(child_object['z']).to eq(42)
+        expect(test_class_instance.persist_state_hash['x']).to eq(1)
+      end
+
+      it "raises error with invalid object name" do
+        expect do
+          test_class_instance.update_workspace(invalid_obj_name_hash)
+        end.to raise_exception(MiqAeException::Error)
+      end
+    end
+  end
+end

--- a/spec/miq_ae_reference_spec.rb
+++ b/spec/miq_ae_reference_spec.rb
@@ -1,0 +1,28 @@
+describe MiqAeEngine::MiqAeReference do
+  context "vmdb objects" do
+    let(:user) do
+      FactoryGirl.create(:user_with_group, :userid   => "admin",
+                                           :settings => {:display => { :timezone => "UTC"}})
+    end
+    let(:host) { FactoryGirl.create(:host) }
+    let(:vm) { FactoryGirl.create(:vm_vmware, :host => host) }
+    let(:svc_vm) { MiqAeMethodService::MiqAeServiceVm.find(vm.id) }
+    let(:ref) { "vmdb_reference::#{vm.href_slug}" }
+
+    it "#encode a vm object" do
+      expect(::MiqAeEngine::MiqAeReference.encode(svc_vm)).to eq(ref)
+    end
+
+    it "#decode a vm reference" do
+      expect(::MiqAeEngine::MiqAeReference.decode(ref, user).id).to eq(vm.id)
+    end
+  end
+
+  context "passwords" do
+    let(:password) { MiqAePassword.new("smartvm") }
+
+    it "#encodes a password field" do
+      expect(::MiqAeEngine::MiqAeReference.encode(password)).to eq("miq_password::#{password}")
+    end
+  end
+end

--- a/spec/miq_ae_serialize_workspace_spec.rb
+++ b/spec/miq_ae_serialize_workspace_spec.rb
@@ -1,0 +1,74 @@
+describe "MiqAeSerializeWorkspace" do
+  let(:test_class) do
+    Class.new do
+      include MiqAeEngine::MiqAeSerializeWorkspace
+      def initialize(workspace)
+        @workspace = workspace
+      end
+
+      def get_value(_f, type)
+        @workspace.root[type]
+      end
+
+      def get_obj_from_path(_path)
+        @workspace.root
+      end
+
+      def roots
+        [@workspace.root]
+      end
+    end
+  end
+
+  let(:workspace) { double("MiqAeEngine::MiqAeWorkspaceRuntime", :root => root_object) }
+  let(:test_class_instance) { test_class.new(workspace) }
+  let(:user) do
+    FactoryGirl.create(:user_with_group, :userid   => "admin",
+                                         :settings => {:display => { :timezone => "UTC"}})
+  end
+
+  let(:host) { FactoryGirl.create(:host) }
+  let(:vm) { FactoryGirl.create(:vm_vmware, :host => host) }
+  let(:svc_vm) { MiqAeMethodService::MiqAeServiceVm.find(vm.id) }
+
+  describe "#hash_workspace" do
+    context "simple attributes" do
+      let(:root_hash) { { 'a' => 1, 'b' => '2'} }
+      let(:hashed_workspace) { { "root" => root_hash} }
+      let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+
+      it "return a simple hash" do
+        expect(test_class_instance.hash_workspace).to eq(hashed_workspace)
+      end
+    end
+
+    context "vmdb_object" do
+      let(:root_hash) { { 'a' => 1, 'b' => '2', 'my_vm' => svc_vm} }
+      let(:ref_hash) { { 'a' => 1, 'b' => '2', 'my_vm' => "vmdb_reference::#{vm.href_slug}"} }
+      let(:hashed_workspace) { { "root" => ref_hash} }
+      let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+
+      it "return a simple hash with the vm reference" do
+        expect(test_class_instance.hash_workspace).to eq(hashed_workspace)
+      end
+    end
+
+    context "object graph" do
+      let(:root_hash) { { 'a' => 1, 'b' => '2' } }
+      let(:child_hash) { { 'age' => 55 } }
+      let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+      let(:child_object) { Spec::Support::MiqAeMockObject.new(child_hash) }
+
+      it "returns a nested hash" do
+        child_object.namespace = "manageiq/bedrock"
+        child_object.klass     = "mogul"
+        child_object.instance  = "fred"
+
+        child_object.link_parent_child(root_object, child_object)
+        result = { "root"                         => {"a" => 1, "b" => "2"},
+                   "/manageiq/bedrock/mogul/fred" => {"age" => 55, "::miq::parent" => "root"}}
+        expect(test_class_instance.hash_workspace).to eq(result)
+      end
+    end
+  end
+end

--- a/spec/support/miq_ae_mock_object.rb
+++ b/spec/support/miq_ae_mock_object.rb
@@ -2,8 +2,14 @@ module Spec
   module Support
     class MiqAeMockObject
       attr_reader :parent
+      attr_reader :children
+      attr_accessor :namespace
+      attr_accessor :klass
+      attr_accessor :instance
+
       def initialize(hash = {})
         @object_hash = HashWithIndifferentAccess.new(hash)
+        @children = []
       end
 
       def attributes
@@ -20,6 +26,21 @@ module Spec
 
       def []=(attr, value)
         @object_hash[attr.downcase] = value
+      end
+
+      def link_parent_child(parent, child)
+        parent.children << child
+        child.parent = parent
+      end
+
+      def object_name
+        if namespace && klass && instance
+          ::MiqAeEngine::MiqAePath.new(:ae_namespace => namespace,
+                                       :ae_class     => klass,
+                                       :ae_instance  => instance).to_s
+        else
+          "root"
+        end
       end
     end
   end


### PR DESCRIPTION
Allows for workspace to be stored in the AutomateWorkspace model to be retrieved and updated by external methods

In the AutomateWorkspace model we have 2 columns which store json blobs
**input** - (main nodes, **workspace**, **state_vars**, **method_parameters**, **current**)
**output** - (main nodes **workspace**, **state_vars**)

The output only contains the subset of the workspace and state_vars that was updated by the user in their methods.


## Input
```script
{
    "current" => {
        "class" => "Request", "method" => "testing", "message" => "create", "instance" => "Testing", "namespace" => "Demo/System"
    }, "workspace" => {
        "root" => {
            "abc" => 123, "xyz" => [1, 2, 3, 4], "user" => "vmdb_reference::users/2", "tenant" => "vmdb_reference::tenants/2", "message" => "create", "my_hash" => {
                "a" => 1, "b" => {
                    "age" => 34, "name" => "Fred", "his_vm" => nil
                }, "c" => [5, 6, 7]
            }, "request" => "REST_API_TEST", "user_id" => "2", "miq_group" => "vmdb_reference::groups/18", "miq_server" => "vmdb_reference::servers/2", "object_name" => "Request", "miq_server_id" => "2", "ae_provider_category" => "unknown"
        }, "/Demo/System/Request/Testing" => {
            "::miq::parent" => "/Demo/NS1/Person/Fred_Flintstone"
        }, "/Demo/NS1/Person/Fred_Flintstone" => {
            "age" => 40, "city" => "Mahwah", "name" => "Fred", "state" => "NJ", "address" => "1 International Blvd, 5th Floor", "::miq::parent" => "/Demo/System/Request/REST_API_TEST"
        }, "/Demo/System/Request/REST_API_TEST" => {
            "::miq::parent" => "root"
        }
    }, "state_vars" => {
        "name" => "Fred", "other_vm" => nil
    }, "method_parameters" => {
        "exename" => "/Users/madhukanoor/go/bin/automate_method", "runtime" => "go", "whichvm" => "", "zipcode" => 7495, "areacode" => 201
    }
}
```

## Output
```script
{
    "workspace" => {
        "root" => {
            "via_rest_hash" => {
                "prod" => 5, "test" => 2
            }, "via_rest_port" => 3460, "via_rest_reboot" => false, "via_rest_ae_retry" => true, "via_rest_ipaddress" => "1.1.1.94"
        }, "/Demo/System/Request/Testing" => {
            "via_rest_in_current_obj" => "45"
        }, "/Demo/System/Request/REST_API_TEST" => {
            "via_rest_age" => 34, "via_rest_name" => "Fordo"
        }
    }, "state_vars" => {
        "my_ids" => [2, 3, 5, 7, 11, 13], "my_name" => "Fred Flintstone", "my_town" => "Bedrock", "my_friend" => "Barney Rubble"
    }
}
```