### PR TITLE
Added method show_url for Service Model objects

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -28,25 +28,7 @@ module MiqAeEngine
   end
 
   private_class_method def self.options_from_args(args)
-    options = {}
-    if args.length == 1
-      # options = Hash
-      options = args.first
-    else
-      binding.pry
-      # Legacy
-      options[:object_type]      = args.shift
-      options[:object_id]        = args.shift
-      options[:attrs]            = args.shift
-      options[:instance_name]    = args.shift
-      options[:user_id]          = args.shift
-      options[:state]            = args.shift
-      options[:automate_message] = args.shift
-      options[:ae_fsm_started]   = args.shift
-      options[:ae_state_started] = args.shift
-      options[:ae_state_retries] = args.shift
-    end
-
+    options = args.first
     options[:instance_name] ||= 'AUTOMATION'
     options[:attrs] ||= {}
     options

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -27,16 +27,13 @@ module MiqAeEngine
     MiqQueue.put(options)
   end
 
-  def self.deliver(*args)
+  private_class_method def self.options_from_args(args)
     options = {}
-
-    case args.length
-    when 0
-      # options = nil
-    when 1
+    if args.length == 1
       # options = Hash
       options = args.first
     else
+      binding.pry
       # Legacy
       options[:object_type]      = args.shift
       options[:object_id]        = args.shift
@@ -52,46 +49,59 @@ module MiqAeEngine
 
     options[:instance_name] ||= 'AUTOMATION'
     options[:attrs] ||= {}
-    user_obj = ae_user_object(options)
+    options
+  end
 
-    object_type      = options[:object_type]
-    object_id        = options[:object_id]
-    state            = options[:state]
-    user_id          = options[:user_id]
-    ae_fsm_started   = options[:ae_fsm_started]
-    ae_state_started = options[:ae_state_started]
-    ae_state_retries = options[:ae_state_retries]
-    ae_state_data    = options[:ae_state_data]
-    ae_state_previous = options[:ae_state_previous]
-    vmdb_object      = nil
-    ae_result        = 'error'
+  private_class_method def self.automate_attrs_from_options(options)
+    automate_attrs = options[:attrs].dup
+    automate_attrs['User::user']        = options[:user_id]           unless options[:user_id].nil?
+    automate_attrs[:ae_state]           = options[:state]             unless options[:state].nil?
+    automate_attrs[:ae_fsm_started]     = options[:ae_fsm_started]    unless options[:ae_fsm_started].nil?
+    automate_attrs[:ae_state_started]   = options[:ae_state_started]  unless options[:ae_state_started].nil?
+    automate_attrs[:ae_state_retries]   = options[:ae_state_retries]  unless options[:ae_state_retries].nil?
+    automate_attrs['ae_state_data']     = options[:ae_state_data]     unless options[:ae_state_data].nil?
+    automate_attrs['ae_state_previous'] = options[:ae_state_previous] unless options[:ae_state_previous].nil?
+    automate_attrs
+  end
+
+  private_class_method def self.create_automation_object_options(options, vmdb_object)
+    automation_object_options = {}
+    automation_object_options[:vmdb_object] = vmdb_object                unless vmdb_object.nil?
+    automation_object_options[:class]       = options[:class_name]       unless options[:class_name].nil?
+    automation_object_options[:namespace]   = options[:namespace]        unless options[:namespace].nil?
+    automation_object_options[:fqclass]     = options[:fqclass_name]     unless options[:fqclass_name].nil?
+    automation_object_options[:message]     = options[:automate_message] unless options[:automate_message].nil?
+    automation_object_options
+  end
+
+  private_class_method def self.change_options_by_ws(options, ws)
+    options[:state]             = ws.root['ae_state'] || options[:state]
+    options[:ae_fsm_started]    = ws.root['ae_fsm_started']
+    options[:ae_state_started]  = ws.root['ae_state_started']
+    options[:ae_state_retries]  = ws.root['ae_state_retries']
+    options[:ae_state_data]     = YAML.dump(ws.persist_state_hash) unless ws.persist_state_hash.empty?
+    options[:ae_state_previous] = YAML.dump(ws.current_state_info) unless ws.current_state_info.empty?
+  end
+
+  def self.deliver(*args)
+    options     = options_from_args(args)
+    user_obj    = ae_user_object(options)
+    state       = options[:state]
+    vmdb_object = nil
+    ae_result   = 'error'
 
     begin
-      object_name = "#{object_type}.#{object_id}"
+      object_name = "#{options[:object_type]}.#{options[:object_id]}"
       _log.info("Delivering #{options[:attrs].inspect} for object [#{object_name}] with state [#{state}] to Automate")
-      automate_attrs = options[:attrs].dup
+      automate_attrs = automate_attrs_from_options(options)
 
-      if object_type
-        vmdb_object = object_type.constantize.find_by(:id => object_id)
-        automate_attrs[create_automation_attribute_key(vmdb_object)] = object_id
+      if options[:object_type]
+        vmdb_object = options[:object_type].constantize.find_by(:id => options[:object_id])
+        automate_attrs[create_automation_attribute_key(vmdb_object)] = options[:object_id]
         vmdb_object.before_ae_starts(options) if vmdb_object.respond_to?(:before_ae_starts)
       end
 
-      automate_attrs['User::user']      = user_id            unless user_id.nil?
-      automate_attrs[:ae_state]         = state              unless state.nil?
-      automate_attrs[:ae_fsm_started]   = ae_fsm_started     unless ae_fsm_started.nil?
-      automate_attrs[:ae_state_started] = ae_state_started   unless ae_state_started.nil?
-      automate_attrs[:ae_state_retries] = ae_state_retries   unless ae_state_retries.nil?
-      automate_attrs['ae_state_data']   = ae_state_data      unless ae_state_data.nil?
-      automate_attrs['ae_state_previous'] = ae_state_previous  unless ae_state_previous.nil?
-
-      create_automation_object_options = {}
-      create_automation_object_options[:vmdb_object] = vmdb_object                unless vmdb_object.nil?
-      create_automation_object_options[:class]       = options[:class_name]       unless options[:class_name].nil?
-      create_automation_object_options[:namespace]   = options[:namespace]        unless options[:namespace].nil?
-      create_automation_object_options[:fqclass]     = options[:fqclass_name]     unless options[:fqclass_name].nil?
-      create_automation_object_options[:message]     = options[:automate_message] unless options[:automate_message].nil?
-      uri = create_automation_object(options[:instance_name], automate_attrs, create_automation_object_options)
+      uri = create_automation_object(options[:instance_name], automate_attrs, create_automation_object_options(options, vmdb_object))
       ws  = resolve_automation_object(uri, user_obj)
 
       if ws.nil? || ws.root.nil?
@@ -106,13 +116,7 @@ module MiqAeEngine
         if ae_result.casecmp('retry').zero?
           ae_retry_interval = ws.root['ae_retry_interval'].to_s.to_i_with_method
           deliver_on = Time.now.utc + ae_retry_interval
-
-          options[:state]            = ws.root['ae_state'] || state
-          options[:ae_fsm_started]   = ws.root['ae_fsm_started']
-          options[:ae_state_started] = ws.root['ae_state_started']
-          options[:ae_state_retries] = ws.root['ae_state_retries']
-          options[:ae_state_data]    = YAML.dump(ws.persist_state_hash) unless ws.persist_state_hash.empty?
-          options[:ae_state_previous] = YAML.dump(ws.current_state_info) unless ws.current_state_info.empty?
+          change_options_by_ws(options, ws)
 
           message = "Requeuing #{options.inspect} for object [#{object_name}] with state [#{options[:state]}] to Automate for delivery in [#{ae_retry_interval}] seconds"
           _log.info(message)

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -8,6 +8,7 @@ module MiqAeMethodService
       include DRbUndumped  # Ensure that Automate Method can get at the class itself over DRb
     end
 
+    include Rails.application.routes.url_helpers
     include DRbUndumped    # Ensure that Automate Method can get at instances over DRb
     include MiqAeMethodService::MiqAeServiceObjectCommon
     include Vmdb::Logging
@@ -243,6 +244,13 @@ module MiqAeMethodService
       end
       @object = obj.kind_of?(ar_klass) ? obj : ar_method { ar_klass.find_by(:id => obj) }
       raise MiqAeException::ServiceNotFound, "#{ar_klass.name} Object [#{obj}] not found" if @object.nil?
+    end
+
+    def show_url
+      default_url_options[:host] = MiqRegion.my_region.remote_ui_url
+      url_for(:controller => ActiveModel::Naming.singular(self.class.ar_base_model),
+              :action     => 'show',
+              :id         => @object.id)
     end
 
     def virtual_columns_inspect

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -806,6 +806,16 @@ describe MiqAeEngine do
       expect(test_class_instance).to receive(:before_ae_starts).once.with(options)
       MiqAeEngine.deliver(options)
     end
+
+    it 'raises error while delivering' do
+      allow(MiqAeEngine).to receive(:create_automation_object).with(any_args).and_return('_ wong_uri _')
+      expect(test_class_name).to receive(:constantize).and_return(test_class)
+      expect(test_class).to receive(:find_by).with(any_args).and_return(test_class_instance)
+      allow(MiqAeEngine).to receive(:create_automation_attribute_key)
+      expect(MiqAeEngine._log).to receive(:error)
+        .with("Error delivering {\"User::user\"=>#{user.id}, nil=>nil} for object [TestClass.] with state [] to Automate: bad URI(is not URI?): _ wong_uri _")
+      MiqAeEngine.deliver(options)
+    end
   end
 end
 

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -314,6 +314,11 @@ describe MiqAeEngine do
       expect(MiqAeEngine.create_automation_attribute_key(host)).to eq("Host::host")
     end
 
+    it "with a MiqRequest" do
+      host = FactoryGirl.create(:miq_host_provision_request)
+      expect(MiqAeEngine.create_automation_attribute_key(host)).to eq("MiqHostProvisionRequest::miq_host_provision_request")
+    end
+
     it "with an EmsCluster" do
       cluster = FactoryGirl.create(:ems_cluster)
       expect(MiqAeEngine.create_automation_attribute_key(cluster)).to eq("EmsCluster::ems_cluster")
@@ -337,6 +342,11 @@ describe MiqAeEngine do
     it "with an Host" do
       host = FactoryGirl.create(:host)
       expect(MiqAeEngine.create_automation_attribute_class_name(host)).to eq("Host")
+    end
+
+    it "with an MiqRequest" do
+      host = FactoryGirl.create(:miq_host_provision_request)
+      expect(MiqAeEngine.create_automation_attribute_class_name(host)).to eq("MiqHostProvisionRequest")
     end
   end
 
@@ -423,6 +433,11 @@ describe MiqAeEngine do
     it "with a string value" do
       expect(MiqAeEngine.create_automation_attributes("")).to eq("")
       expect(MiqAeEngine.create_automation_attributes("")).to eq("")
+    end
+
+    it 'with an Array of attrs' do
+      array = [%w(key value), %w(key1 value1)]
+      expect(MiqAeEngine.create_automation_attributes(array)).to eq('key' => 'value', 'key1' => 'value1')
     end
   end
 

--- a/spec/miq_ae_service_model_spec.rb
+++ b/spec/miq_ae_service_model_spec.rb
@@ -12,6 +12,15 @@ describe MiqAeMethodService::MiqAeServiceVm do
     expect(MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.base_class).to eq(MiqAeMethodService::MiqAeServiceVmOrTemplate)
   end
 
+  it "#show_url" do
+    ui_url = "https://www.example.com"
+    miq_region = FactoryGirl.create(:miq_region)
+    allow(MiqRegion).to receive(:my_region).and_return(miq_region)
+    allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+
+    expect(@ae_vm.show_url).to eq("#{ui_url}/vm/show/#{@vm.id}")
+  end
+
   it "vm should be valid" do
     expect(@vm).to be_kind_of(Vm)
     expect(@vm).not_to be_nil


### PR DESCRIPTION
This allows automate methods to fetch the URL for request objects and
other objects with a simple call like

     svc_miq_request.show_url

instead of the current implementation

     https://${/#miq_server.ipaddress}/miq_request/show/${/#svc_miq_request.id}