### PR TITLE
[wip]Add method to check if vm exists on provider

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager.rb
@@ -3,5 +3,6 @@ module MiqAeMethodService
     expose :validate_import_vm
     expose :submit_import_vm
     expose :submit_configure_imported_vm_networks
+    expose :exists_on_provider?
   end
 end


### PR DESCRIPTION
The vm removal was based on refresh failing with exception.
It is now based on an explicit check to validate if it exists on the provider or not.

This is part of a fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1478108
This is required for: https://github.com/ManageIQ/manageiq-content/pull/173

Depends on: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/81