### PR TITLE
Allow automate scripts to use gems from GEM_PATH and BUNDLE_PATH

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -125,7 +125,7 @@ module MiqAeEngine
 
     def self.run_ruby_method(code)
       ActiveRecord::Base.connection_pool.release_connection
-      Bundler.with_clean_env do
+      with_automation_env do
         ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
           run_method(Gem.ruby) do |stdin|
             stdin.puts(code)
@@ -134,6 +134,22 @@ module MiqAeEngine
       end
     end
     private_class_method :run_ruby_method
+
+    def self.with_automation_env
+      bundle_path = Bundler.bundle_path.to_s
+      Bundler.with_clean_env do
+        begin
+          backup = ENV.to_hash
+          gem_paths = (backup["GEM_PATH"].split(File::PATH_SEPARATOR) << bundle_path).uniq
+          ENV.replace(backup.merge("GEM_PATH" => gem_paths.join(File::PATH_SEPARATOR)))
+
+          yield
+        ensure
+          ENV.replace(backup)
+        end
+      end
+    end
+    private_class_method :with_automation_env
 
     def self.process_ruby_method_results(rc, msg)
       case rc


### PR DESCRIPTION
With bundler v1.16.0 the `BUNDLE_PATH` is not always on the `GEM_PATH`.  Ensure that gems from the `BUNDLE_PATH` are available to automate scripts by modifying the `ENV` before shelling out.