### PR TITLE
Allow rest-client to work again in automate methods

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -136,7 +136,7 @@ module MiqAeEngine
     private_class_method :run_ruby_method
 
     def self.with_automation_env
-      gem_paths = (Gem.path + [Bundler.bundle_path.to_s]).uniq
+      gem_paths = ([Rails.root.join("vendor", "miq_gems").to_s] + Gem.path + [Bundler.bundle_path.to_s]).uniq
       Bundler.with_clean_env do
         begin
           backup = ENV.to_hash


### PR DESCRIPTION
To be paired with https://github.com/ManageIQ/manageiq/pull/16581

Basically includes the `manageiq/vendor/miq_gems` into the `ENV["GEM_PATH"]` when running automate methods, which allows the `rest-client` gem (or anything that relies on `mime-types`) to function properly using our `mime-types` patch.


Links
-----
* https://bugzilla.redhat.com/show_bug.cgi?id=1518865
* https://github.com/ManageIQ/manageiq/pull/16581
* PR introducing `mime-types-redirector`: https://github.com/ManageIQ/manageiq/pull/14525