### PR TITLE
Add and remove dependent services correctly in hierarchical structures

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -77,8 +77,8 @@ module MiqAeMethodService
           raise ArgumentError, "service must be a MiqAeServiceService" unless service.kind_of?(
             MiqAeMethodService::MiqAeServiceService)
           @object.add_to_service(Service.find(service.id))
-        else
-          @object.remove_from_service(@object.parent) if @object.parent.present?
+        elsif @object.parent.present?
+          @object.remove_from_service(@object.parent)
         end
         @object.save
       end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -76,9 +76,9 @@ module MiqAeMethodService
         if service
           raise ArgumentError, "service must be a MiqAeServiceService" unless service.kind_of?(
             MiqAeMethodService::MiqAeServiceService)
-          @object.service = Service.find(service.id)
+          @object.add_to_service(Service.find(service.id))
         else
-          @object.service = nil
+          @object.remove_from_service(@object.parent) if @object.parent.present?
         end
         @object.save
       end

--- a/spec/service_models/miq_ae_service_service_spec.rb
+++ b/spec/service_models/miq_ae_service_service_spec.rb
@@ -72,6 +72,16 @@ module MiqAeServiceServiceSpec
 
         @parent.reload
         expect(@parent.direct_service_children.collect(&:id)).to eq([@service.id])
+        expect(@parent.service_resources.collect(&:resource_id)).to eq([@service.id])
+        expect(@parent.service_resources.first).to be_a_kind_of(ServiceResource)
+      end
+
+      it "raises error if child service is already owned by different parent" do
+        parent1 = FactoryGirl.create(:service)
+        service.add_to_service(parent1)
+        parent_service = MiqAeMethodService::MiqAeServiceService.find(@parent.id)
+
+        expect { service_service.parent_service = parent_service }.to raise_error(MiqException::Error)
       end
 
       it "clears the parent service" do
@@ -81,6 +91,7 @@ module MiqAeServiceServiceSpec
 
         @parent.reload
         expect(@parent.direct_service_children).to eq([])
+        expect(@parent.service_resources).to eq([])
       end
 
       it "validates the parent service" do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1515741

Changes how we add and remove dependent services in hierarchical structures. Previously dependent services weren't being retired because we weren't setting the hierarchy correctly.