### PR TITLE
Expose initializing to automate

### DIFF
--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_retirement_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_retirement_mixin.rb
@@ -7,6 +7,7 @@ module MiqAeServiceRetirementMixin
     expose :retiring?
     expose :error_retiring?
     expose :retired?
+    expose :retirement_initialized?
     expose :extend_retires_on
   end
 


### PR DESCRIPTION
The retirement state of initializing needs to be exposed to the engine. 