### PR TITLE
Renamed vmdb_reference to href_slug

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_reference.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_reference.rb
@@ -6,7 +6,7 @@ module MiqAeEngine
       elsif value.kind_of?(Hash)
         value.each_with_object({}) { |(k, v), hash| hash[k] = encode(v) }
       elsif /MiqAeMethodService::/ =~ value.class.to_s
-        "vmdb_reference::#{value.href_slug}"
+        "href_slug::#{value.href_slug}"
       elsif /MiqAePassword/ =~ value.class.to_s
         "miq_password::#{value}"
       else
@@ -19,7 +19,7 @@ module MiqAeEngine
         value.map { |v| decode(v, user) }
       elsif value.kind_of?(Hash)
         value.each_with_object({}) { |(k, v), hash| hash[k] = decode(v, user) }
-      elsif value.kind_of?(String) && /vmdb_reference::(.*)/.match(value)
+      elsif value.kind_of?(String) && /href_slug::(.*)/.match(value)
         obj = Api::Utils.resource_search_by_href_slug($1, user)
         MiqAeMethodService::MiqAeServiceModelBase.wrap_results(obj)
       elsif value.kind_of?(String) && /miq_password::(.*)/.match(value)

--- a/spec/miq_ae_deserialize_workspace_spec.rb
+++ b/spec/miq_ae_deserialize_workspace_spec.rb
@@ -42,7 +42,7 @@ describe "MiqAeDeserializeWorkspace" do
           'objects'    => {
             'root'                => {
               'a'     => 9,
-              'my_vm' => "vmdb_reference::#{vm.href_slug}",
+              'my_vm' => "href_slug::#{vm.href_slug}",
               'd'     => '2'
             },
             '/miq/demo/test/ins1' => {

--- a/spec/miq_ae_reference_spec.rb
+++ b/spec/miq_ae_reference_spec.rb
@@ -7,7 +7,7 @@ describe MiqAeEngine::MiqAeReference do
     let(:host) { FactoryGirl.create(:host) }
     let(:vm) { FactoryGirl.create(:vm_vmware, :host => host) }
     let(:svc_vm) { MiqAeMethodService::MiqAeServiceVm.find(vm.id) }
-    let(:ref) { "vmdb_reference::#{vm.href_slug}" }
+    let(:ref) { "href_slug::#{vm.href_slug}" }
 
     it "#encode a vm object" do
       expect(::MiqAeEngine::MiqAeReference.encode(svc_vm)).to eq(ref)

--- a/spec/miq_ae_serialize_workspace_spec.rb
+++ b/spec/miq_ae_serialize_workspace_spec.rb
@@ -44,7 +44,7 @@ describe "MiqAeSerializeWorkspace" do
 
     context "vmdb_object" do
       let(:root_hash) { { 'a' => 1, 'b' => '2', 'my_vm' => svc_vm} }
-      let(:ref_hash) { { 'a' => 1, 'b' => '2', 'my_vm' => "vmdb_reference::#{vm.href_slug}"} }
+      let(:ref_hash) { { 'a' => 1, 'b' => '2', 'my_vm' => "href_slug::#{vm.href_slug}"} }
       let(:hashed_workspace) { { "root" => ref_hash} }
       let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
 


### PR DESCRIPTION
Renamed the reference to vmdb objects in the AutomateWorkspace stored in the database to use href_slug:: instead of vmdb_reference::

