### PR TITLE
Add comment about leak in engine.rb

### DIFF
--- a/lib/manageiq/automation_engine/engine.rb
+++ b/lib/manageiq/automation_engine/engine.rb
@@ -5,6 +5,14 @@ module ManageIQ
     class Engine < ::Rails::Engine
       isolate_namespace ManageIQ::AutomationEngine
 
+      # NOTE:  If you are going to make changes to autoload_paths, please make
+      # sure they are all strings.  Rails will push these paths into the
+      # $LOAD_PATH.
+      #
+      # More info can be found in the ruby-lang bug:
+      #
+      #   https://bugs.ruby-lang.org/issues/14372
+      #
       config.autoload_paths << root.join("app/models/mixins").to_s
       config.autoload_paths << root.join("lib/miq_automation_engine").to_s
       config.autoload_paths << root.join("lib/miq_automation_engine/engine").to_s


### PR DESCRIPTION
Provides comments and info regarding the changes to the `autoload_paths`.  Specs to test this is not a problem can be found in the main repo in https://github.com/ManageIQ/manageiq/pull/16847


Links
-----

* https://github.com/ManageIQ/manageiq/pull/16847