### PR TITLE
Changes service name update to raise errors

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -55,8 +55,7 @@ module MiqAeMethodService
 
     def name=(new_name)
       ar_method do
-        @object.name = new_name
-        @object.save
+        @object.update!(:name => new_name)
       end
     end
 

--- a/spec/service_models/miq_ae_service_service_spec.rb
+++ b/spec/service_models/miq_ae_service_service_spec.rb
@@ -33,6 +33,10 @@ module MiqAeServiceServiceSpec
       expect(@service.name).to eq('new_test_service')
     end
 
+    it "#raises error with service name that's nil" do
+      expect { @ae_method.update_attributes!(:name => nil) }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
     it "#set the service description" do
       expect(@service.description).to eq('test_description')
       method = "$evm.root['#{@ae_result_key}'] = $evm.root['service'].description = 'new_test_description' "


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1505033. Service names, if nil, should raise error so this changes the name update method to be the update bang so the validation will be actually raised.