### PR TITLE
Fix the complaints rather than updating the rubocop:disable and enable

### DIFF
--- a/spec/engine/miq_ae_method_spec.rb
+++ b/spec/engine/miq_ae_method_spec.rb
@@ -3,14 +3,20 @@ describe MiqAeEngine::MiqAeMethod do
     let(:workspace) do
       Class.new do
         attr_accessor :invoker, :root
-        # rubocop:disable Style/SingleLineMethods, Style/EmptyLineBetweenDefs
-        def persist_state_hash; end
-        def disable_rbac; end
-        def current_method; "/my/automate/method"; end
+
+        def persist_state_hash
+        end
+
+        def disable_rbac
+        end
+
+        def current_method
+          "/my/automate/method"
+        end
+
         def root
           {}
         end
-        # rubocop:enable Style/SingleLineMethods, Style/EmptyLineBetweenDefs
       end.new
     end
 


### PR DESCRIPTION
The rubocop checker on the bot is failing because Style/EmptyLineBetweenDefs has moved to the Layout namespace.