### PR TITLE
Expose generic_objects from GenericObjectDefinition.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_generic_object_definition.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_generic_object_definition.rb
@@ -1,5 +1,6 @@
 module MiqAeMethodService
   class MiqAeServiceGenericObjectDefinition < MiqAeServiceModelBase
+    expose :generic_objects, :association => true
     expose :property_attributes
     expose :property_associations
     expose :property_methods


### PR DESCRIPTION
To make it possible to list the generic_objects associated to a generic object definition in automate.

https://bugzilla.redhat.com/show_bug.cgi?id=1565174

@miq-bot add_label bug, gaprindashvili/yes