### PR TITLE
Add missing service model change for calculating active quota counts for Service requests.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_provision_request.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_provision_request.rb
@@ -1,5 +1,8 @@
 module MiqAeMethodService
   class MiqAeServiceServiceTemplateProvisionRequest < MiqAeServiceMiqRequest
+    require_relative "mixins/miq_ae_service_miq_provision_mixin"
+    include MiqAeServiceMiqProvisionMixin
+
     def ci_type
       'service'
     end


### PR DESCRIPTION
Added miq_provision_quota mixin include to Service Template Provision Request Service model.

Recently added the ability to calculate active quota counts for Service and VM requests. Missing include results in Service requests getting undefined error while running check_quota() method.
 
https://bugzilla.redhat.com/show_bug.cgi?id=1491409

Original ticket/PR to add active quota calculations modify prov methods. 
https://bugzilla.redhat.com/show_bug.cgi?id=1456819
https://github.com/ManageIQ/manageiq/pull/15466 