### PR TITLE
Service model: method exposing

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -74,13 +74,13 @@ module MiqAeMethodService
 
     def self.base_class
       @base_class ||= begin
-        MiqAeMethodService.const_get("MiqAeService#{model.base_class.name}")
+        model_name_from_active_record_model(model.base_class).constantize
       end
     end
 
     def self.base_model
       @base_model ||= begin
-        MiqAeMethodService.const_get("MiqAeService#{model.base_model.name}")
+        model_name_from_active_record_model(model.base_model).constantize
       end
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -45,6 +45,7 @@ module MiqAeMethodService
     def self.expose_class_attributes(subclass)
       subclass.class_eval do
         model.attribute_names.each do |attr|
+          next if model.private_method_defined?(attr)
           next if EXPOSED_ATTR_BLACK_LIST.any? { |rexp| attr =~ rexp }
           next if subclass.base_class != self && method_defined?(attr)
           expose attr

--- a/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
@@ -84,6 +84,13 @@ describe MiqAeMethodService::MiqAeServiceModelBase do
         expect(test_class.name).to eq('MiqAeMethodService::MiqAeServiceMiqAeServiceModelSpec_TestVmOrTemplate')
         expect(test_class.superclass.name).to eq('MiqAeMethodService::MiqAeServiceVmOrTemplate')
       end
+
+      it 'does not list private attributes' do
+        expect(MiqAeMethodService::MiqAeServiceModelBase).not_to(receive(:expose).with('properties'))
+        obj     = MiqAeServiceModelSpec::TestPrivateAttrExpose.create
+        svc_obj = described_class.model_name_from_active_record_model(MiqAeServiceModelSpec::TestPrivateAttrExpose).constantize.find(obj.id)
+        expect(svc_obj.methods.include?(:properties)).to(eq(false))
+      end
     end
   end
 end
@@ -92,4 +99,17 @@ module MiqAeServiceModelSpec
   class TestInteger < ::Integer; end
   class TestApplicationRecord < ::ApplicationRecord; end
   class TestVmOrTemplate < ::VmOrTemplate; end
+  class TestPrivateAttrExpose < ::ApplicationRecord
+    self.table_name = 'generic_objects'
+
+    def self.attribute_names
+      ['properties']
+    end
+
+    private
+
+    def properties
+      super
+    end
+  end
 end


### PR DESCRIPTION
* Adding the check for private attributes expose with spec. 
* Fixing a broken `base_class` and `base_model` methods in `miq_ae_service_model_base.rb` for classes with modules.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1560632