### PR TITLE
Support for substitution from state_var

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -396,7 +396,7 @@ module MiqAeEngine
 
     def fetch_object_attribute(path, name, required = false)
       o = @workspace.get_obj_from_path(path)
-      raise MiqAeException::ObjectNotFound, "Object Not Found for path=[#{path}]"  if o.nil?
+      raise MiqAeException::ObjectNotFound, "Object Not Found for path=[#{path}]" if o.nil?
 
       if o.attributes.key?(name.downcase)
         o.attributes[name.downcase]
@@ -427,7 +427,7 @@ module MiqAeEngine
         attribute_name = frags.shift
         methods        = frags
 
-        value = if path.casecmp("STATE_VAR") == 0
+        value = if path.casecmp("STATE_VAR").zero?
                   fetch_state_attribute(attribute_name, required)
                 else
                   fetch_object_attribute(path, attribute_name, required)

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -386,6 +386,25 @@ module MiqAeEngine
       invoke_method(ns, klass, method_name, MiqAeUri.query2hash(query))
     end
 
+    def fetch_state_attribute(name, required = false)
+      if @workspace.persist_state_hash.key?(name)
+        @workspace.persist_state_hash[name]
+      elsif required
+        raise MiqAeException::AttributeNotFound, "State var #{name} not found"
+      end
+    end
+
+    def fetch_object_attribute(path, name, required = false)
+      o = @workspace.get_obj_from_path(path)
+      raise MiqAeException::ObjectNotFound, "Object Not Found for path=[#{path}]"  if o.nil?
+
+      if o.attributes.key?(name.downcase)
+        o.attributes[name.downcase]
+      elsif required
+        raise MiqAeException::AttributeNotFound, "Attribute #{name} not found for object [#{path}]"
+      end
+    end
+
     def uri2value(uri, required = false)
       scheme, userinfo, host, port, registry, path, opaque, query, fragment = MiqAeUri.split(uri)
 
@@ -403,18 +422,17 @@ module MiqAeEngine
           return @workspace.current_message if path.downcase == '!current_message'
           raise MiqAeException::MethodNotFound, "Method [#{path}] Not Found for Current Object"
         end
-        o = @workspace.get_obj_from_path(path)
-        raise MiqAeException::ObjectNotFound, "Object Not Found for path=[#{path}]"  if o.nil?
 
         frags          = fragment.split('.')
         attribute_name = frags.shift
         methods        = frags
 
-        if required && !o.attributes.key?(attribute_name.downcase)
-          raise MiqAeException::AttributeNotFound, "Attribute #{attribute_name} not found for object [#{path}]"
-        end
+        value = if path.casecmp("STATE_VAR") == 0
+                  fetch_state_attribute(attribute_name, required)
+                else
+                  fetch_object_attribute(path, attribute_name, required)
+                end
 
-        value          = o.attributes[attribute_name.downcase]
         begin
           methods.each { |meth| value = call_method(value, meth) }
         rescue => err

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -814,7 +814,7 @@ describe MiqAeEngine do
 
   before do
     @user = FactoryGirl.create(:user_with_group)
-    nco_value = '${/#var1} || ${XY/ABC#var2} || Pebbles'
+    nco_value = '${/#var1} || ${XY/ABC#var2} || ${State_Var#my_id} || Pebbles'
     default_value = '${/#var2} || ${XY/ABC#var2} || Bamm Bamm Rubble'
     instance_name = 'FRED'
     ae_instances = {instance_name => {'field1' => {:value => nco_value},
@@ -849,6 +849,14 @@ describe MiqAeEngine do
 
     it "undefined variable" do
       workspace = MiqAeEngine.instantiate("/A/C/BARNEY/FRED", @user)
+      expect(workspace.root['field2']).to eq('Bamm Bamm Rubble')
+      expect(workspace.root.attributes.keys.exclude?('field3')).to be_truthy
+    end
+
+    it "fetches value from state_var" do
+      ae_state_data = {:my_id => 45}.to_yaml
+      workspace = MiqAeEngine.instantiate("/A/C/BARNEY/FRED?ae_state_data=#{ae_state_data}", @user)
+      expect(workspace.root['field1']).to eq("45")
       expect(workspace.root['field2']).to eq('Bamm Bamm Rubble')
       expect(workspace.root.attributes.keys.exclude?('field3')).to be_truthy
     end


### PR DESCRIPTION
The state_var stores key data that is needed between states, these
are typically user provided scalar data (ids, strings). The Automate
engine keeps the state_var segregated from the objects in the
workspace. The user might want to fetch one of these state var during
substitution. This PR allows access to the state vars using the
following syntax.

The format for substitution is

   ${object_path#attribute_name.optional_methods}
  The object path can be
   **.**                Default is missing stands for the current object
   **/**               The root object
   **/a/b/c**      The object in path /a/b/c

We are adding a new object path value called **STATE_VAR** (case insensitive)
to fetch attributes from state vars

e.g to get a state var called MY_TASK_ID use the following substitute string

**${STATE_VAR#MY_TASK_ID}**