### PR TITLE
Fix removed have_attributes failures

### DIFF
--- a/spec/models/miq_ae_domain_spec.rb
+++ b/spec/models/miq_ae_domain_spec.rb
@@ -304,7 +304,7 @@ describe MiqAeDomain do
     let(:info) { {'commit_time' => commit_time, 'commit_message' => commit_message, 'commit_sha' => commit_sha} }
     let(:new_info) { {'commit_time' => commit_time_new, 'commit_message' => "BB-8", 'commit_sha' => "def"} }
     let(:commit_hash) do
-      {'commit_message' => commit_message, 'commit_time' => commit_time,
+      {'commit_message' => commit_message, 'commit_time' => a_value_within(1.second).of(commit_time),
        'commit_sha' => commit_sha, 'ref' => branch_name, 'ref_type' => MiqAeGitImport::BRANCH}
     end
     let(:branch) { FactoryGirl.create(:git_branch, :name => branch_name) }

--- a/spec/service_models/miq_ae_service_service_spec.rb
+++ b/spec/service_models/miq_ae_service_service_spec.rb
@@ -252,7 +252,7 @@ EOF
           :retirement_last_warn => nil,
           :retired              => false,
           :retirement_state     => nil,
-          :retires_on           => future_retires_on + extend_days.days
+          :retires_on           => a_value_within(1.second).of(future_retires_on + extend_days.days)
         )
       end
     end

--- a/spec/service_models/miq_ae_service_vm_spec.rb
+++ b/spec/service_models/miq_ae_service_vm_spec.rb
@@ -201,7 +201,7 @@ module MiqAeServiceVmSpec
           :retirement_last_warn => nil,
           :retired              => false,
           :retirement_state     => nil,
-          :retires_on           => future_retires_on + extend_days.days
+          :retires_on           => a_value_within(1.second).of(future_retires_on + extend_days.days)
         )
       end
     end


### PR DESCRIPTION
Our custom have_attributes behavior of automatically comparing approximate times has been removed. You must specify this in the specs themselves now.

See https://github.com/ManageIQ/manageiq/pull/17021