### PR TITLE
Expose generic objects to the services service model.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -24,6 +24,7 @@ module MiqAeMethodService
     expose :indirect_service_children, :association => true
     expose :parent_service,            :association => true
     expose :tenant,                    :association => true
+    expose :generic_objects,           :association => true
 
     CREATE_ATTRIBUTES = [:name, :description, :service_template]
 


### PR DESCRIPTION
Expose generic objects to the services service model.

https://bugzilla.redhat.com/show_bug.cgi?id=1522988

@miq-bot add_label bug, gaprindashvili/yes