### PR TITLE
[WIP]Changed substitution for non-string datatypes.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -54,7 +54,7 @@ module MiqAeEngine
       aem.inputs.each do |f|
         key   = f.name
         value = args[key]
-        value = obj.attributes[key] || obj.substitute_value(f.default_value) if value.nil?
+        value = obj.attributes[key] || obj.substitute_value(f.default_value, f.datatype) if value.nil?
         inputs[key] = MiqAeObject.convert_value_based_on_datatype(value, f["datatype"])
 
         if obj.attributes[key] && f["datatype"] != "string"


### PR DESCRIPTION
Changed substitute_value method to take datatype, and return subst value unless string datatype. 
Modified method calls to reflect datatype change and modified convert_value_based_on_datatype to return value if kind of service model.