### PR TITLE
Ansible Playbook Automate Method

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -16,6 +16,11 @@ module MiqAeEngine
       exp_method.run
     end
 
+    def self.invoke_playbook(aem, obj, inputs)
+      playbook_method = MiqAeEngine::MiqAePlaybookMethod.new(aem, obj, inputs)
+      playbook_method.run
+    end
+
     def self.invoke_uri(aem, obj, _inputs)
       scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(aem.data)
       raise  MiqAeException::MethodNotFound, "Specified URI [#{aem.data}] in Method [#{aem.name}] has unsupported scheme of #{scheme}; supported scheme is file" unless scheme.downcase == "file"
@@ -65,7 +70,7 @@ module MiqAeEngine
 
       if obj.workspace.readonly?
         $miq_ae_logger.info("Workspace Instantiation is READONLY -- skipping method [#{aem.fqname}] with inputs [#{inputs.inspect}]")
-      elsif %w(inline builtin uri expression).include?(aem.location.downcase.strip)
+      elsif %w(inline builtin uri expression playbook).include?(aem.location.downcase.strip)
         $miq_ae_logger.info("Invoking [#{aem.location}] method [#{aem.fqname}] with inputs [#{inputs.inspect}]")
         return MiqAeEngine::MiqAeMethod.send("invoke_#{aem.location.downcase.strip}", aem, obj, inputs)
       end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -17,8 +17,7 @@ module MiqAeEngine
     end
 
     def self.invoke_playbook(aem, obj, inputs)
-      playbook_method = MiqAeEngine::MiqAePlaybookMethod.new(aem, obj, inputs)
-      playbook_method.run
+      MiqAeEngine::MiqAePlaybookMethod.new(aem, obj, inputs).run
     end
 
     def self.invoke_uri(aem, obj, _inputs)

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -1,59 +1,112 @@
 module MiqAeEngine
   class MiqAePlaybookMethod
-    include ApplicationController::Filter::SubstMixin
+    PLAYBOOK_CLASS = ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload
+
     def initialize(aem, obj, inputs)
       @workspace = obj.workspace
       @inputs    = inputs
       @aem       = aem
-      @aw = AutomateWorkspace.create(:input  => serialize_workspace(inputs),
-                                     :user   => @workspace.ae_user,
-                                     :tenant => @workspace.ae_user.current_tenant)
-      @runner_options = build_options_hash(aem, @aw.guid)
-    end
-
-    def manageiq_env
-      {
-        'api_token'  => Api::UserTokenService.new.generate_token(@workspace.ae_user.userid, 'api'),
-        'api_url'    => MiqRegion.my_region.remote_ws_url,
-        'guid'       => @aw.guid,
-        'MIQ_SCRIPT' => @contents,
-        'miq_group'  => @workspace.ae_user.current_group.description
-      }
     end
 
     def run
-      $miq_ae_logger.info("Playbook Method passing options to runner: #{@runner_options}")
-      begin
-        result = ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload.run(@runner_options)
-      rescue => err
-        $miq_ae_logger.error("Playbook Method Ended with error #{err.message}")
-        raise MiqAeException::AbortInstantiation, err.message
+      if @workspace.persist_state_hash[method_key].present?
+        task_id = @workspace.persist_state_hash[method_key]
+        @aw = AutomateWorkspace.find_by(:guid => @workspace.persist_state_hash['automate_workspace_guid'])
+        check_task_status(task_id)
+      else
+        execute
       end
-
-      $miq_ae_logger.error("Playbook Method Ended with success #{result}")
-      @aw.reload
-      @workspace.update_workspace(@aw.output)
     end
 
     private
 
-    def serialize_workspace(inputs)
-      {'workspace'         => @workspace.hash_workspace,
-       'method_parameters' => MiqAeReference.encode(inputs),
-       'current'           => current_info(@workspace),
+    def execute
+      @aw = AutomateWorkspace.create(:input  => serialize_workspace,
+                                     :user   => @workspace.ae_user,
+                                     :tenant => @workspace.ae_user.current_tenant)
+      playbook_options = build_options_hash
+      $miq_ae_logger.info("Playbook Method passing options to runner: #{playbook_options}")
+      begin
+        task_id = PLAYBOOK_CLASS.run(playbook_options)
+      rescue => err
+        $miq_ae_logger.error("Playbook Method Ended with error #{err.message}")
+        reset
+        raise MiqAeException::AbortInstantiation, err.message
+      end
+
+      @workspace.root['ae_state_started'].blank? ? wait_for_method(task_id) : check_task_status(task_id)
+    end
+
+    def process_result
+      @aw.reload
+      @workspace.update_workspace(@aw.output)
+      reset
+    end
+
+    def reset
+      @workspace.persist_state_hash.delete('automate_workspace_guid')
+      @workspace.persist_state_hash.delete(method_key)
+      @aw.delete
+    end
+
+    def wait_for_method(task_id)
+      task = MiqTask.wait_for_taskid(task_id)
+      raise MiqAeException::Error, task.message unless task.status == "Ok"
+      process_result
+    ensure
+      reset
+    end
+
+    def check_task_status(task_id)
+      task = MiqTask.find(task_id)
+      raise MiqAeException::Error, "Task id #{task_id} not found" unless task
+      if task.state == MiqTask::STATE_FINISHED
+        if task.status == MiqTask::STATUS_OK
+          @workspace.root['ae_result'] = 'ok'
+          process_result
+        else
+          @workspace.root['ae_result'] = 'error'
+          reset
+          raise MiqAeException::Error, task.message
+        end
+      else
+        @workspace.root['ae_result'] = 'retry'
+        @workspace.root['ae_retry_interval'] = 1.minute
+        @workspace.persist_state_hash['automate_workspace_guid'] = @aw.guid
+        @workspace.persist_state_hash[method_key] = task_id
+      end
+    end
+
+    def manageiq_env
+      {
+        'api_token' => Api::UserTokenService.new.generate_token(@workspace.ae_user.userid, 'api'),
+        'api_url'   => MiqRegion.my_region.remote_ws_url,
+        'guid'      => @aw.guid,
+        'miq_group' => @workspace.ae_user.current_group.description
+      }
+    end
+
+    def method_key
+      @method_key_value ||= "#{@aem.name}_ansible_method_task_id".gsub(/\s+/, "")
+    end
+
+    def serialize_workspace
+      {'objects'           => @workspace.hash_workspace,
+       'method_parameters' => MiqAeReference.encode(@inputs),
+       'current'           => current_info,
        'state_vars'        => MiqAeReference.encode(@workspace.persist_state_hash)}
     end
 
-    def current_info(workspace)
+    def current_info
       list = %w(namespace class instance message method)
-      list.each.with_object({}) { |m, hash| hash[m] = workspace.send("current_#{m}".to_sym) }
+      list.each.with_object({}) { |m, hash| hash[m] = @workspace.send("current_#{m}".to_sym) }
     end
 
-    def build_options_hash(aem, guid)
-      config_info = YAML.load(aem.data)
+    def build_options_hash
+      config_info = YAML.load(@aem.data)
       config_info[:extra_vars] = MiqAeReference.encode(@inputs)
       config_info[:extra_vars][:manageiq] = manageiq_env
-      { :name => aem.name, :config_info => config_info }
+      { :name => @aem.name, :config_info => config_info }
     end
   end
 end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -1,6 +1,6 @@
 module MiqAeEngine
   class MiqAePlaybookMethod
-    PLAYBOOK_CLASS = ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload
+    PLAYBOOK_CLASS = ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Job
 
     def initialize(aem, obj, inputs)
       @workspace = obj.workspace

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -34,7 +34,7 @@ module MiqAeEngine
         raise MiqAeException::AbortInstantiation, err.message
       end
 
-      running_in_state_machine? ? check_task_status(task_id) : wait_for_method(task_id) 
+      running_in_state_machine? ? check_task_status(task_id) : wait_for_method(task_id)
     end
 
     def running_in_state_machine?
@@ -74,11 +74,11 @@ module MiqAeEngine
           raise MiqAeException::Error, task.message
         end
       else
-        set_retry(task_id)
+        mark_for_retry(task_id)
       end
     end
 
-    def set_retry(task_id)
+    def mark_for_retry(task_id)
       @workspace.root['ae_result'] = 'retry'
       @workspace.root['ae_retry_interval'] = 1.minute
       @workspace.persist_state_hash['automate_workspace_guid'] = @aw.guid

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -1,0 +1,59 @@
+module MiqAeEngine
+  class MiqAePlaybookMethod
+    include ApplicationController::Filter::SubstMixin
+    def initialize(aem, obj, inputs)
+      @workspace = obj.workspace
+      @inputs    = inputs
+      @aem       = aem
+      @aw = AutomateWorkspace.create(:input  => serialize_workspace(inputs),
+                                     :user   => @workspace.ae_user,
+                                     :tenant => @workspace.ae_user.current_tenant)
+      @runner_options = build_options_hash(aem, @aw.guid)
+    end
+
+    def manageiq_env
+      {
+        'api_token'  => Api::UserTokenService.new.generate_token(@workspace.ae_user.userid, 'api'),
+        'api_url'    => MiqRegion.my_region.remote_ws_url,
+        'guid'       => @aw.guid,
+        'MIQ_SCRIPT' => @contents,
+        'miq_group'  => @workspace.ae_user.current_group.description
+      }
+    end
+
+    def run
+      $miq_ae_logger.info("Playbook Method passing options to runner: #{@runner_options}")
+      begin
+        result = ManageIQ::Providers::EmbeddedAutomationManager::ConfigurationScriptPayload.run(@runner_options)
+      rescue => err
+        $miq_ae_logger.error("Playbook Method Ended with error #{err.message}")
+        raise MiqAeException::AbortInstantiation, err.message
+      end
+
+      $miq_ae_logger.error("Playbook Method Ended with success #{result}")
+      @aw.reload
+      @workspace.update_workspace(@aw.output)
+    end
+
+    private
+
+    def serialize_workspace(inputs)
+      {'workspace'         => @workspace.hash_workspace,
+       'method_parameters' => MiqAeReference.encode(inputs),
+       'current'           => current_info(@workspace),
+       'state_vars'        => MiqAeReference.encode(@workspace.persist_state_hash)}
+    end
+
+    def current_info(workspace)
+      list = %w(namespace class instance message method)
+      list.each.with_object({}) { |m, hash| hash[m] = workspace.send("current_#{m}".to_sym) }
+    end
+
+    def build_options_hash(aem, guid)
+      config_info = YAML.load(aem.data)
+      config_info[:extra_vars] = MiqAeReference.encode(@inputs)
+      config_info[:extra_vars][:manageiq] = manageiq_env
+      { :name => aem.name, :config_info => config_info }
+    end
+  end
+end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -59,7 +59,6 @@ module MiqAeEngine
       self.class.cleanup(@workspace)
     end
 
-
     def wait_for_method(task_id)
       task = MiqTask.wait_for_taskid(task_id)
       raise MiqAeException::Error, task.message unless task.status == "Ok"

--- a/spec/miq_ae_playbook_method_spec.rb
+++ b/spec/miq_ae_playbook_method_spec.rb
@@ -1,0 +1,152 @@
+describe MiqAeEngine::MiqAePlaybookMethod do
+  describe "run" do
+    let(:user) { FactoryGirl.create(:user_with_group) }
+    let(:aw) { FactoryGirl.create(:automate_workspace, :user => user, :tenant => user.current_tenant) }
+    let(:root_hash) { { 'name' => 'Flintstone' } }
+    let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+    let(:persist_hash) { {} }
+    let(:script) { {"a" => "1"} }
+    let(:method_name) { "Freddy Kreuger" }
+    let(:method_key) { "FreddyKreuger_ansible_method_task_id" }
+    let(:miq_task) { FactoryGirl.create(:miq_task) }
+
+    let(:workspace) do
+      double("MiqAeEngine::MiqAeWorkspaceRuntime", :root               => root_object,
+                                                   :persist_state_hash => persist_hash,
+                                                   :ae_user            => user,
+                                                   :hash_workspace     => {},
+                                                   :current_namespace  => "Bedrock",
+                                                   :current_class      => "Mogul",
+                                                   :current_instance   => "Fred",
+                                                   :current_message    => "Yabba Dabba",
+                                                   :current_method     => "Dino")
+    end
+
+    let(:user) do
+      FactoryGirl.create(:user_with_group, :userid   => "admin",
+                                           :settings => {:display => { :timezone => "UTC"}})
+    end
+
+    let(:aem)    { double("AEM", :data => script.to_yaml, :name => method_name) }
+    let(:obj)    { double("OBJ", :workspace => workspace) }
+    let(:inputs) { { 'name' => 'Fred' } }
+
+    context "regular method" do
+      it "success" do
+        allow(described_class::PLAYBOOK_CLASS).to receive(:run).and_return(miq_task.id)
+        allow(MiqRegion).to receive(:my_region).and_return(FactoryGirl.create(:miq_region))
+        allow(AutomateWorkspace).to receive(:create).and_return(aw)
+        miq_task.update_status(MiqTask::STATE_FINISHED, MiqTask::STATUS_OK, "Done")
+        allow(MiqTask).to receive(:wait_for_taskid).and_return(miq_task)
+        allow(workspace).to receive(:update_workspace)
+
+        ap = described_class.new(aem, obj, inputs)
+        ap.run
+
+        expect { aw.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+
+      it "method fails" do
+        allow(described_class::PLAYBOOK_CLASS).to receive(:run).and_return(miq_task.id)
+        allow(MiqRegion).to receive(:my_region).and_return(FactoryGirl.create(:miq_region))
+        allow(AutomateWorkspace).to receive(:create).and_return(aw)
+        miq_task.update_status(MiqTask::STATE_FINISHED, MiqTask::STATUS_ERROR, "Done")
+        allow(MiqTask).to receive(:wait_for_taskid).and_return(miq_task)
+        allow(workspace).to receive(:update_workspace)
+
+        ap = described_class.new(aem, obj, inputs)
+        expect { ap.run }.to raise_exception(MiqAeException::Error)
+        expect { aw.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+
+      it "playbook launch fails" do
+        allow(described_class::PLAYBOOK_CLASS).to receive(:run).and_raise("Bamm Bamm Rubble")
+        allow(MiqRegion).to receive(:my_region).and_return(FactoryGirl.create(:miq_region))
+        allow(AutomateWorkspace).to receive(:create).and_return(aw)
+
+        ap = described_class.new(aem, obj, inputs)
+        expect { ap.run }.to raise_exception(MiqAeException::Error)
+        expect { aw.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "state machine" do
+      it "sets up retry as a state method" do
+        root_hash['ae_state_started'] = Time.zone.now.utc.to_s
+        allow(described_class::PLAYBOOK_CLASS).to receive(:run).and_return(miq_task.id)
+        allow(MiqRegion).to receive(:my_region).and_return(FactoryGirl.create(:miq_region))
+        allow(AutomateWorkspace).to receive(:create).and_return(aw)
+        ap = described_class.new(aem, obj, inputs)
+        allow(workspace).to receive(:update_workspace)
+        miq_task.update_status(MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "Actively working")
+        allow(MiqTask).to receive(:wait_for_taskid).and_return(miq_task)
+        ap.run
+
+        expect(root_object['ae_result']).to eq('retry')
+        expect(persist_hash[method_key]).to eq(miq_task.id)
+        expect(AutomateWorkspace.find_by(:guid => aw.guid)).not_to be_nil
+      end
+
+      it "on subsequent calls" do
+        root_hash['ae_state_started'] = Time.zone.now.utc.to_s
+        persist_hash[method_key] = miq_task.id
+        persist_hash['automate_workspace_guid'] = aw.guid
+
+        allow(described_class::PLAYBOOK_CLASS).to receive(:run).and_return(miq_task.id)
+        allow(MiqRegion).to receive(:my_region).and_return(FactoryGirl.create(:miq_region))
+        allow(AutomateWorkspace).to receive(:find_by).and_return(aw)
+        ap = described_class.new(aem, obj, inputs)
+        allow(workspace).to receive(:update_workspace)
+        miq_task.update_status(MiqTask::STATE_ACTIVE, MiqTask::STATUS_OK, "Actively working")
+        allow(MiqTask).to receive(:wait_for_taskid).and_return(miq_task)
+        ap.run
+
+        expect(root_object['ae_result']).to eq('retry')
+        expect(persist_hash[method_key]).to eq(miq_task.id)
+        expect(AutomateWorkspace.find_by(:guid => aw.guid)).not_to be_nil
+      end
+
+      it "state finishes succesfully" do
+        root_hash['ae_state_started'] = Time.zone.now.utc.to_s
+        persist_hash[method_key] = miq_task.id
+        persist_hash['automate_workspace_guid'] = aw.guid
+
+        allow(described_class::PLAYBOOK_CLASS).to receive(:run).and_return(miq_task.id)
+        allow(MiqRegion).to receive(:my_region).and_return(FactoryGirl.create(:miq_region))
+        allow(AutomateWorkspace).to receive(:find_by).and_return(aw)
+        ap = described_class.new(aem, obj, inputs)
+        allow(workspace).to receive(:update_workspace)
+        miq_task.update_status(MiqTask::STATE_FINISHED, MiqTask::STATUS_OK, "Done")
+        allow(MiqTask).to receive(:wait_for_taskid).and_return(miq_task)
+
+        ap.run
+
+        expect(root_object['ae_result']).to eq('ok')
+        expect(persist_hash[method_key]).to be_nil
+        expect(persist_hash['automate_workspace_guid']).to be_nil
+        expect { aw.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+
+      it "state finishes in error" do
+        root_hash['ae_state_started'] = Time.zone.now.utc.to_s
+        persist_hash[method_key] = miq_task.id
+        persist_hash['automate_workspace_guid'] = aw.guid
+
+        allow(described_class::PLAYBOOK_CLASS).to receive(:run).and_return(miq_task.id)
+        allow(MiqRegion).to receive(:my_region).and_return(FactoryGirl.create(:miq_region))
+        allow(AutomateWorkspace).to receive(:find_by).and_return(aw)
+        ap = described_class.new(aem, obj, inputs)
+        allow(workspace).to receive(:update_workspace)
+        miq_task.update_status(MiqTask::STATE_FINISHED, MiqTask::STATUS_ERROR, "Done")
+        allow(MiqTask).to receive(:wait_for_taskid).and_return(miq_task)
+
+        expect { ap.run }.to raise_exception(MiqAeException::Error)
+
+        expect(root_object['ae_result']).to eq('error')
+        expect(persist_hash[method_key]).to be_nil
+        expect(persist_hash['automate_workspace_guid']).to be_nil
+        expect { aw.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the ability to launch an Ansible Playbook as a
 - State machine method, the method can run longer and we will internally do the retry
 - Regular Method, the playbook has to end execution in 10 minutes