### PR TITLE
Log encryption failures

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -561,8 +561,8 @@ module MiqAeEngine
     def self.decrypt_password(value)
       MiqAePassword.new(MiqAePassword.decrypt(value))
     rescue MiqPassword::MiqPasswordError => err
-      $miq_ae_logger.error("Error decrypting password #{err.message}. Is this password imported from a different environment?")
-      raise err
+      $miq_ae_logger.error("Error decrypting password #{err.message}. Possible cause: Password value was encrypted with a different encryption key")
+      raise
     end
     private_class_method :decrypt_password
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -545,7 +545,7 @@ module MiqAeEngine
       return value.to_i                                      if datatype == 'integer' || datatype == 'Fixnum'
       return value.to_f                                      if datatype == 'float' || datatype == 'Float'
       return value.gsub(/[\[\]]/, '').strip.split(/\s*,\s*/)  if datatype == 'array' && value.class == String
-      return MiqAePassword.new(MiqAePassword.decrypt(value)) if datatype == 'password'
+      return decrypt_password(value) if datatype == 'password'
 
       if datatype &&
          (service_model = "MiqAeMethodService::MiqAeService#{SM_LOOKUP[datatype]}".safe_constantize)
@@ -557,6 +557,14 @@ module MiqAeEngine
       # default datatype => 'string'
       value
     end
+
+    def self.decrypt_password(value)
+      MiqAePassword.new(MiqAePassword.decrypt(value))
+    rescue MiqPassword::MiqPasswordError => err
+      $miq_ae_logger.error("Error decrypting password #{err.message}. Is this password imported from a different environment?")
+      raise err
+    end
+    private_class_method :decrypt_password
 
     def process_assertion(f, message, args)
       Benchmark.current_realtime[:assertion_count] += 1

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -91,6 +91,7 @@ module MiqAeMethodService
       return nil if obj.nil?
       MiqAeServiceObject.new(obj, self)
     rescue => e
+      $miq_ae_logger.error("instantiate failed : #{e.message}")
       return nil
     end
 

--- a/spec/miq_ae_object_spec.rb
+++ b/spec/miq_ae_object_spec.rb
@@ -300,3 +300,20 @@ describe MiqAeEngine::MiqAeObject do
     end
   end
 end
+
+describe MiqAeEngine::MiqAeObject do
+  context "password" do
+    let(:p45) { "Pneumonoultramicroscopicsilicovolcanoconiosis" }
+    let(:p45_encrypted) { MiqAePassword.encrypt(p45) }
+
+    it "can decrypt passwords" do
+      expect(described_class.convert_value_based_on_datatype(p45_encrypted, 'password').encStr).to eq(p45_encrypted)
+    end
+
+    it "raises exception for bogus passwords" do
+      expect do
+        described_class.convert_value_based_on_datatype('gobbledygook', 'password')
+      end.to raise_exception(MiqPassword::MiqPasswordError)
+    end
+  end
+end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1518058

Customers might export/import models between different environments.
There typically is a different key for each environment. If the export
deck has encrypted fields, they are imported into the new environment
unchanged. This field cannot be decrypted at runtime in the Automate
engine, because of key mismatch.
During $evm.instantiate we were not logging any error messages and
customer has a tough time debugging the issue.

This PR logs the encryption error.