### PR TITLE
Clean up have_attributes deprecation warnings

### DIFF
--- a/spec/models/miq_ae_domain_spec.rb
+++ b/spec/models/miq_ae_domain_spec.rb
@@ -324,7 +324,7 @@ describe MiqAeDomain do
 
       dom1.update_git_info(repo, branch_name, MiqAeGitImport::BRANCH)
       dom1.reload
-      expect(dom1.attributes).to have_attributes(commit_hash)
+      expect(dom1).to have_attributes(commit_hash)
     end
 
     it "git repo changed for non git domain" do
@@ -336,7 +336,7 @@ describe MiqAeDomain do
       dom1.update_attributes(:ref => branch_name, :git_repository => repo,
                              :ref_type => MiqAeGitImport::BRANCH, :commit_sha => commit_sha)
       expect(dom1.git_repo_changed?).to be_truthy
-      expect(dom1.latest_ref_info).to have_attributes(new_info)
+      expect(dom1.latest_ref_info).to eq(new_info)
     end
 
     it "git repo tag changed" do
@@ -344,7 +344,7 @@ describe MiqAeDomain do
       dom1.update_attributes(:ref => tag_name, :ref_type => MiqAeGitImport::TAG,
                              :git_repository => repo, :commit_sha => commit_sha)
       expect(dom1.git_repo_changed?).to be_truthy
-      expect(dom1.latest_ref_info).to have_attributes(new_info)
+      expect(dom1.latest_ref_info).to eq(new_info)
     end
 
     it "git repo tag changed with no branch or tag" do

--- a/spec/models/miq_ae_git_import_spec.rb
+++ b/spec/models/miq_ae_git_import_spec.rb
@@ -72,7 +72,7 @@ describe MiqAeGitImport do
               .and_return(miq_ae_yaml_import_gitfs)
             allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
             dom = miq_ae_git_import.import
-            expect(dom.attributes).to have_attributes(branch_hash)
+            expect(dom).to have_attributes(branch_hash)
           end
         end
 
@@ -122,7 +122,7 @@ describe MiqAeGitImport do
               .and_return(miq_ae_yaml_import_gitfs)
             allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
             dom = miq_ae_git_import.import
-            expect(dom.attributes).to have_attributes(tag_hash)
+            expect(dom).to have_attributes(tag_hash)
           end
         end
 
@@ -165,7 +165,7 @@ describe MiqAeGitImport do
             .and_return(miq_ae_yaml_import_gitfs)
           allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
           dom = miq_ae_git_import.import
-          expect(dom.attributes).to have_attributes(branch_hash)
+          expect(dom).to have_attributes(branch_hash)
           expect(repo.authentications.first.userid).to eq('fred')
           expect(repo.authentications.first.password).to eq('secret')
         end

--- a/spec/models/miq_ae_yaml_import_gitfs_spec.rb
+++ b/spec/models/miq_ae_yaml_import_gitfs_spec.rb
@@ -90,7 +90,7 @@ describe MiqAeYamlImportGitfs do
 
     it "#load_file" do
       @gitfs = MiqAeYamlImportGitfs.new(@domain, 'git_dir' => @repo_path)
-      expect(@gitfs.load_file(@domain_file)).to have_attributes(@default_hash.merge(:fname => @domain_file))
+      expect(@gitfs.load_file(@domain_file)).to eq(@default_hash.merge(:fname => @domain_file))
     end
 
     it "#load_file invalid" do

--- a/spec/service_models/miq_ae_service_vm_spec.rb
+++ b/spec/service_models/miq_ae_service_vm_spec.rb
@@ -226,7 +226,7 @@ module MiqAeServiceVmSpec
       it "without memory" do
         service_vm.create_snapshot('snap', 'crackle & pop')
 
-        expect(MiqQueue.first.args.first).to have_attributes(
+        expect(MiqQueue.first.args.first).to include(
           :task        => 'create_snapshot',
           :memory      => false,
           :name        => 'snap',
@@ -237,7 +237,7 @@ module MiqAeServiceVmSpec
       it "with memory" do
         service_vm.create_snapshot('snap', 'crackle & pop', true)
 
-        expect(MiqQueue.first.args.first).to have_attributes(
+        expect(MiqQueue.first.args.first).to include(
           :task        => 'create_snapshot',
           :memory      => true,
           :name        => 'snap',


### PR DESCRIPTION
WARNING: Use of `have_attributes` with array access (:[]) is deprecated and will be removed shortly.
If you're matching attributes in hashes, use appropriate hash matchers instead (`include`, `eq`).