### PR TITLE
Add remove_from_vmdb method to Host object for Service models

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
@@ -4,6 +4,8 @@ module MiqAeMethodService
     include MiqAeServiceCustomAttributeMixin
     require_relative "mixins/miq_ae_service_ems_operations_mixin"
     include MiqAeServiceEmsOperationsMixin
+    require_relative "mixins/miq_ae_service_remove_from_vmdb_mixin"
+    include MiqAeServiceRemoveFromVmdb
 
     expose :storages,              :association => true
     expose :read_only_storages

--- a/lib/miq_automation_engine/service_models/miq_ae_service_load_balancer.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_load_balancer.rb
@@ -2,6 +2,8 @@ module MiqAeMethodService
   class MiqAeServiceLoadBalancer < MiqAeServiceModelBase
     require_relative "mixins/miq_ae_service_retirement_mixin"
     include MiqAeServiceRetirementMixin
+    require_relative "mixins/miq_ae_service_remove_from_vmdb_mixin"
+    include MiqAeServiceRemoveFromVmdb
 
     expose :ext_management_system, :association => true
     expose :cloud_tenant, :association => true
@@ -16,13 +18,6 @@ module MiqAeMethodService
       error_msg = "service must be a MiqAeServiceService"
       raise ArgumentError, error_msg unless service.kind_of?(MiqAeMethodService::MiqAeServiceService)
       ar_method { wrap_results(Service.find_by(:id => service.id).add_resource!(@object)) }
-    end
-
-    def remove_from_vmdb
-      _log.info "Removing #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}>"
-      object_send(:destroy)
-      @object = nil
-      true
     end
 
     def normalized_live_status

--- a/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_stack.rb
@@ -2,6 +2,8 @@ module MiqAeMethodService
   class MiqAeServiceOrchestrationStack < MiqAeServiceModelBase
     require_relative "mixins/miq_ae_service_retirement_mixin"
     include MiqAeServiceRetirementMixin
+    require_relative "mixins/miq_ae_service_remove_from_vmdb_mixin"
+    include MiqAeServiceRemoveFromVmdb
 
     expose :parameters,             :association => true
     expose :resources,              :association => true
@@ -17,13 +19,6 @@ module MiqAeMethodService
       error_msg = "service must be a MiqAeServiceService"
       raise ArgumentError, error_msg unless service.kind_of?(MiqAeMethodService::MiqAeServiceService)
       ar_method { wrap_results(Service.find_by(:id => service.id).add_resource!(@object)) }
-    end
-
-    def remove_from_vmdb
-      _log.info "Removing #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}>"
-      object_send(:destroy)
-      @object = nil
-      true
     end
 
     def normalized_live_status

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -4,6 +4,8 @@ module MiqAeMethodService
     include MiqAeServiceRetirementMixin
     require_relative "mixins/miq_ae_service_custom_attribute_mixin"
     include MiqAeServiceCustomAttributeMixin
+    require_relative "mixins/miq_ae_service_remove_from_vmdb_mixin"
+    include MiqAeServiceRemoveFromVmdb
 
     expose :retire_service_resources
     expose :automate_retirement_entrypoint
@@ -91,13 +93,6 @@ module MiqAeMethodService
         end
         @object.save
       end
-    end
-
-    def remove_from_vmdb
-      _log.info "Removing #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}>"
-      object_send(:destroy)
-      @object = nil
-      true
     end
 
     def group=(group)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
@@ -8,6 +8,8 @@ module MiqAeMethodService
     include MiqAeServiceInflectorMixin
     require_relative "mixins/miq_ae_service_custom_attribute_mixin"
     include MiqAeServiceCustomAttributeMixin
+    require_relative "mixins/miq_ae_service_remove_from_vmdb_mixin"
+    include MiqAeServiceRemoveFromVmdb
 
     expose :ext_management_system, :association => true
     expose :storage,               :association => true
@@ -75,13 +77,6 @@ module MiqAeMethodService
     # Used to return string object instead of VimString to automate methods which end up with a DrbUnknow object.
     def ems_ref_string
       object_send(:ems_ref)
-    end
-
-    def remove_from_vmdb
-      _log.info "Removing #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}>"
-      object_send(:destroy)
-      @object = nil
-      true
     end
 
     def scan(scan_categories = nil)

--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_remove_from_vmdb_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_remove_from_vmdb_mixin.rb
@@ -1,0 +1,10 @@
+module MiqAeServiceRemoveFromVmdb
+  extend ActiveSupport::Concern
+
+  def remove_from_vmdb
+    _log.info("Removing #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}>")
+    object_send(:destroy)
+    @object = nil
+    true
+  end
+end


### PR DESCRIPTION
Support calling `remove_from_vmdb` on Host object from automate.

https://bugzilla.redhat.com/show_bug.cgi?id=1334930