### PR TITLE
subst mixin moved to MiqExpression namespace

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
@@ -1,6 +1,6 @@
 module MiqAeEngine
   class MiqAeExpressionMethod
-    include ApplicationController::Filter::SubstMixin
+    include MiqExpression::SubstMixin
     def initialize(method_obj, obj, inputs)
       @edit = {}
       @name = method_obj.name


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/16190

It was located [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/96dd2c9b7400bbbe4fb3b4496d4da04a849a88a3/app/controllers/application_controller/filter/subst_mixin.rb)

It is included in ui-classic [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/96dd2c9b7400bbbe4fb3b4496d4da04a849a88a3/app/controllers/application_controller/filter.rb#L4)

In addition, manageiq-automation_engine also includes it, but doesn't
specify manageiq-ui-classic as a dependency [here](
https://github.com/ManageIQ/manageiq-automation_engine/blob/b08ff10f07f6e962e57fc1b201bbce121367bb6c/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb#L3)

Let's just move it back to manageiq so automate is not dependent on
ui-classic code.