### PR TITLE
Add remove_from_vmdb method to generic object for Service models.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
@@ -1,5 +1,7 @@
 module MiqAeMethodService
   class MiqAeServiceGenericObject < MiqAeServiceModelBase
+    require_relative "mixins/miq_ae_service_remove_from_vmdb_mixin"
+    include MiqAeServiceRemoveFromVmdb
     require 'drb'
 
     def add_to_service(service)


### PR DESCRIPTION
Add remove_from_vmdb method to generic object for Service models.

https://bugzilla.redhat.com/show_bug.cgi?id=1523690

@miq-bot add_label bug, gaprindashvili/yes