### PR TITLE
Removed Rackspace credential spec for service model

### DIFF
--- a/spec/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-rackspace_credential_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-rackspace_credential_spec.rb
@@ -1,5 +1,0 @@
-describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_RackspaceCredential do
-  it "get the service model class" do
-    expect { described_class }.not_to raise_error
-  end
-end


### PR DESCRIPTION
Fixes tests after credentials removed in PR https://github.com/ManageIQ/manageiq/pull/16936

https://bugzilla.redhat.com/show_bug.cgi?id=1542182
