### PR TITLE
Set state machine retry interval for Ansible playbook method.

### DIFF
--- a/spec/miq_ae_playbook_method_spec.rb
+++ b/spec/miq_ae_playbook_method_spec.rb
@@ -155,6 +155,52 @@ describe MiqAeEngine::MiqAePlaybookMethod do
         expect(persist_hash['automate_workspace_guid']).to be_nil
         expect { aw.reload }.to raise_exception(ActiveRecord::RecordNotFound)
       end
+
+      shared_context "retry_interval" do
+        let(:max_retries) { 100 }
+        let(:retry_interval) { 1.minute }
+      end
+
+      shared_examples_for "check retry interval" do
+        it "calculate interval" do
+          root_object['ae_state_max_retries'] = max_retries
+          ap = described_class.new(aem, obj, inputs)
+          ap.run
+
+          expect(root_object['ae_result']).to eq('retry')
+          expect(root_object['ae_retry_interval']).to eq(retry_interval)
+        end
+      end
+
+      context "7.minutes, execution_ttl 700" do
+        let(:options) { {:execution_ttl => 700} }
+        let(:max_retries) { 100 }
+        let(:retry_interval) { 7.minutes }
+
+        it_behaves_like "check retry interval"
+      end
+
+      context "default 1.minute, low execution_ttl" do
+        include_context "retry_interval"
+        let(:options) { {:execution_ttl => 40} }
+
+        it_behaves_like "check retry interval"
+      end
+
+      context "default 1.minute, execution_ttl not specified" do
+        include_context "retry_interval"
+        let(:options) { {} }
+
+        it_behaves_like "check retry interval"
+      end
+
+      context "default 1.minute, zero max_retries" do
+        let(:max_retries) { 0 }
+        let(:options) { {} }
+        let(:retry_interval) { 1.minute }
+
+        it_behaves_like "check retry interval"
+      end
     end
   end
 end


### PR DESCRIPTION
Use execution_ttl to calculate the state machine retry_interval.
The Automate Method editor for Ansible playbooks accepts a value for the ttl(time to live) which is the expected time, in minutes, for a playbook to complete execution. Retries are only valid for state machines, so the Ansible Playbook method execution_ttl value is ignored when not executed within a state machine.  
The execution_ttl value is divided by the max_retries to determine the state machine retry interval.
For example, an execution_ttl of 700(minutes) in a state machine state that has a max_retries of 100, would result in a state machine retry interval of 7 minutes.
Any calculation resulting in a retry_interval less than 1 minute will be ignored and replaced by a 1 minute retry interval. 