### PR TITLE
Migrate model display names from locale/en.yml to plugin

### DIFF
--- a/app/models/miq_ae_domain.rb
+++ b/app/models/miq_ae_domain.rb
@@ -178,6 +178,10 @@ class MiqAeDomain < MiqAeNamespace
     MiqTask.generic_action_with_callback(task_options, queue_options)
   end
 
+  def self.display_name(number = 1)
+    n_('Automate Domain', 'Automate Domains', number)
+  end
+
   private
 
   def squeeze_priorities


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from locale/en.yml into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

Core PR: https://github.com/ManageIQ/manageiq/pull/16836