### PR TITLE
Add vm_reconfigure_request service model.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm_cloud_reconfigure_request.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm_cloud_reconfigure_request.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceVmMigrateRequest < MiqAeServiceMiqRequest
+  class MiqAeServiceVmCloudReconfigureRequest < MiqAeServiceMiqRequest
     require_relative "mixins/miq_ae_service_miq_provision_quota_mixin"
     include MiqAeServiceMiqProvisionQuotaMixin
     def ci_type

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm_reconfigure_request.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm_reconfigure_request.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceVmMigrateRequest < MiqAeServiceMiqRequest
+  class MiqAeServiceVmReconfigureRequest < MiqAeServiceMiqRequest
     require_relative "mixins/miq_ae_service_miq_provision_quota_mixin"
     include MiqAeServiceMiqProvisionQuotaMixin
     def ci_type

--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_miq_provision_quota_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_miq_provision_quota_mixin.rb
@@ -1,0 +1,6 @@
+module MiqAeServiceMiqProvisionQuotaMixin
+  extend ActiveSupport::Concern
+  included do
+    expose(:check_quota)
+  end
+end


### PR DESCRIPTION
Quota for vm reconfigure gets stuck in 'pending' state due to undefined check_quota method. 
https://bugzilla.redhat.com/show_bug.cgi?id=1517112

New quota mixin exposes check_quota method.

ManageIQ change required to include provision mixin: 
https://github.com/ManageIQ/manageiq/pull/16626