### PR TITLE
Add support for accessing objects from anywhere in the workspace

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -116,6 +116,7 @@ module MiqAeEngine
       # Make sure we found what we needed before proceeding
       raise MiqAeException::ClassNotFound, "Class [#{@class_fqname}] not found in MiqAeDatastore" if @aec.nil?
 
+      @workspace.add_obj_entry(@namespace, @klass, @instance, self)
       Benchmark.realtime_block(:inherit_time) do
         # Who do we inherit from
         @inherits = BASE_OBJECT

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object_lookup.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object_lookup.rb
@@ -1,0 +1,56 @@
+module MiqAeEngine
+  module MiqAeObjectLookup
+    def initialize_obj_entries
+      @lookup_table = []
+    end
+
+    def add_obj_entry(fqns, klass, instance, object)
+      parts = fqns.split('/')
+      domain = parts.shift
+      namespace = parts.join('/')
+
+      @lookup_table << {:domain    => domain.downcase,
+                        :namespace => namespace.downcase,
+                        :klass     => klass.downcase,
+                        :instance  => instance.downcase,
+                        :object    => object}
+    end
+
+    def find_obj_entry(path)
+      query = path[0] == '/' ? parse_obj_path(path[1..-1]) : parse_obj_path(path)
+
+      entries = @lookup_table.select { |entry| entry[:klass] == query['class_name'] }
+      ientries = entries.select { |entry| instance_match?(query['instance'], entry) }
+      match = ientries.detect { |entry| fq_match?(query['domain'], query['partial_ns'], entry) }
+      match ||= ientries.detect { |entry| ns_match?(query['fqns'], entry) }
+      match[:object] if match
+    rescue MiqAeException::InvalidPathFormat => err
+      $miq_ae_logger.error(err.message)
+      nil
+    end
+
+    def ns_match?(ns, entry)
+      ns == entry[:namespace]
+    end
+
+    def fq_match?(domain, ns, entry)
+      domain == entry[:domain] && ns == entry[:namespace]
+    end
+
+    def instance_match?(instance, entry)
+      File.fnmatch(instance, entry[:instance], File::FNM_CASEFOLD)
+    end
+
+    def parse_obj_path(path)
+      parts = path.downcase.split('/')
+      raise MiqAeException::InvalidPathFormat, "#{path} is invalid. Need atleast Namespace/Class/Instance" if parts.length < 3
+      {
+        'instance'   => parts.pop,
+        'class_name' => parts.pop,
+        'fqns'       => parts.join('/'),
+        'domain'     => parts.shift,
+        'partial_ns' => parts.join('/')
+      }
+    end
+  end
+end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object_lookup.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object_lookup.rb
@@ -43,7 +43,7 @@ module MiqAeEngine
 
     def parse_obj_path(path)
       parts = path.downcase.split('/')
-      raise MiqAeException::InvalidPathFormat, "#{path} is invalid. Need atleast Namespace/Class/Instance" if parts.length < 3
+      raise MiqAeException::InvalidPathFormat, "#{path} is invalid. Need at least Namespace/Class/Instance" if parts.length < 3
       {
         'instance'   => parts.pop,
         'class_name' => parts.pop,

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object_lookup.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object_lookup.rb
@@ -21,12 +21,16 @@ module MiqAeEngine
 
       entries = @lookup_table.select { |entry| entry[:klass] == query['class_name'] }
       ientries = entries.select { |entry| instance_match?(query['instance'], entry) }
-      match = ientries.detect { |entry| fq_match?(query['domain'], query['partial_ns'], entry) }
-      match ||= ientries.detect { |entry| ns_match?(query['fqns'], entry) }
-      match[:object] if match
+      find_best_match(ientries, query)
     rescue MiqAeException::InvalidPathFormat => err
       $miq_ae_logger.error(err.message)
       nil
+    end
+
+    def find_best_match(ientries, query)
+      match = ientries.detect { |entry| fq_match?(query['domain'], query['partial_ns'], entry) }
+      match ||= ientries.detect { |entry| ns_match?(query['fqns'], entry) }
+      match[:object] if match
     end
 
     def ns_match?(ns, entry)

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object_lookup.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object_lookup.rb
@@ -1,25 +1,24 @@
 module MiqAeEngine
   module MiqAeObjectLookup
     def initialize_obj_entries
-      @lookup_table = []
+      @lookup_hash = Hash.new { |h, k| h[k] = [] }
     end
 
     def add_obj_entry(fqns, klass, instance, object)
       parts = fqns.split('/')
       domain = parts.shift
       namespace = parts.join('/')
-
-      @lookup_table << {:domain    => domain.downcase,
-                        :namespace => namespace.downcase,
-                        :klass     => klass.downcase,
-                        :instance  => instance.downcase,
-                        :object    => object}
+      key = klass.downcase
+      @lookup_hash[key] = @lookup_hash[key] << {:domain    => domain.downcase,
+                                                :namespace => namespace.downcase,
+                                                :instance  => instance.downcase,
+                                                :object    => object}
     end
 
     def find_obj_entry(path)
       query = path[0] == '/' ? parse_obj_path(path[1..-1]) : parse_obj_path(path)
 
-      entries = @lookup_table.select { |entry| entry[:klass] == query['class_name'] }
+      entries = @lookup_hash[query['class_name']]
       ientries = entries.select { |entry| instance_match?(query['instance'], entry) }
       find_best_match(ientries, query)
     rescue MiqAeException::InvalidPathFormat => err

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -7,6 +7,7 @@ module MiqAeEngine
     include MiqAeStateInfo
     include MiqAeSerializeWorkspace
     include MiqAeDeserializeWorkspace
+    include MiqAeObjectLookup
 
     attr_reader :nodes
 
@@ -22,6 +23,7 @@ module MiqAeEngine
       @state_machine_objects = []
       @ae_user = nil
       @rbac = false
+      initialize_obj_entries
     end
 
     delegate :prepend_namespace=, :to =>  :@dom_search
@@ -318,11 +320,14 @@ module MiqAeEngine
         end
       else
         obj = find_named_ancestor(path)
+        # Find object in whole workspace
+        obj = find_obj_entry(path) unless obj
       end
       obj
     end
 
     def find_named_ancestor(path)
+      path = path[1..-1] if path[0] == '/'
       plist = path.split("/")
       raise MiqAeException::InvalidPathFormat, "Unsupported Path [#{path}]" if plist[0].blank?
       klass = plist.pop

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -320,8 +320,8 @@ module MiqAeEngine
         end
       else
         obj = find_named_ancestor(path)
-        # Find object in whole workspace
-        obj = find_obj_entry(path) unless obj
+        # if not found try finding object in whole workspace
+        obj ||= find_obj_entry(path)
       end
       obj
     end

--- a/spec/miq_ae_assertion_spec.rb
+++ b/spec/miq_ae_assertion_spec.rb
@@ -63,12 +63,12 @@ describe MiqAeEngine::MiqAeObject do
     context "missing object" do
       let(:assert_value) { "${/missing_object#var1}" }
 
-      it "raises InvalidPathFormat" do
+      it "raises ObjectNotFound" do
         ae_model
 
         expect do
-          MiqAeEngine.instantiate(child_url, user)
-        end.to raise_exception(MiqAeException::InvalidPathFormat)
+          MiqAeEngine.instantiate('/A/C/BARNEY/FRED', user)
+        end.to raise_exception(MiqAeException::ObjectNotFound)
       end
     end
 

--- a/spec/miq_ae_assertion_spec.rb
+++ b/spec/miq_ae_assertion_spec.rb
@@ -67,7 +67,7 @@ describe MiqAeEngine::MiqAeObject do
         ae_model
 
         expect do
-          MiqAeEngine.instantiate('/A/C/BARNEY/FRED', user)
+          MiqAeEngine.instantiate(child_url, user)
         end.to raise_exception(MiqAeException::ObjectNotFound)
       end
     end

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -703,7 +703,6 @@ describe MiqAeEngine do
     b4 = a4.children[0]
     expect(b4.attributes["attr1"]).to eq("a4")
 
-    expect { MiqAeEngine.instantiate("/EVM/A/a5", @user) }.to raise_error(MiqAeException::InvalidPathFormat)
     expect { MiqAeEngine.instantiate("/EVM/A/a6", @user) }.to raise_error(MiqAeException::ObjectNotFound)
     expect { MiqAeEngine.instantiate("/EVM/A/a7", @user) }.to raise_error(MiqAeException::ObjectNotFound)
 

--- a/spec/miq_ae_object_lookup_spec.rb
+++ b/spec/miq_ae_object_lookup_spec.rb
@@ -1,0 +1,65 @@
+describe "MiqAeObjectLookup" do
+  let(:test_class) do
+    Class.new do
+      include MiqAeEngine::MiqAeObjectLookup
+      def initialize
+        initialize_obj_entries
+      end
+    end
+  end
+
+  let(:test_instance) { test_class.new }
+  let(:obj1) { double("OBJ", :fqns => 'Dom1/A/B', :klass => 'CLASS1', :instance => 'INSTANCE1') }
+  let(:obj2) { double("OBJ", :fqns => 'Dom1/C/D', :klass => 'CLASS1', :instance => 'INSTANCE1') }
+  let(:obj3) { double("OBJ", :fqns => 'Dom1/E/F', :klass => 'CLASS2', :instance => 'INSTANCE2') }
+
+  describe "#find_obj_entry" do
+    before do
+      test_instance.add_obj_entry(obj1.fqns, obj1.klass, obj1.instance, obj1)
+      test_instance.add_obj_entry(obj2.fqns, obj2.klass, obj2.instance, obj2)
+      test_instance.add_obj_entry(obj3.fqns, obj3.klass, obj3.instance, obj3)
+    end
+
+    context "domain qualified" do
+      it "return a valid object with leading slash" do
+        expect(test_instance.find_obj_entry('/Dom1/A/B/class1/instance1')).to eq(obj1)
+      end
+
+      it "return a valid object without leading slash" do
+        expect(test_instance.find_obj_entry('Dom1/A/B/class1/instance1')).to eq(obj1)
+      end
+    end
+
+    context "namespace qualified" do
+      it "return a valid object with leading slash" do
+        expect(test_instance.find_obj_entry('/C/d/ClASs1/instance1')).to eq(obj2)
+      end
+
+      it "return a valid object without leading slash" do
+        expect(test_instance.find_obj_entry('C/d/class1/instance1')).to eq(obj2)
+      end
+    end
+
+    context "glob in instance name" do
+      it "return a valid object with leading slash" do
+        expect(test_instance.find_obj_entry('/C/d/ClASs1/i?stance1')).to eq(obj2)
+      end
+
+      it "return a valid object with *" do
+        expect(test_instance.find_obj_entry('/C/d/ClASs1/*')).to eq(obj2)
+      end
+    end
+
+    context "object not found" do
+      it "return a nil" do
+        expect(test_instance.find_obj_entry('/Dom5/A/B/class1/instance1')).to be_nil
+      end
+    end
+
+    context "invalid path" do
+      it "returns nil" do
+        expect(test_instance.find_obj_entry('A/B')).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1350560

The Automation Workspace consists of resolved objects, which are instantiated from the database and optionally embellished by methods. These resolved objects contain the location from where they were instantiated which includes the domain, namespace(s), class and instance names.

e.g.
/ManageIQ/System/Request/MyInstance

Since each resolved object has this path, we can enhance our search to be based on the fully qualified path of the object. The current object search is limited to objects in the current leg of the resolution and doesn't allow access to earlier created objects in different parts of the resolution.

The enhanced search would help in 
 * Not using collect to migrate attributes between objects, since any object in the workspace is now accessible.
 * Substitution using objects from any where in the workspace

Additional Features
 * Object search can optionally include the domain name (**not recommended**)
 * Allows glob support for instance names only

Substitution examples
 * ${/System/Request/MyInstance#attr1}                     Specifies the namespace, class and instance  
 * ${/System/Request/*#attr1}                                       Uses any instance
 * ${/ManageIQ/System/Request/MyInstance#attr1}   uses the domain name - **not recommended**

Since a namespaces can contain other namespaces, its important to always specify the instance name. If you are sure that there is only one instance you can drop the instance name and use * instead.

Previously substitution limits the object search path to current leg of resolution

![screen shot 2017-11-08 at 3 08 41 pm](https://user-images.githubusercontent.com/6452699/32571984-3e229d94-c497-11e7-841d-1d9641764f87.png)

Enhanced search path would allow us to search for objects anywhere in the workspace

![screen shot 2017-11-08 at 3 10 36 pm](https://user-images.githubusercontent.com/6452699/32572013-52b495a0-c497-11e7-98c0-8a50900454e2.png)
