### PR TITLE
Renamed key from workspace to objects

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_deserialize_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_deserialize_workspace.rb
@@ -1,7 +1,7 @@
 module MiqAeEngine
   module MiqAeDeserializeWorkspace
     def update_workspace(hash)
-      hash['workspace'].each { |path, attrs| update_object(path, attrs, ae_user) }
+      hash['objects'].each { |path, attrs| update_object(path, attrs, ae_user) }
       hash['state_vars'].each { |k, v| @persist_state_hash[k] = MiqAeReference.decode(v, ae_user) }
     end
 

--- a/spec/miq_ae_deserialize_workspace_spec.rb
+++ b/spec/miq_ae_deserialize_workspace_spec.rb
@@ -39,7 +39,7 @@ describe "MiqAeDeserializeWorkspace" do
       let(:updated_hash) do
         {
           'state_vars' => { 'x' => 1 },
-          'workspace'  => {
+          'objects'    => {
             'root'                => {
               'a'     => 9,
               'my_vm' => "vmdb_reference::#{vm.href_slug}",
@@ -53,7 +53,7 @@ describe "MiqAeDeserializeWorkspace" do
       end
 
       let(:invalid_obj_name_hash) do
-        {'workspace' => { 'frooti' => {} }}
+        {'objects' => { 'frooti' => {} }}
       end
 
       let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }


### PR DESCRIPTION
Renamed a key in the output field from workspace to objects.
This is the automate engine part of PR https://github.com/ManageIQ/manageiq/pull/15977