### PR TITLE
Added method show_url for service model objects

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -8,6 +8,7 @@ module MiqAeMethodService
       include DRbUndumped  # Ensure that Automate Method can get at the class itself over DRb
     end
 
+    include Rails.application.routes.url_helpers
     include DRbUndumped    # Ensure that Automate Method can get at instances over DRb
     include MiqAeMethodService::MiqAeServiceObjectCommon
     include Vmdb::Logging
@@ -243,6 +244,13 @@ module MiqAeMethodService
       end
       @object = obj.kind_of?(ar_klass) ? obj : ar_method { ar_klass.find_by(:id => obj) }
       raise MiqAeException::ServiceNotFound, "#{ar_klass.name} Object [#{obj}] not found" if @object.nil?
+    end
+
+    def show_url
+      default_url_options[:host] = MiqRegion.my_region.remote_ui_url
+      url_for(:controller => ActiveModel::Naming.singular(self.class.ar_base_model),
+              :action     => 'show',
+              :id         => @object.id)
     end
 
     def virtual_columns_inspect

--- a/spec/miq_ae_service_model_spec.rb
+++ b/spec/miq_ae_service_model_spec.rb
@@ -12,6 +12,15 @@ describe MiqAeMethodService::MiqAeServiceVm do
     expect(MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.base_class).to eq(MiqAeMethodService::MiqAeServiceVmOrTemplate)
   end
 
+  it "#show_url" do
+    ui_url = "https://www.example.com"
+    miq_region = FactoryGirl.create(:miq_region)
+    allow(MiqRegion).to receive(:my_region).and_return(miq_region)
+    allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+
+    expect(@ae_vm.show_url).to eq("#{ui_url}/vm/show/#{@vm.id}")
+  end
+
   it "vm should be valid" do
     expect(@vm).to be_kind_of(Vm)
     expect(@vm).not_to be_nil


### PR DESCRIPTION
This allows automate methods to fetch the URL for request objects and
other objects with a simple call like

  svc_miq_request.show_url

Instead of

  https://${/#miq_server.ipaddress}/miq_request/show/${/#svc_miq_request.id}

This is a common use case for sending emails to approvers with the
URL for the request to approve