### PR TITLE
Builtin method for check_provisioned

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -14,6 +14,8 @@ module MiqAeEngine
     INFRASTRUCTURE = 'infrastructure'.freeze
     UNKNOWN        = 'unknown'.freeze
 
+    include_concern 'MiqAeTaskBuiltin'
+
     def self.miq_log_object(obj, _inputs)
       $miq_ae_logger.info("===========================================")
       $miq_ae_logger.info("Dumping Object")

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method/miq_ae_task_builtin.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method/miq_ae_task_builtin.rb
@@ -10,7 +10,7 @@ module MiqAeEngine
           raise ArgumentError, "miq_provision not specified" unless task
 
           result = task.statemachine_task_status
-          $miq_ae_logger.info("Builtin ProvisionCheck returned <#{result}> for state <#{task.state}> and status <#{task['status']}>")
+          $miq_ae_logger.info("Builtin check_provisioned returned <#{result}> for state <#{task.state}> and status <#{task['status']}>")
 
           set_ae_result(result, task, root, inputs)
         end
@@ -20,7 +20,7 @@ module MiqAeEngine
           when 'error'
             root['ae_result'] = 'error'
             reason = task.message
-            $miq_ae_logger.error("ProvisionCheck error <#{reason}>")
+            $miq_ae_logger.error("Builtin check_provisioned error <#{reason}>")
             reason = reason[7..-1] if reason[0..6] == 'Error: '
             root['ae_reason'] = reason
           when 'retry'

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method/miq_ae_task_builtin.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method/miq_ae_task_builtin.rb
@@ -1,0 +1,36 @@
+module MiqAeEngine
+  class MiqAeBuiltinMethod
+    module MiqAeTaskBuiltin
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def miq_check_provisioned(obj, inputs = {})
+          root = obj.workspace.root
+          task = root['miq_provision']
+          raise ArgumentError, "miq_provision not specified" unless task
+
+          result = task.statemachine_task_status
+          $miq_ae_logger.info("Builtin ProvisionCheck returned <#{result}> for state <#{task.state}> and status <#{task['status']}>")
+
+          set_ae_result(result, task, root, inputs)
+        end
+
+        def set_ae_result(result, task, root, inputs)
+          case result
+          when 'error'
+            root['ae_result'] = 'error'
+            reason = task.message
+            $miq_ae_logger.error("ProvisionCheck error <#{reason}>")
+            reason = reason[7..-1] if reason[0..6] == 'Error: '
+            root['ae_reason'] = reason
+          when 'retry'
+            root['ae_result']         = 'retry'
+            root['ae_retry_interval'] = inputs['ae_retry_interval'] || '1.minute'
+          when 'ok'
+            root['ae_result'] = 'ok'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/engine/miq_ae_engine/miq_ae_builtin_method/miq_ae_task_builtin_spec.rb
+++ b/spec/engine/miq_ae_engine/miq_ae_builtin_method/miq_ae_task_builtin_spec.rb
@@ -1,0 +1,74 @@
+describe MiqAeEngine::MiqAeBuiltinMethod::MiqAeTaskBuiltin do
+  describe '.miq_check_provisioned' do
+    let(:ems) { FactoryGirl.create(:ems_vmware_with_authentication) }
+    let(:vm_template) { FactoryGirl.create(:template_vmware, :ext_management_system => ems) }
+    let(:vm) { nil }
+    let(:admin) { FactoryGirl.create(:user_with_group, :role => "admin") }
+    let(:pr) do
+      FactoryGirl.create(:miq_provision_request,
+                         :requester => admin,
+                         :src_vm_id => vm_template.id)
+    end
+    let(:options) { { :src_vm_id => [vm_template.id, vm_template.name] } }
+    let(:status) { "Ok" }
+    let(:state) { "pending" }
+    let(:message_with_error) { "Error: Yabba Dabba Doo" }
+    let(:message) { "Yabba Dabba Doo" }
+    let(:miq_provision) do
+      FactoryGirl.create(:miq_provision,
+                         :userid       => admin.userid,
+                         :miq_request  => pr,
+                         :source       => vm_template,
+                         :request_type => 'template',
+                         :state        => state,
+                         :vm           => vm,
+                         :message      => message_with_error,
+                         :options      => options,
+                         :status       => status)
+    end
+    let(:svc_miq_provision) { MiqAeMethodService::MiqAeServiceMiqProvision.find(miq_provision.id) }
+    let(:root_obj) { { 'miq_provision' => svc_miq_provision } }
+    let(:workspace) { double('WORKSPACE', :root => root_obj) }
+    let(:obj) { double('OBJ', :workspace => workspace) }
+
+    context "invalid args" do
+      let(:root_obj) { { } }
+      it "raises exception" do
+        expect do
+          MiqAeEngine::MiqAeBuiltinMethod.miq_check_provisioned(obj, {})
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    it 'task still running' do
+      MiqAeEngine::MiqAeBuiltinMethod.miq_check_provisioned(obj, 'ae_retry_interval' => 10)
+
+      expect(root_obj['ae_result']).to eq('retry')
+      expect(root_obj['ae_retry_interval']).to eq(10)
+    end
+
+    context 'task finished' do
+      let(:status) { "Ok" }
+      let(:state) { "finished" }
+      let(:vm) { FactoryGirl.create(:vm_vmware) }
+
+      it "normal exit" do
+        MiqAeEngine::MiqAeBuiltinMethod.miq_check_provisioned(obj, {})
+
+        expect(root_obj['ae_result']).to eq('ok')
+      end
+    end
+
+    context 'task fails' do
+      let(:status) { "Error" }
+      let(:state) { "finished" }
+
+      it "sets ae_reason" do
+        MiqAeEngine::MiqAeBuiltinMethod.miq_check_provisioned(obj, {})
+
+        expect(root_obj['ae_result']).to eq('error')
+        expect(root_obj['ae_reason']).to eq(message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
A builtin method is run directly in the Automate Engine and doesn't have to be run via DRb, so its faster.

This is an example of invoking the check_provisioned for VM and Instance provisioning.

Currently the check_provisioned method for vm and instance provisioning is an inline method
For testing you do would have to do the following steps

1. Create a new domain, mark it as enabled
2. Copy the following 2 methods to the new domain
 a. /ManageIQ/Infrastructure/VM/Provisioning/StateMachines/Methods/check_provisioned
 b. /ManageIQ/Cloud/VM/Provisioning/StateMachines/Methods/check_provisioned
3. Copying the methods gives you the exact path of where the method should be with classes and namespaces
4. Delete the above 2 methods and add them back in as builtin
5. Make sure that the name is check_provisioned, builtin method names match to the internal name.


This method takes an optional single input parameter 
 

- ae_retry_interval                     Time in seconds to sleep between retries default is 60 seconds