### PR TITLE
Tech debt

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_event.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_event.rb
@@ -33,7 +33,7 @@ module MiqAeEvent
   def self.raise_evm_event(event_name, target, inputs = {}, options = {})
     if target.kind_of?(Array)
       klass, id = target
-      klass = Object.const_get(klass)
+      klass = ApplicationRecord.const_get(klass)
       target = klass.find_by(:id => id)
       raise "Unable to find object with class: [#{klass}], Id: [#{id}]" if target.nil?
     end

--- a/lib/miq_automation_engine/engine/miq_ae_event.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_event.rb
@@ -33,9 +33,7 @@ module MiqAeEvent
   def self.raise_evm_event(event_name, target, inputs = {}, options = {})
     if target.kind_of?(Array)
       klass, id = target
-      klass = ApplicationRecord.const_get(klass)
-      target = klass.find_by(:id => id)
-      raise "Unable to find object with class: [#{klass}], Id: [#{id}]" if target.nil?
+      target = ApplicationRecord.const_get(klass).find(id)
     end
 
     call_automate(target, build_evm_event(event_name, inputs), 'Event', options)


### PR DESCRIPTION
- Limit the scope of constant lookup
- Allow ActiveRecord to raise RecordNotFound error rather than making up our own