### PR TITLE
Support for internal methods

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_internal_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_internal_method.rb
@@ -1,0 +1,100 @@
+module MiqAeEngine
+  class MiqAeInternalMethod
+    DEFAULT_ATTR_NAME = 'result'.freeze
+    DEFAULT_RETRY_INTERVAL = 1.minute
+
+    def initialize(aem, obj, inputs)
+      @workspace = obj.workspace
+      @inputs    = inputs
+      @aem       = aem
+      @ae_object = obj
+    end
+
+    def run
+      validate_args
+      obj = resolved_object || @aem.options[:class].constantize
+      run_method(obj, @aem.options[:method].to_sym)
+    end
+
+    private
+
+    def resolved_object
+      if @aem.options[:object]
+        @ae_object.substitute_value(@aem.options[:object], nil, true).tap do |value|
+          raise ArgumentError, "Object #{@aem.options[:object]} resolved to empty string" if value.blank?
+        end
+      end
+    end
+
+    def run_method(obj, method)
+      if obj.respond_to?(method)
+        process_result(@inputs.blank? ? obj.send(method) : obj.send(method, @inputs))
+        @workspace.root['ae_result'] = 'ok' if in_state?
+      else
+        raise MiqAeException::MethodNotFound, "#{method} not defined for object #{obj}"
+      end
+    rescue MiqAeException::MiqAeRetryException
+      set_retry if @aem.options[:output_parameters].fetch(:retry_exception, false) && in_state?
+    rescue StandardError => err
+      error_handler(err)
+    end
+
+    def error_handler(err)
+      $miq_ae_logger.error("Internal method failed. error  #{err.message}")
+      if in_state?
+        @workspace.root['ae_result'] = 'error'
+      else
+        raise err
+      end
+    end
+
+    def validate_args
+      if @aem.options[:object].blank? && @aem.options[:class].blank?
+        raise MiqAeException::MethodParmMissing, "need an object or a class to execute the internal method"
+      end
+
+      raise MiqAeException::MethodParmMissing, "method name not provided" if @aem.options[:method].blank?
+    end
+
+    def process_result(result)
+      output_params = @aem.options[:output_parameters]
+      if output_params
+        if output_params[:result_object] == 'state_var'
+          set_state_var(result, output_params[:result_attr])
+        else
+          set_object_attribute(result, output_params[:result_attr])
+        end
+      end
+    end
+
+    def set_state_var(result, key)
+      key, value = MiqAeEngine.create_automation_attribute(key, result)
+      @workspace.set_state_var(key || DEFAULT_ATTR_NAME, value)
+    end
+
+    def set_object_attribute(result, key)
+      value = if result.kind_of?(ActiveRecord::Base)
+                MiqAeMethodService::MiqAeServiceModelBase.wrap_results(result)
+              else
+                result
+              end
+      target_object[key || DEFAULT_ATTR_NAME] = value
+    end
+
+    def target_object
+      obj_name = @aem.options[:output_parameters][:result_object] || '.'
+      @workspace.get_obj_from_path(obj_name).tap do |obj|
+        raise MiqAeException::ObjectNotFound, "Internal method results, object #{obj_name} missing" unless obj
+      end
+    end
+
+    def set_retry
+      @workspace.root['ae_result'] = 'retry'
+      @workspace.root['ae_retry_interval'] = @aem.options[:output_parameters].fetch(:retry_interval, DEFAULT_RETRY_INTERVAL)
+    end
+
+    def in_state?
+      @workspace.root['ae_state_started'].present?
+    end
+  end
+end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -20,6 +20,10 @@ module MiqAeEngine
       MiqAeEngine::MiqAePlaybookMethod.new(aem, obj, inputs).run
     end
 
+    def self.invoke_internal(aem, obj, inputs)
+      MiqAeEngine::MiqAeInternalMethod.new(aem, obj, inputs).run
+    end
+
     def self.invoke_uri(aem, obj, _inputs)
       scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(aem.data)
       raise  MiqAeException::MethodNotFound, "Specified URI [#{aem.data}] in Method [#{aem.name}] has unsupported scheme of #{scheme}; supported scheme is file" unless scheme.downcase == "file"
@@ -69,7 +73,7 @@ module MiqAeEngine
 
       if obj.workspace.readonly?
         $miq_ae_logger.info("Workspace Instantiation is READONLY -- skipping method [#{aem.fqname}] with inputs [#{inputs.inspect}]")
-      elsif %w(inline builtin uri expression playbook).include?(aem.location.downcase.strip)
+      elsif ::MiqAeMethod::AVAILABLE_LOCATIONS.include?(aem.location.downcase.strip)
         $miq_ae_logger.info("Invoking [#{aem.location}] method [#{aem.fqname}] with inputs [#{inputs.inspect}]")
         return MiqAeEngine::MiqAeMethod.send("invoke_#{aem.location.downcase.strip}", aem, obj, inputs)
       end

--- a/lib/miq_automation_engine/miq_ae_exception.rb
+++ b/lib/miq_automation_engine/miq_ae_exception.rb
@@ -47,6 +47,7 @@ module MiqAeException
   class MethodExpressionResultTypeInvalid < MiqAeEngineError; end
   class MethodParameterNotFound < MiqAeEngineError; end
   class MethodNotDefined < MiqAeEngineError; end
+  class MiqAeRetryException < MiqAeEngineError; end
 end
 
 module MiqException

--- a/spec/miq_ae_internal_method_spec.rb
+++ b/spec/miq_ae_internal_method_spec.rb
@@ -1,0 +1,250 @@
+describe MiqAeEngine::MiqAeInternalMethod do
+  describe "run" do
+    let(:root_hash) { { 'name' => 'Flintstone' } }
+    let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
+    let(:persist_hash) { {} }
+    let(:method_name) { "Freddy_Kreuger" }
+    let(:description) { "Yaba Daba Doo" }
+    let(:object_str) { "${/#miq_provision}" }
+
+    let(:workspace) do
+      double("MiqAeEngine::MiqAeWorkspaceRuntime", :root               => root_object,
+                                                   :persist_state_hash => persist_hash,
+                                                   :ae_user            => user)
+    end
+
+    let(:user) do
+      FactoryGirl.create(:user_with_group, :userid   => "admin",
+                                           :settings => {:display => { :timezone => "UTC"}})
+    end
+
+    let(:result_object) { "." }
+    let(:result_attribute) { "BammBammRubble" }
+
+    let(:vm) { FactoryGirl.create(:vm_vmware, :name => "VM1") }
+
+    let(:output) do
+      {
+        :result_attr   => result_attribute,
+        :result_object => result_object,
+      }
+    end
+
+    let(:aem)    { double("AEM", :options => options, :name => method_name) }
+    let(:inputs) { { 'name' => 'Fred' } }
+
+    let(:mpr) { FactoryGirl.create(:miq_provision_request, :requester => user, :description => description) }
+
+    let(:svc_mpr) { MiqAeMethodService::MiqAeServiceMiqProvisionRequest.find(mpr.id) }
+
+    let(:test_obj) { Spec::Support::MiqAeMockObject.new(:workspace => workspace) }
+
+    let(:options) do
+      {
+        :output_parameters => output,
+        :method            => object_method_name,
+        :object            => object_str
+      }
+    end
+
+    before do
+      allow(workspace).to receive(:get_obj_from_path).and_return(test_obj)
+    end
+
+    context "instance method" do
+      before do
+        allow(test_obj).to receive(:substitute_value).with(object_str, nil, true).and_return(svc_mpr)
+      end
+      let(:root_hash) { { 'name' => 'Flintstone', 'miq_provision' => svc_mpr} }
+      let(:object_method_name) { "description" }
+
+      context "method defined" do
+        it "success" do
+          described_class.new(aem, test_obj, {}).run
+          expect(test_obj[result_attribute]).to eq(description)
+        end
+      end
+
+      context "method not defined" do
+        let(:object_method_name) { "nada" }
+        it "raises exception" do
+          expect { described_class.new(aem, test_obj, {}).run }.to raise_exception(MiqAeException::MethodNotFound)
+        end
+      end
+
+      context "result attribute not defined" do
+        let(:result_attribute) { nil }
+
+        it "uses default attribute name" do
+          described_class.new(aem, test_obj, {}).run
+          expect(test_obj['result']).to eq(description)
+        end
+      end
+
+      context "invalid args, no object or class" do
+        let(:options) { {} }
+        it "raises exception" do
+          expect { described_class.new(aem, test_obj, {}).run }.to raise_exception(MiqAeException::MethodParmMissing)
+        end
+      end
+
+      context "invalid args, no method name specified" do
+        let(:object_method_name) { "" }
+        it "raises exception" do
+          expect { described_class.new(aem, test_obj, {}).run }.to raise_exception(MiqAeException::MethodParmMissing)
+        end
+      end
+
+      context "target object missing" do
+        before do
+          allow(workspace).to receive(:get_obj_from_path).and_return(nil)
+        end
+
+        it "raises exception" do
+          expect { described_class.new(aem, test_obj, {}).run }.to raise_exception(MiqAeException::ObjectNotFound)
+        end
+      end
+
+      context "substitution returns an empty string" do
+        before do
+          allow(test_obj).to receive(:substitute_value).with(object_str, nil, true).and_return(nil)
+        end
+
+        it "raises exception" do
+          expect { described_class.new(aem, test_obj, inputs).run }.to raise_exception(ArgumentError)
+        end
+      end
+
+      context "method runtime failure" do
+        before do
+          allow(svc_mpr).to receive(:bail).and_raise(StandardError)
+        end
+        let(:object_method_name) { "bail" }
+
+        it "raises exception" do
+          expect { described_class.new(aem, test_obj, {}).run }.to raise_exception(StandardError)
+        end
+      end
+    end
+
+    context "class method" do
+      let(:options) do
+        {
+          :output_parameters => output,
+          :method            => "name",
+          :class             => svc_mpr.class.name
+        }
+      end
+
+      it "runs successfully" do
+        described_class.new(aem, test_obj, {}).run
+        expect(test_obj[result_attribute]).to eq(svc_mpr.class.name)
+      end
+    end
+
+    context "state machine" do
+      before do
+        allow(svc_mpr).to receive(:bail).and_raise(MiqAeException::MiqAeRetryException)
+        allow(test_obj).to receive(:substitute_value).with(object_str, nil, true).and_return(svc_mpr)
+      end
+
+      let(:object_method_name) { "bail" }
+      let(:root_hash) { { 'ae_state_started' => '1' } }
+      let(:output) { { :retry_exception => true } }
+      let(:options) do
+        {
+          :output_parameters => output,
+          :method            => object_method_name,
+          :object            => object_str
+        }
+      end
+
+      context "default retry interval" do
+        it "default retry interval" do
+          described_class.new(aem, test_obj, {}).run
+
+          expect(root_object['ae_result']).to eq('retry')
+          expect(root_object['ae_retry_interval']).to eq(1.minute)
+        end
+      end
+
+      context "set retry interval" do
+        let(:output) { { :retry_exception => true, :retry_interval => 10.minutes} }
+        it "default retry interval" do
+          described_class.new(aem, test_obj, {}).run
+
+          expect(root_object['ae_result']).to eq('retry')
+          expect(root_object['ae_retry_interval']).to eq(10.minutes)
+        end
+      end
+
+      context "trap any error" do
+        before do
+          allow(svc_mpr).to receive(:bail).and_raise(StandardError)
+        end
+
+        it "set ae_result to error" do
+          described_class.new(aem, test_obj, {}).run
+          expect(root_object['ae_result']).to eq('error')
+        end
+      end
+    end
+
+    context "state var" do
+      let(:result_object) { "state_var" }
+      let(:options) do
+        {
+          :output_parameters => output,
+          :method            => "name",
+          :class             => svc_mpr.class.name
+        }
+      end
+
+      it "sets the state var" do
+        expect(workspace).to receive(:set_state_var).with(result_attribute, svc_mpr.class.name)
+        described_class.new(aem, test_obj, {}).run
+      end
+    end
+
+    context "method called with correct parameters" do
+      before do
+        allow(test_obj).to receive(:substitute_value).with(object_str, nil, true).and_return(svc_mpr)
+      end
+      let(:object_method_name) { "ka_boom" }
+
+      it "validate method params" do
+        expect(svc_mpr).to receive(:ka_boom).with(inputs).and_return(true)
+
+        described_class.new(aem, test_obj, inputs).run
+      end
+    end
+
+    context "vmdb object" do
+      before do
+        allow(test_obj).to receive(:substitute_value).with(object_str, nil, true).and_return(svc_mpr)
+        allow(svc_mpr).to receive(:get_me_a_vm).and_return(vm)
+      end
+
+      let(:object_method_name) { "get_me_a_vm" }
+
+      context "result in object" do
+        it "returns a service vm object" do
+          described_class.new(aem, test_obj, {}).run
+
+          expect(test_obj[result_attribute].id).to eq(vm.id)
+          expect(test_obj[result_attribute].class).to eq(MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm)
+        end
+      end
+
+      context "result in state var" do
+        let(:result_object) { "state_var" }
+        let(:result_attr) { nil }
+
+        it "returns a service vm object" do
+          expect(workspace).to receive(:set_state_var).with("VmOrTemplate::#{result_attribute}", vm.id)
+          described_class.new(aem, test_obj, {}).run
+        end
+      end
+    end
+  end
+end

--- a/spec/miq_ae_internal_method_spec.rb
+++ b/spec/miq_ae_internal_method_spec.rb
@@ -43,7 +43,7 @@ describe MiqAeEngine::MiqAeInternalMethod do
       {
         :output_parameters => output,
         :method            => object_method_name,
-        :object            => object_str
+        :target            => object_str
       }
     end
 
@@ -132,7 +132,7 @@ describe MiqAeEngine::MiqAeInternalMethod do
         {
           :output_parameters => output,
           :method            => "name",
-          :class             => svc_mpr.class.name
+          :target_class      => svc_mpr.class.name
         }
       end
 
@@ -155,7 +155,7 @@ describe MiqAeEngine::MiqAeInternalMethod do
         {
           :output_parameters => output,
           :method            => object_method_name,
-          :object            => object_str
+          :target            => object_str
         }
       end
 
@@ -196,7 +196,7 @@ describe MiqAeEngine::MiqAeInternalMethod do
         {
           :output_parameters => output,
           :method            => "name",
-          :class             => svc_mpr.class.name
+          :target_class      => svc_mpr.class.name
         }
       end
 

--- a/spec/miq_ae_internal_method_spec.rb
+++ b/spec/miq_ae_internal_method_spec.rb
@@ -18,15 +18,15 @@ describe MiqAeEngine::MiqAeInternalMethod do
                                            :settings => {:display => { :timezone => "UTC"}})
     end
 
-    let(:result_object) { "." }
+    let(:result_obj) { "." }
     let(:result_attribute) { "BammBammRubble" }
 
     let(:vm) { FactoryGirl.create(:vm_vmware, :name => "VM1") }
 
     let(:output) do
       {
-        :result_attr   => result_attribute,
-        :result_object => result_object,
+        :result_attr => result_attribute,
+        :result_obj  => result_obj,
       }
     end
 
@@ -191,7 +191,7 @@ describe MiqAeEngine::MiqAeInternalMethod do
     end
 
     context "state var" do
-      let(:result_object) { "state_var" }
+      let(:result_obj) { "state_var" }
       let(:options) do
         {
           :output_parameters => output,
@@ -237,7 +237,7 @@ describe MiqAeEngine::MiqAeInternalMethod do
       end
 
       context "result in state var" do
-        let(:result_object) { "state_var" }
+        let(:result_obj) { "state_var" }
         let(:result_attr) { nil }
 
         it "returns a service vm object" do

--- a/spec/support/miq_ae_mock_object.rb
+++ b/spec/support/miq_ae_mock_object.rb
@@ -6,9 +6,11 @@ module Spec
       attr_accessor :namespace
       attr_accessor :klass
       attr_accessor :instance
+      attr_accessor :workspace
 
       def initialize(hash = {})
         @object_hash = HashWithIndifferentAccess.new(hash)
+        @workspace   = @object_hash[:workspace]
         @children = []
       end
 


### PR DESCRIPTION
Fixes #135

This enhancement allows you to call an internal method defined
in our app/models so we dont have to always run a method via DRb.
The default method implementation can be in app/models and if the
customer would like to overwrite the method they would add their
ruby method. The overhead for a customer script would be going
thru DRb.

The UI for an Internal Method would allow the user to configure the following options


 * target            :  The Service model object on which the method should be executed (allows for substitution) e.g. {/#miq_provision}

  * method         :  The name of the method
  * target_class  :  Service model class name, doesn’t allow for substitution (only needed if object is not specified)

  * output parameters : (optional)
      * result_obj    : The output of the method can be stored in an object in the workspace 
                valid values are
                 - **/** for the root object
                 - **.** for the current object
                 - **state_var** if the result should be stored as a state variable to persist between invocations.
      * result_attr         : the attribute name to store the result
      * retry_exception : true|false
      * retry_interval   : time interval in seconds

This is the existing interface for methods
Input_parameters
      User defined parameters are collected into a hash and passed into the method.
       Parameters can be substituted

Depends on ManageIQ PR https://github.com/ManageIQ/manageiq/pull/16715
  
  