### PR TITLE
Ability to add and remove volumes for an instance 

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_cloud_volume.rb
@@ -9,6 +9,7 @@ module MiqAeMethodService
     expose :base_snapshot,          :association => true
     expose :cloud_volume_backups,   :association => true
     expose :cloud_volume_snapshots, :association => true
+    expose :create_volume_snapshot, :override_return => nil
     expose :attachments,            :association => true
     expose :attach_volume,          :override_return => nil
     expose :detach_volume,          :override_return => nil

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-cloud_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-cloud_manager-vm.rb
@@ -4,6 +4,7 @@ module MiqAeMethodService
     expose :flavor,            :association => true
     expose :cloud_network,     :association => true
     expose :cloud_subnet,      :association => true
+    expose :cloud_volumes,     :association => true
     expose :network_ports,     :association => true
     expose :network_routers,   :association => true
     expose :cloud_subnets,     :association => true


### PR DESCRIPTION
Expose `create_volume_snapshot` and `cloud_volumes` so that users can add or remove a volume from an instance.

Modifications based on http://talk.manageiq.org/t/aws-cloud-volume-relationships/3111/2

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1507667