### PR TITLE
Replaced the double slashes with a single slash to be more forgiving …

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_uri.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_uri.rb
@@ -25,6 +25,7 @@ module MiqAeEngine
     end
 
     def self.split(uri, default_scheme = 'miqaews')
+      uri.gsub!('//', '/')
       scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(uri.strip)
       scheme = default_scheme if scheme.nil?
       scheme = 'miqaews' if scheme.downcase == 'miqae'

--- a/spec/miq_ae_uri_spec.rb
+++ b/spec/miq_ae_uri_spec.rb
@@ -30,4 +30,12 @@ describe MiqAeEngine::MiqAeUri do
 
     expect(path).to eq(uri.strip)
   end
+
+  it "remove extra slashes" do
+    uri = "//Cloud//VM/StateMachines//Sample  "
+    result_uri = "/Cloud/VM/StateMachines/Sample"
+    _, _, _, _, _, path = described_class.split(uri)
+
+    expect(path).to eq(result_uri)
+  end
 end


### PR DESCRIPTION
…in path substitution.

Path example: /{/#a}/{/#b}/{/#c}/{/#d}
before: if {/#a} is nil, path becomes //b/c/d which is invalid
after: if {/#a} is nil, path becomes /b/c/d which is valid(*if b/c/d exists)