### PR TITLE
Fail request when vm migration fails

### DIFF
--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_custom_attribute_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_custom_attribute_mixin.rb
@@ -2,8 +2,11 @@ module MiqAeServiceCustomAttributeMixin
   extend ActiveSupport::Concern
 
   included do
-    expose :custom_keys, :method => :miq_custom_keys
-    expose :custom_get,  :method => :miq_custom_get
-    expose :custom_set,  :method => :miq_custom_set, :override_return => true
+    expose :migration_status,       :method => :migration_status
+    expose :set_migration_status,   :method => :set_migration_status
+    expose :reset_migration_status, :method => :reset_migration_status
+    expose :custom_keys,            :method => :miq_custom_keys
+    expose :custom_get,             :method => :miq_custom_get
+    expose :custom_set,             :method => :miq_custom_set, :override_return => true
   end
 end


### PR DESCRIPTION
When vm migration fails it is not reflected in migration request status. We use custom attribute to track migration state when migration is done (error or ok) we need to remove the attribute.

BugUrl:
https://bugzilla.redhat.com/1478518