### PR TITLE
Expose disks and volumes in the ServiceModel through Hardware.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_hardware.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_hardware.rb
@@ -9,6 +9,8 @@ module MiqAeMethodService
     expose :host,             :association => true
     expose :networks,         :association => true
     expose :partitions,       :association => true
+    expose :disks,            :association => true
+    expose :volumes,          :association => true
 
     def mac_addresses
       object_send(:nics).collect(&:address)


### PR DESCRIPTION
Partitions were already exposed.

https://bugzilla.redhat.com/show_bug.cgi?id=1498863


