### PR TITLE
Changed deliver find_by to raise an error when the object is not found.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -72,7 +72,7 @@ module MiqAeEngine
       automate_attrs = options[:attrs].dup
 
       if object_type
-        vmdb_object = object_type.constantize.find_by(:id => object_id)
+        vmdb_object = object_type.constantize.find_by!(:id => object_id)
         automate_attrs[create_automation_attribute_key(vmdb_object)] = object_id
         vmdb_object.before_ae_starts(options) if vmdb_object.respond_to?(:before_ae_starts)
       end


### PR DESCRIPTION
Several customer evm.logs show the following error:
MIQ(MiqQueue#deliver) Message id: [204945], Error: [undefined method `base_class' for NilClass:Class]
Which is caused by a Service request(and task) being deleted while Service provisioning is executing.

Changing the deliver find_by method will show that the ServiceTemplateProvisionTask does not exist.

https://bugzilla.redhat.com/show_bug.cgi?id=1467537