### PR TITLE
Fix memory leak with ruby/require/autoload_paths

### DIFF
--- a/lib/manageiq/automation_engine/engine.rb
+++ b/lib/manageiq/automation_engine/engine.rb
@@ -5,9 +5,9 @@ module ManageIQ
     class Engine < ::Rails::Engine
       isolate_namespace ManageIQ::AutomationEngine
 
-      config.autoload_paths << root.join("app/models/mixins")
-      config.autoload_paths << root.join("lib/miq_automation_engine")
-      config.autoload_paths << root.join("lib/miq_automation_engine/engine")
+      config.autoload_paths << root.join("app/models/mixins").to_s
+      config.autoload_paths << root.join("lib/miq_automation_engine").to_s
+      config.autoload_paths << root.join("lib/miq_automation_engine/engine").to_s
 
       def vmdb_plugin?
         true


### PR DESCRIPTION
In ruby versions less than 2.5.0, it was found that if you have `Pathname` objects in the `$LOAD_PATH` instead of regular strings, it messes with ruby's internals and causes a memory leak.

In most ruby applications, this wouldn't be much of an issue, but there are a significant number of deferred require statements that we do in `manageiq` that cause this to leak overtime.  Further more, this seems to be an issue that presents itself even if the file has been loaded previously (mostly a no-op for `require`).

Replication of this issue can be done using a simple ruby script:

```ruby
require 'pathname'
require 'fileutils'

puts Process.pid

Dir.mkdir("foo") unless Dir.exists?("foo")
$LOAD_PATH.unshift(Pathname.new("foo"))

FileUtils.touch("empty.rb")
1500.times { 1500.times { require "empty" }; print "."; GC.start; }
```

By simply running the application with the Pathnames converted to strings, this should be a proper and low cost workaround for us until it is patched in ruby or we update `manageiq` to >= ruby 2.5.0.


Links
-----

* https://github.com/ManageIQ/manageiq/pull/16837


Steps for Testing/QA
--------------------

Being tested in https://github.com/ManageIQ/manageiq/pull/16837