### PR TITLE
Fix Automate State Machine ae_max_retries root object value.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_info.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_info.rb
@@ -1,6 +1,6 @@
 module MiqAeEngine
   module MiqAeStateInfo
-    STATE_SALIENT_ATTRIBUTES = %w(ae_state ae_state_retries ae_state_started)
+    STATE_SALIENT_ATTRIBUTES = %w(ae_state ae_state_retries ae_state_started ae_state_max_retries).freeze
 
     def save_current_state_info(key)
       return unless root && root['ae_state']

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
@@ -11,7 +11,7 @@ module MiqAeEngine
     def initialize_state_maxima_metadata(field)
       @workspace.root['ae_state_started'] = Time.zone.now.utc.to_s  if @workspace.root['ae_state_started'].blank?
       @workspace.root['ae_state_retries'] = 0                  if @workspace.root['ae_state_retries'].blank?
-      @workspace.root['ae_state_max_retries'] = field['max_retries'].to_i if @workspace.root['ae_state_max_retries'].to_i.zero?
+      @workspace.root['ae_state_max_retries'] = field['max_retries'].to_i
     end
 
     def reset_state_maxima_metadata

--- a/spec/engine/miq_ae_state_machine_multi_spec.rb
+++ b/spec/engine/miq_ae_state_machine_multi_spec.rb
@@ -11,7 +11,7 @@ describe "MultipleStateMachineSteps" do
     @common_state_method = 'common_state_method'
     @domain              = 'SPEC_DOMAIN'
     @namespace           = 'NS1'
-    @max_retries         = 3
+    @max_retries         = 2
     @state_class1        = 'SM1'
     @state_class2        = 'SM2'
     @state_class3        = 'SM3'
@@ -103,6 +103,8 @@ describe "MultipleStateMachineSteps" do
       steps_executed = $evm.root[step_name].to_a
       steps_executed << $evm.root['ae_state']
       $evm.root[step_name] = steps_executed
+      max_retries = $evm.root['ae_state'].split('_').last.to_i
+      $evm.root['ae_result'] = 'error' unless $evm.root['ae_state_max_retries'] == max_retries
       $evm.root['ae_result'] = inputs['ae_result'] if %w(retry error).exclude?($evm.root['ae_result'])
       $evm.root['ae_result'] = inputs['ae_result'] if inputs['ae_result'] == 'continue'
       $evm.root['ae_next_state']  = inputs['ae_next_state'] unless inputs['ae_next_state'].blank?
@@ -154,11 +156,11 @@ describe "MultipleStateMachineSteps" do
     all_steps = {'on_entry' => "common_state_method",
                  'on_exit'  => "common_state_method",
                  'on_error' => "common_state_method"}
-    ae_fields = {"#{stem}_1" => {:aetype => 'state', :datatype => 'string', :priority => 1},
+    ae_fields = {"#{stem}_1" => {:aetype => 'state', :datatype => 'string', :priority => 1, :max_retries => 1},
                  "#{stem}_2" => {:aetype => 'state', :datatype => 'string', :priority => 2,
                                  :max_retries => @max_retries, :message  => 'create'},
-                 "#{stem}_3" => {:aetype => 'state', :datatype => 'string', :priority => 3},
-                 "#{stem}_4" => {:aetype => 'state', :datatype => 'string', :priority => 4}}
+                 "#{stem}_3" => {:aetype => 'state', :datatype => 'string', :priority => 3, :max_retries => 3},
+                 "#{stem}_4" => {:aetype => 'state', :datatype => 'string', :priority => 4, :max_retries => 4}}
     state1_value = "/#{@domain}/#{@namespace}/#{@method_class}/#{@instance1}"
     state2_value = "/#{@domain}/#{@namespace}/#{@method_class}/#{@instance2}"
     state3_value = "/#{@domain}/#{@namespace}/#{@method_class}/#{@instance3}"


### PR DESCRIPTION
This fixes an issue with a change we made to populate the root object ae_state_max_retries attribute with value of max_retries from the class schema. The value was only getting set if the root object attribute value was zero.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1529735