### PR TITLE
Allow for substitution of hosts 

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -8,6 +8,7 @@ module MiqAeEngine
       @workspace = obj.workspace
       @inputs    = inputs
       @aem       = aem
+      @ae_object = obj
     end
 
     def run
@@ -148,6 +149,7 @@ module MiqAeEngine
         config_info[:extra_vars] = MiqAeReference.encode(@inputs)
         config_info[:extra_vars][:manageiq] = manageiq_env
         config_info[:extra_vars][:manageiq_connection] = manageiq_connection_env
+        config_info[:hosts] = resolved_hosts
       end
     end
 
@@ -168,6 +170,12 @@ module MiqAeEngine
         end
       end
       result
+    end
+
+    def resolved_hosts
+      @ae_object.substitute_value(@aem.options[:hosts], nil, true).tap do |value|
+        raise ArgumentError, "Hosts field #{@aem.options[:hosts]} resolved to empty string" if value.blank?
+      end
     end
   end
 end


### PR DESCRIPTION
At runtime we can substitute the host where the Ansible Playbook should be run.

The use case for this is running Ansible Playbooks as part of post provisioning step

e.g If you are trying to fetch the IP address of a newly ManageIQ provisioned VM

``` ${/#miq_provision.destination.ipaddresses.first} ```

For a cloud vm you could use
``` ${/#miq_provision.destination.floating_ips.first} ```