### PR TITLE
Changes for generic object method calls via REST API.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -45,8 +45,8 @@ module MiqAeEngine
     def self.instantiate(uri, user, attrs = {})
       User.current_user = user
       workspace = MiqAeWorkspaceRuntime.new(attrs)
-      workspace.instantiate(uri, user, nil)
       self.current = workspace
+      workspace.instantiate(uri, user, nil)
       workspace
     rescue MiqAeException
     ensure

--- a/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
@@ -17,7 +17,9 @@ module MiqAeMethodService
     private
 
     def ae_user_identity
-      @ae_user = MiqAeEngine::DrbRemoteInvoker.workspace.ae_user
+      workspace = MiqAeEngine::MiqAeWorkspaceRuntime.current || MiqAeEngine::DrbRemoteInvoker.workspace
+      raise 'Workspace not found when running generic object' unless workspace
+      @ae_user = workspace.ae_user
       ar_method { @object.ae_user_identity(@ae_user, @ae_user.current_group, @ae_user.current_tenant) }
     end
 


### PR DESCRIPTION
The original use case for generic object method call is from the automate scripts. 
Add changes to support calling the generic object method via REST API.

@miq-bot assign @mkanoor 
@miq-bot add_label enhancement, fine/no

cc @gmcculloug @abellotti @jntullo 