### PR TITLE
Making processing log to be uniform.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
@@ -51,7 +51,7 @@ module MiqAeEngine
       end
     rescue => e
       error_message = "State=<#{f['name']}> running #{step} raised exception: <#{e.message}>"
-      $miq_ae_logger.error error_message
+      $miq_ae_logger.error(error_message)
       @workspace.root['ae_reason'] = error_message
       @workspace.root['ae_result'] = 'error'
     end
@@ -79,20 +79,20 @@ module MiqAeEngine
 
         # Check the ae_result and set the next state appropriately
         if   @workspace.root['ae_result'] == 'ok'
-          $miq_ae_logger.info "Processed State=[#{f['name']}]"
+          $miq_ae_logger.info("Processed State=[#{f['name']}]")
         elsif @workspace.root['ae_result'] == 'skip'
-          $miq_ae_logger.warn "Skipping State=[#{f['name']}]"
+          $miq_ae_logger.warn("Skipping State=[#{f['name']}]")
           return set_next_state(f, message)
         elsif %w(retry restart).include?(@workspace.root['ae_result'])
           increment_state_retries
         elsif @workspace.root['ae_result'] == 'error'
-          $miq_ae_logger.warn "Error in State=[#{f['name']}]"
+          $miq_ae_logger.warn("Error in State=[#{f['name']}]")
           # Process on_error method
 
           return process_state_step_with_error_handling(f, 'on_error') do
             process_state_method(f, 'on_error')
             if @workspace.root['ae_result'] == 'continue'
-              $miq_ae_logger.warn "Resetting Error in State=[#{f['name']}]"
+              $miq_ae_logger.warn("Resetting Error in State=[#{f['name']}]")
               @workspace.root['ae_result'] = 'ok'
               set_next_state(f, message)
             end
@@ -114,7 +114,7 @@ module MiqAeEngine
     def process_state_relationship(f, message, args)
       relationship = get_value(f, :aetype_relationship)
       unless relationship.blank? || relationship.lstrip[0, 1] == '#'
-        $miq_ae_logger.info "Processing State=[#{f['name']}]"
+        $miq_ae_logger.info("Processing State=[#{f['name']}]")
         @workspace.root['ae_state_step'] = 'main'
         enforce_state_maxima(f)
         match_data = STATE_METHOD_REGEX.match(relationship)
@@ -124,7 +124,7 @@ module MiqAeEngine
           process_relationship_raw(relationship, message, args, f['name'], f['collect'])
           raise MiqAeException::MiqAeDatastoreError, "empty relationship" unless @rels[f['name']]
         end
-        $miq_ae_logger.info "Processed State=[#{f['name']}] with Result=[#{@workspace.root['ae_result']}]"
+        $miq_ae_logger.info("Processed State=[#{f['name']}] with Result=[#{@workspace.root['ae_result']}]")
       end
     end
 
@@ -132,7 +132,7 @@ module MiqAeEngine
       f[method_name].split(";").each do |method|
         method = substitute_value(method.strip)
         unless method.blank? || method.lstrip[0, 1] == '#'
-          $miq_ae_logger.info "In State=[#{f['name']}], invoking [#{method_name}] method=[#{method}]"
+          $miq_ae_logger.info("In State=[#{f['name']}], invoking [#{method_name}] method=[#{method}]")
           @workspace.root['ae_status_state'] = method_name
           @workspace.root['ae_state']        = f['name']
           @workspace.root['ae_state_step'] = method_name
@@ -156,13 +156,13 @@ module MiqAeEngine
       if %w(skip ok).include?(@workspace.root['ae_result'])
         @workspace.root['ae_state'] = next_state(f['name'], message).to_s
         reset_state_maxima_metadata
-        $miq_ae_logger.info "Next State=[#{@workspace.root['ae_state']}]"
+        $miq_ae_logger.info("Next State=[#{@workspace.root['ae_state']}]")
         @workspace.root['ae_result'] = 'ok'
       elsif @workspace.root['ae_result'] == 'restart'
-        $miq_ae_logger.info "State=[#{f['name']}] has requested a restart"
+        $miq_ae_logger.info("State=[#{f['name']}] has requested a restart")
         @workspace.root['ae_result'] = 'retry'
         @workspace.root['ae_state'] = restart_state(message).to_s
-        $miq_ae_logger.info "Will restart at State=[#{@workspace.root['ae_state']}]"
+        $miq_ae_logger.info("Will restart at State=[#{@workspace.root['ae_state']}]")
       end
     end
 
@@ -175,7 +175,7 @@ module MiqAeEngine
     def validate_state(states)
       next_state = @workspace.root['ae_next_state']
       if next_state.present? && states.exclude?(next_state)
-        $miq_ae_logger.error "Next State=#{next_state} is invalid aborting state machine"
+        $miq_ae_logger.error("Next State=#{next_state} is invalid aborting state machine")
         raise MiqAeException::AbortInstantiation, "Invalid state specified <#{next_state}>"
       end
     end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
@@ -79,9 +79,9 @@ module MiqAeEngine
 
         # Check the ae_result and set the next state appropriately
         if   @workspace.root['ae_result'] == 'ok'
-          $miq_ae_logger.info "Processed State =[#{f['name']}]"
+          $miq_ae_logger.info "Processed State=[#{f['name']}]"
         elsif @workspace.root['ae_result'] == 'skip'
-          $miq_ae_logger.warn "Skipping State =[#{f['name']}]"
+          $miq_ae_logger.warn "Skipping State=[#{f['name']}]"
           return set_next_state(f, message)
         elsif %w(retry restart).include?(@workspace.root['ae_result'])
           increment_state_retries
@@ -124,7 +124,7 @@ module MiqAeEngine
           process_relationship_raw(relationship, message, args, f['name'], f['collect'])
           raise MiqAeException::MiqAeDatastoreError, "empty relationship" unless @rels[f['name']]
         end
-        $miq_ae_logger.info "Processed  State=[#{f['name']}] with Result=[#{@workspace.root['ae_result']}]"
+        $miq_ae_logger.info "Processed State=[#{f['name']}] with Result=[#{@workspace.root['ae_result']}]"
       end
     end
 


### PR DESCRIPTION
Making processing logs to be uniform by removing a few white spaces in log messages.

based on https://bugzilla.redhat.com/show_bug.cgi?id=1535231