### PR TITLE
Add task_href_slug as an extra_var for Ansible Playbook

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -164,7 +164,7 @@ module MiqAeEngine
       if @workspace.root['vmdb_object_type']
         vmdb_obj = @workspace.root[@workspace.root['vmdb_object_type']]
         if vmdb_obj.kind_of?(MiqAeMethodService::MiqAeServiceMiqRequestTask)
-          result['task_href_slug'] = "#{vmdb_obj.miq_request.href_slug}/#{vmdb_obj.href_slug}"
+          result['request_task'] = "#{vmdb_obj.miq_request.href_slug}/#{vmdb_obj.href_slug}"
         end
       end
       result

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -116,7 +116,7 @@ module MiqAeEngine
         'group'              => @workspace.ae_user.current_group.href_slug,
         'automate_workspace' => @aw.href_slug,
         'X_MIQ_Group'        => @workspace.ae_user.current_group.description
-      }
+      }.merge(miq_request_task_url)
     end
 
     def manageiq_connection_env
@@ -157,6 +157,17 @@ module MiqAeEngine
 
     def api_url
       @api_url ||= MiqRegion.my_region.remote_ws_url
+    end
+
+    def miq_request_task_url
+      result = {}
+      if @workspace.root['vmdb_object_type']
+        vmdb_obj = @workspace.root[@workspace.root['vmdb_object_type']]
+        if vmdb_obj.kind_of?(MiqAeMethodService::MiqAeServiceMiqRequestTask)
+          result['task_href_slug'] = "#{vmdb_obj.miq_request.href_slug}/#{vmdb_obj.href_slug}"
+        end
+      end
+      result
     end
   end
 end

--- a/spec/miq_ae_playbook_method_spec.rb
+++ b/spec/miq_ae_playbook_method_spec.rb
@@ -74,10 +74,10 @@ describe MiqAeEngine::MiqAePlaybookMethod do
         expect { aw.reload }.to raise_exception(ActiveRecord::RecordNotFound)
       end
 
-      shared_examples_for "href_slug" do
+      shared_examples_for "task_slug" do
         it "matches" do
           expect(playbook).to receive(:run) do |args|
-            expect(args[:extra_vars][:manageiq]['task_href_slug']).to eq(task_href_slug)
+            expect(args[:extra_vars][:manageiq]['request_task']).to eq(task_href_slug)
             miq_task.id
           end
 
@@ -92,7 +92,7 @@ describe MiqAeEngine::MiqAePlaybookMethod do
           { 'vmdb_object_type'                => 'service_template_provision_task',
             'service_template_provision_task' => svc_stpt }
         end
-        it_behaves_like "href_slug"
+        it_behaves_like "task_slug"
       end
 
       context "provision_task" do
@@ -101,7 +101,7 @@ describe MiqAeEngine::MiqAePlaybookMethod do
           { 'vmdb_object_type' => 'miq_provision',
             'miq_provision'    => svc_mpt }
         end
-        it_behaves_like "href_slug"
+        it_behaves_like "task_slug"
       end
     end
 

--- a/spec/miq_ae_playbook_method_spec.rb
+++ b/spec/miq_ae_playbook_method_spec.rb
@@ -33,8 +33,25 @@ describe MiqAeEngine::MiqAePlaybookMethod do
     let(:obj)    { double("OBJ", :workspace => workspace) }
     let(:inputs) { { 'name' => 'Fred' } }
 
+    let(:mpr) { FactoryGirl.create(:miq_provision_request, :requester => user) }
+
+    let(:svc_mpr) { MiqAeMethodService::MiqAeServiceMiqProvisionRequest.find(mpr.id) }
+
+    let(:stpr) { FactoryGirl.create(:service_template_provision_request, :requester => user) }
+
+    let(:svc_stpr) { MiqAeMethodService::MiqAeServiceServiceTemplateProvisionRequest.find(stpr.id) }
+
+    let(:mpt) { FactoryGirl.create(:miq_provision_task, :miq_request => mpr) }
+
+    let(:svc_mpt) { MiqAeMethodService::MiqAeServiceMiqProvisionTask.find(mpt.id) }
+
+    let(:stpt) { FactoryGirl.create(:service_template_provision_task, :miq_request => stpr) }
+
+    let(:svc_stpt) { MiqAeMethodService::MiqAeServiceServiceTemplateProvisionTask.find(stpt.id) }
+
     context "check miq extra vars passed into playbook" do
       before do
+        miq_task.update_status(MiqTask::STATE_FINISHED, MiqTask::STATUS_OK, "Done")
         allow(MiqRegion).to receive(:my_region).and_return(FactoryGirl.create(:miq_region))
         allow(AutomateWorkspace).to receive(:create).and_return(aw)
         allow(MiqTask).to receive(:wait_for_taskid).and_return(miq_task)
@@ -43,7 +60,6 @@ describe MiqAeEngine::MiqAePlaybookMethod do
       end
 
       it "success" do
-        miq_task.update_status(MiqTask::STATE_FINISHED, MiqTask::STATUS_OK, "Done")
         expect(playbook).to receive(:run) do |args|
           expect(args['test']).to eq(13)
           expect(args[:extra_vars][:manageiq]['automate_workspace']).to eq(aw.href_slug)
@@ -56,6 +72,36 @@ describe MiqAeEngine::MiqAePlaybookMethod do
         ap.run
 
         expect { aw.reload }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+
+      shared_examples_for "href_slug" do
+        it "matches" do
+          expect(playbook).to receive(:run) do |args|
+            expect(args[:extra_vars][:manageiq]['task_href_slug']).to eq(task_href_slug)
+            miq_task.id
+          end
+
+          ap = described_class.new(aem, obj, inputs)
+          ap.run
+        end
+      end
+
+      context "service_template_provision_task" do
+        let(:task_href_slug) { "#{svc_stpr.href_slug}/#{svc_stpt.href_slug}" }
+        let(:root_hash) do
+          { 'vmdb_object_type'                => 'service_template_provision_task',
+            'service_template_provision_task' => svc_stpt }
+        end
+        it_behaves_like "href_slug"
+      end
+
+      context "provision_task" do
+        let(:task_href_slug) { "#{svc_mpr.href_slug}/#{svc_mpt.href_slug}" }
+        let(:root_hash) do
+          { 'vmdb_object_type' => 'miq_provision',
+            'miq_provision'    => svc_mpt }
+        end
+        it_behaves_like "href_slug"
       end
     end
 


### PR DESCRIPTION
This allows Ansible Playbook to access the Request Task so that we
can update provisioning options from the playbook. Since a request_task doesn't have RBAC the only way to edit the Request Task is as a sub collection of the Request, which does have RBAC.