### PR TITLE
Don't call on_exit method while Ansible Playbook method is running.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -89,7 +89,7 @@ module MiqAeEngine
     end
 
     def mark_for_retry(task_id)
-      @workspace.root['ae_result'] = 'retry'
+      @workspace.root['ae_result'] = 'async_launch'
       @workspace.root['ae_retry_interval'] = retry_interval
       @workspace.persist_state_hash['automate_workspace_guid'] = @aw.guid
       @workspace.persist_state_hash[method_key] = task_id

--- a/spec/miq_ae_playbook_method_spec.rb
+++ b/spec/miq_ae_playbook_method_spec.rb
@@ -184,7 +184,7 @@ describe MiqAeEngine::MiqAePlaybookMethod do
         ap = described_class.new(aem, obj, inputs)
         ap.run
 
-        expect(root_object['ae_result']).to eq('retry')
+        expect(root_object['ae_result']).to eq('async_launch')
         expect(persist_hash[method_key]).to eq(miq_task.id)
         expect(AutomateWorkspace.find_by(:guid => aw.guid)).not_to be_nil
       end
@@ -196,7 +196,7 @@ describe MiqAeEngine::MiqAePlaybookMethod do
         ap = described_class.new(aem, obj, inputs)
         ap.run
 
-        expect(root_object['ae_result']).to eq('retry')
+        expect(root_object['ae_result']).to eq('async_launch')
         expect(persist_hash[method_key]).to eq(miq_task.id)
         expect(AutomateWorkspace.find_by(:guid => aw.guid)).not_to be_nil
       end
@@ -242,7 +242,7 @@ describe MiqAeEngine::MiqAePlaybookMethod do
           ap = described_class.new(aem, obj, inputs)
           ap.run
 
-          expect(root_object['ae_result']).to eq('retry')
+          expect(root_object['ae_result']).to eq('async_launch')
           expect(root_object['ae_retry_interval']).to eq(retry_interval)
         end
       end


### PR DESCRIPTION
The State Machine executes the on_exit method for ae_result = retry.  The Ansible playbook method was setting the ae_result = retry when the playbook was launched, and until it was completed which resulted in the on_exit method being executed. 
Changed the Ansible Playbook method ae_result value from 'retry' to 'async_launch' and changed the state machine processing to skip the on_exit for the ae_result = async_launch, then changed the ae_result value to 'retry' for normal processing.

https://bugzilla.redhat.com/show_bug.cgi?id=1557310