### PR TITLE
Rename miq_password to password in AutomateWorkspace

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_reference.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_reference.rb
@@ -8,7 +8,7 @@ module MiqAeEngine
       elsif /MiqAeMethodService::/ =~ value.class.to_s
         "href_slug::#{value.href_slug}"
       elsif /MiqAePassword/ =~ value.class.to_s
-        "miq_password::#{value}"
+        "password::#{value}"
       else
         value
       end
@@ -22,7 +22,7 @@ module MiqAeEngine
       elsif value.kind_of?(String) && /href_slug::(.*)/.match(value)
         obj = Api::Utils.resource_search_by_href_slug($1, user)
         MiqAeMethodService::MiqAeServiceModelBase.wrap_results(obj)
-      elsif value.kind_of?(String) && /miq_password::(.*)/.match(value)
+      elsif value.kind_of?(String) && /password::(.*)/.match(value)
         MiqAePassword.new(value)
       else
         value

--- a/spec/miq_ae_reference_spec.rb
+++ b/spec/miq_ae_reference_spec.rb
@@ -22,7 +22,7 @@ describe MiqAeEngine::MiqAeReference do
     let(:password) { MiqAePassword.new("smartvm") }
 
     it "#encodes a password field" do
-      expect(::MiqAeEngine::MiqAeReference.encode(password)).to eq("miq_password::#{password}")
+      expect(::MiqAeEngine::MiqAeReference.encode(password)).to eq("password::#{password}")
     end
   end
 end


### PR DESCRIPTION
We already have a way of passing passwords into Automate using password::encrypted_value, for the AutomateWorkspace we were using miq_password::encrypted_value.

Changing it to be password to be consistent.