### PR TITLE
Support calling update_vm_name for miq_provision service models

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision.rb
@@ -8,6 +8,7 @@ module MiqAeMethodService
     expose :vm_template,           :association => true
     expose :target_type
     expose :source_type
+    expose :update_vm_name
 
     expose_eligible_resources :hosts
     expose_eligible_resources :storages


### PR DESCRIPTION
Make the `update_vm_name` method available to the MiqProvision service model so it can generate the name at a later time in the provisioning process and take advantage of the auto-incrementing name feature.  See https://github.com/ManageIQ/manageiq/pull/16897 for details

Depends on PR https://github.com/ManageIQ/manageiq/pull/16897

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1455002

