### PR TITLE
Get the current user if user context is set.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_event.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_event.rb
@@ -115,13 +115,16 @@ module MiqAeEvent
   end
 
   def self.call_automate(obj, attrs, instance_name, options = {})
-    user = obj.tenant_identity
+    user = User.current_user || obj.tenant_identity
     raise "A user is needed to raise #{instance_name} to automate. [#{obj.class.name}] id:[#{obj.id}]" unless user
 
     q_options = {
       :miq_callback => options[:miq_callback],
       :priority     => MiqQueue::HIGH_PRIORITY,
-      :task_id      => nil          # Clear task_id to allow running synchronously under current worker process
+      :user_id      => user.id,
+      :group_id     => user.current_group.id,
+      :tenant_id    => user.current_tenant.id,
+      :task_id      => nil # Clear task_id to allow running synchronously under current worker process
     }
     q_options[:zone] = options[:zone] if options[:zone].present?
 

--- a/spec/miq_ae_event_spec.rb
+++ b/spec/miq_ae_event_spec.rb
@@ -124,6 +124,15 @@ describe MiqAeEvent do
 
           MiqAeEvent.raise_evm_event("vm_create", vm, :vm => vm)
         end
+
+        it "has current user" do
+          User.with_user(user) do
+            args = {:user_id => user.id, :miq_group_id => user.current_group.id, :tenant_id => user.current_tenant.id}
+            expect(MiqAeEngine).to receive(:deliver_queue).with(hash_including(args), anything)
+
+            MiqAeEvent.raise_evm_event("vm_create", vm, :vm => vm)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
PR https://github.com/ManageIQ/manageiq/pull/16089 allows the user_id/group_id/tenant_id to be recorded in the Queue and sets the user context when dispatching the item from the Queue.

This PR would use the user context if it is available when sending events to automate.

Blocks https://github.com/ManageIQ/manageiq/pull/16179.

https://bugzilla.redhat.com/show_bug.cgi?id=1487749
cc @mkanoor 