### PR TITLE
Added support for manageiq_connection

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -7,6 +7,8 @@ module MiqAeEngine
       @workspace = obj.workspace
       @inputs    = inputs
       @aem       = aem
+      @api_token = Api::UserTokenService.new.generate_token(@workspace.ae_user.userid, 'api')
+      @api_url   = MiqRegion.my_region.remote_ws_url
     end
 
     def run
@@ -95,12 +97,20 @@ module MiqAeEngine
 
     def manageiq_env
       {
-        'api_token'          => Api::UserTokenService.new.generate_token(@workspace.ae_user.userid, 'api'),
-        'api_url'            => MiqRegion.my_region.remote_ws_url,
+        'api_token'          => @api_token,
+        'api_url'            => @api_url,
         'user'               => @workspace.ae_user.href_slug,
         'group'              => @workspace.ae_user.current_group.href_slug,
         'automate_workspace' => @aw.href_slug,
         'X_MIQ_Group'        => @workspace.ae_user.current_group.description
+      }
+    end
+
+    def manageiq_connection_env
+      {
+        'token'       => @api_token,
+        'url'         => @api_url,
+        'X_MIQ_Group' => @workspace.ae_user.current_group.description
       }
     end
 
@@ -124,6 +134,7 @@ module MiqAeEngine
       @aem.options.tap do |config_info|
         config_info[:extra_vars] = MiqAeReference.encode(@inputs)
         config_info[:extra_vars][:manageiq] = manageiq_env
+        config_info[:extra_vars][:manageiq_connection] = manageiq_connection_env
       end
     end
   end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -7,8 +7,6 @@ module MiqAeEngine
       @workspace = obj.workspace
       @inputs    = inputs
       @aem       = aem
-      @api_token = Api::UserTokenService.new.generate_token(@workspace.ae_user.userid, 'api')
-      @api_url   = MiqRegion.my_region.remote_ws_url
     end
 
     def run
@@ -97,8 +95,8 @@ module MiqAeEngine
 
     def manageiq_env
       {
-        'api_token'          => @api_token,
-        'api_url'            => @api_url,
+        'api_token'          => api_token,
+        'api_url'            => api_url,
         'user'               => @workspace.ae_user.href_slug,
         'group'              => @workspace.ae_user.current_group.href_slug,
         'automate_workspace' => @aw.href_slug,
@@ -108,8 +106,8 @@ module MiqAeEngine
 
     def manageiq_connection_env
       {
-        'token'       => @api_token,
-        'url'         => @api_url,
+        'token'       => api_token,
+        'url'         => api_url,
         'X_MIQ_Group' => @workspace.ae_user.current_group.description
       }
     end
@@ -136,6 +134,14 @@ module MiqAeEngine
         config_info[:extra_vars][:manageiq] = manageiq_env
         config_info[:extra_vars][:manageiq_connection] = manageiq_connection_env
       end
+    end
+
+    def api_token
+      @api_token ||= Api::UserTokenService.new.generate_token(@workspace.ae_user.userid, 'api')
+    end
+
+    def api_url
+      @api_url ||= MiqRegion.my_region.remote_ws_url
     end
   end
 end

--- a/spec/miq_ae_playbook_method_spec.rb
+++ b/spec/miq_ae_playbook_method_spec.rb
@@ -47,6 +47,8 @@ describe MiqAeEngine::MiqAePlaybookMethod do
         expect(playbook).to receive(:run) do |args|
           expect(args['test']).to eq(13)
           expect(args[:extra_vars][:manageiq]['automate_workspace']).to eq(aw.href_slug)
+          expect(%w(api_url api_token) - args[:extra_vars][:manageiq].keys).to be_empty
+          expect(%w(url token) - args[:extra_vars][:manageiq_connection].keys).to be_empty
           miq_task.id
         end
 


### PR DESCRIPTION
The python client api expects the URL and token to be defined in the manageiq_connection hash.
When we pass extra_vars into Ansible playbook we need to set the
* url
* token

In the manageiq_connection hash.