### PR TITLE
Pass in the workspace as href_slug

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -93,10 +93,10 @@ module MiqAeEngine
 
     def manageiq_env
       {
-        'api_token'      => Api::UserTokenService.new.generate_token(@workspace.ae_user.userid, 'api'),
-        'api_url'        => MiqRegion.my_region.remote_ws_url,
-        'workspace_guid' => @aw.guid,
-        'miq_group'      => @workspace.ae_user.current_group.description
+        'api_token'          => Api::UserTokenService.new.generate_token(@workspace.ae_user.userid, 'api'),
+        'api_url'            => MiqRegion.my_region.remote_ws_url,
+        'automate_workspace' => @aw.href_slug,
+        'miq_group'          => @workspace.ae_user.current_group.description
       }
     end
 


### PR DESCRIPTION
The Automate Workspace is passed in as a href_slug. 

The following is a list of the manageiq extra vars passed into the play book.

**api_token**  =>  "fe26f7172182c266a831dba62ac8a92a", 
**api_url**"       => "http://localhost:3000", 
 **automate_workspace** =>"automate_workspaces/1b0fc6e8-7add-4b0e-bd84-f738f877f7e4",       **miq_group**  => "Test Group1"

Please note that the miq_group is not passed in as a slug since its needed to connect to the API end point using **X-MIQ-Group** as described here. http://manageiq.org/docs/reference/latest/api/overview/authorization