### PR TITLE
Added show_url for specific service model objects

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_ems_cluster.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_ems_cluster.rb
@@ -18,5 +18,9 @@ module MiqAeMethodService
       sync_or_async_ems_operation(false, "register_host", [host.id])
       true
     end
+
+    def show_url
+      MiqRegion.my_region.remote_ui_url + "/ems_cluster/show/" + "#{@object.id}"
+    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_ems_cluster.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_ems_cluster.rb
@@ -20,7 +20,7 @@ module MiqAeMethodService
     end
 
     def show_url
-      MiqRegion.my_region.remote_ui_url + "/ems_cluster/show/" + "#{@object.id}"
+      MiqRegion.my_region.remote_ui_url + "/ems_cluster/show/" + @object.id.to_s
     end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_ems_cluster.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_ems_cluster.rb
@@ -20,7 +20,7 @@ module MiqAeMethodService
     end
 
     def show_url
-      MiqRegion.my_region.remote_ui_url + "/ems_cluster/show/" + @object.id.to_s
+      URI.join(MiqRegion.my_region.remote_ui_url, "ems_cluster/show/#{@object.id}").to_s
     end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
@@ -86,7 +86,7 @@ module MiqAeMethodService
     end
 
     def show_url
-      MiqRegion.my_region.remote_ui_url + "/host/show/" + "#{@object.id}"
+      MiqRegion.my_region.remote_ui_url + "/host/show/" + @object.id.to_s
     end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
@@ -84,5 +84,9 @@ module MiqAeMethodService
     def current_memory_headroom
       object_send(:current_memory_headroom)
     end
+
+    def show_url
+      MiqRegion.my_region.remote_ui_url + "/host/show/" + "#{@object.id}"
+    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
@@ -86,7 +86,7 @@ module MiqAeMethodService
     end
 
     def show_url
-      MiqRegion.my_region.remote_ui_url + "/host/show/" + @object.id.to_s
+      URI.join(MiqRegion.my_region.remote_ui_url, "host/show/#{@object.id}").to_s
     end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
@@ -34,7 +34,7 @@ module MiqAeMethodService
     end
 
     def show_url
-      MiqRegion.my_region.remote_ui_url + "/miq_request/show/" + @object.id.to_s
+      URI.join(MiqRegion.my_region.remote_ui_url, "miq_request/show/#{@object.id}").to_s
     end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
@@ -32,5 +32,9 @@ module MiqAeMethodService
     def description=(new_description)
       object_send(:update_attributes, :description => new_description)
     end
+
+    def show_url
+      MiqRegion.my_region.remote_ui_url + "/miq_request/show/" + "#{@object.id}"
+    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
@@ -34,7 +34,7 @@ module MiqAeMethodService
     end
 
     def show_url
-      MiqRegion.my_region.remote_ui_url + "/miq_request/show/" + "#{@object.id}"
+      MiqRegion.my_region.remote_ui_url + "/miq_request/show/" + @object.id.to_s
     end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -107,7 +107,7 @@ module MiqAeMethodService
     end
 
     def show_url
-      MiqRegion.my_region.remote_ui_url + "/service/show/" + @object.id.to_s
+      URI.join(MiqRegion.my_region.remote_ui_url, "service/show/#{@object.id}").to_s
     end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -107,7 +107,7 @@ module MiqAeMethodService
     end
 
     def show_url
-      MiqRegion.my_region.remote_ui_url + "/service/show/" + "#{@object.id}"
+      MiqRegion.my_region.remote_ui_url + "/service/show/" + @object.id.to_s
     end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -105,5 +105,9 @@ module MiqAeMethodService
         @object.save
       end
     end
+
+    def show_url
+      MiqRegion.my_region.remote_ui_url + "/service/show/" + "#{@object.id}"
+    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
@@ -11,7 +11,7 @@ module MiqAeMethodService
     expose :scan,                   :override_return => true
 
     def show_url
-      MiqRegion.my_region.remote_ui_url + "/storage/show/" + "#{@object.id}"
+      MiqRegion.my_region.remote_ui_url + "/storage/show/" + @object.id.to_s
     end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
@@ -9,5 +9,9 @@ module MiqAeMethodService
     expose :storage_clusters,       :association => true
     expose :to_s
     expose :scan,                   :override_return => true
+
+    def show_url
+      MiqRegion.my_region.remote_ui_url + "/storage/show/" + "#{@object.id}"
+    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
@@ -11,7 +11,7 @@ module MiqAeMethodService
     expose :scan,                   :override_return => true
 
     def show_url
-      MiqRegion.my_region.remote_ui_url + "/storage/show/" + @object.id.to_s
+      URI.join(MiqRegion.my_region.remote_ui_url, "storage/show/#{@object.id}").to_s
     end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
@@ -36,5 +36,9 @@ module MiqAeMethodService
       options[:task] = task.to_s
       Vm.process_tasks(options)
     end
+
+    def show_url
+      MiqRegion.my_region.remote_ui_url + "/vm/show/" + "#{@object.id}"
+    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
@@ -38,7 +38,7 @@ module MiqAeMethodService
     end
 
     def show_url
-      MiqRegion.my_region.remote_ui_url + "/vm/show/" + @object.id.to_s
+      URI.join(MiqRegion.my_region.remote_ui_url, "vm/show/#{@object.id}").to_s
     end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
@@ -38,7 +38,7 @@ module MiqAeMethodService
     end
 
     def show_url
-      MiqRegion.my_region.remote_ui_url + "/vm/show/" + "#{@object.id}"
+      MiqRegion.my_region.remote_ui_url + "/vm/show/" + @object.id.to_s
     end
   end
 end

--- a/spec/service_models/miq_ae_service_ems_cluster_spec.rb
+++ b/spec/service_models/miq_ae_service_ems_cluster_spec.rb
@@ -1,0 +1,13 @@
+describe MiqAeMethodService::MiqAeServiceEmsCluster do
+  let(:cluster) { FactoryGirl.create(:ems_cluster) }
+  let(:svc_cluster) { MiqAeMethodService::MiqAeServiceEmsCluster.find(cluster.id) }
+
+  it "#show_url" do
+    ui_url = "https://www.example.com"
+    miq_region = FactoryGirl.create(:miq_region)
+    allow(MiqRegion).to receive(:my_region).and_return(miq_region)
+    allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+
+    expect(svc_cluster.show_url).to eq("#{ui_url}/ems_cluster/show/#{cluster.id}")
+  end
+end

--- a/spec/service_models/miq_ae_service_ems_cluster_spec.rb
+++ b/spec/service_models/miq_ae_service_ems_cluster_spec.rb
@@ -3,10 +3,7 @@ describe MiqAeMethodService::MiqAeServiceEmsCluster do
   let(:svc_cluster) { MiqAeMethodService::MiqAeServiceEmsCluster.find(cluster.id) }
 
   it "#show_url" do
-    ui_url = "https://www.example.com"
-    miq_region = FactoryGirl.create(:miq_region)
-    allow(MiqRegion).to receive(:my_region).and_return(miq_region)
-    allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+    ui_url = stub_remote_ui_url
 
     expect(svc_cluster.show_url).to eq("#{ui_url}/ems_cluster/show/#{cluster.id}")
   end

--- a/spec/service_models/miq_ae_service_host_spec.rb
+++ b/spec/service_models/miq_ae_service_host_spec.rb
@@ -13,10 +13,8 @@ module MiqAeServiceHostSpec
     end
 
     it "#show_url" do
-      ui_url = "https://www.example.com"
-      miq_region = FactoryGirl.create(:miq_region)
-      allow(MiqRegion).to receive(:my_region).and_return(miq_region)
-      allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+      ui_url = stub_remote_ui_url
+
       svc_host = MiqAeMethodService::MiqAeServiceHost.find(@host.id)
 
       expect(svc_host.show_url).to eq("#{ui_url}/host/show/#{@host.id}")

--- a/spec/service_models/miq_ae_service_host_spec.rb
+++ b/spec/service_models/miq_ae_service_host_spec.rb
@@ -12,6 +12,16 @@ module MiqAeServiceHostSpec
       MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?Host::host=#{@host.id}", @user)
     end
 
+    it "#show_url" do
+      ui_url = "https://www.example.com"
+      miq_region = FactoryGirl.create(:miq_region)
+      allow(MiqRegion).to receive(:my_region).and_return(miq_region)
+      allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+      svc_host = MiqAeMethodService::MiqAeServiceHost.find(@host.id)
+
+      expect(svc_host.show_url).to eq("#{ui_url}/host/show/#{@host.id}")
+    end
+
     context "$evm.vmdb" do
       it "with no parms" do
         method = "$evm.root['#{@ae_result_key}'] = $evm.vmdb('host')"

--- a/spec/service_models/miq_ae_service_miq_request_spec.rb
+++ b/spec/service_models/miq_ae_service_miq_request_spec.rb
@@ -18,6 +18,16 @@ module MiqAeServiceMiqRequestSpec
       MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?MiqRequest::miq_request=#{@miq_request.id}", @fred)
     end
 
+    it "#show_url" do
+      ui_url = "https://www.example.com"
+      miq_region = FactoryGirl.create(:miq_region)
+      allow(MiqRegion).to receive(:my_region).and_return(miq_region)
+      allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+      svc_request = MiqAeMethodService::MiqAeServiceMiqRequest.find(@miq_request.id)
+
+      expect(svc_request.show_url).to eq("#{ui_url}/miq_request/show/#{@miq_request.id}")
+    end
+
     it "#approve" do
       approver = 'wilma'
       reason   = "Why Not?"

--- a/spec/service_models/miq_ae_service_miq_request_spec.rb
+++ b/spec/service_models/miq_ae_service_miq_request_spec.rb
@@ -19,10 +19,7 @@ module MiqAeServiceMiqRequestSpec
     end
 
     it "#show_url" do
-      ui_url = "https://www.example.com"
-      miq_region = FactoryGirl.create(:miq_region)
-      allow(MiqRegion).to receive(:my_region).and_return(miq_region)
-      allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+      ui_url = stub_remote_ui_url
       svc_request = MiqAeMethodService::MiqAeServiceMiqRequest.find(@miq_request.id)
 
       expect(svc_request.show_url).to eq("#{ui_url}/miq_request/show/#{@miq_request.id}")

--- a/spec/service_models/miq_ae_service_service_spec.rb
+++ b/spec/service_models/miq_ae_service_service_spec.rb
@@ -17,10 +17,7 @@ module MiqAeServiceServiceSpec
     end
 
     it "#show_url" do
-      ui_url = "https://www.example.com"
-      miq_region = FactoryGirl.create(:miq_region)
-      allow(MiqRegion).to receive(:my_region).and_return(miq_region)
-      allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+      ui_url = stub_remote_ui_url
 
       expect(service_service.show_url).to eq("#{ui_url}/service/show/#{service.id}")
     end

--- a/spec/service_models/miq_ae_service_service_spec.rb
+++ b/spec/service_models/miq_ae_service_service_spec.rb
@@ -16,6 +16,15 @@ module MiqAeServiceServiceSpec
       MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?Service::service=#{@service.id}", user)
     end
 
+    it "#show_url" do
+      ui_url = "https://www.example.com"
+      miq_region = FactoryGirl.create(:miq_region)
+      allow(MiqRegion).to receive(:my_region).and_return(miq_region)
+      allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+
+      expect(service_service.show_url).to eq("#{ui_url}/service/show/#{service.id}")
+    end
+
     it "#remove_from_vmdb" do
       expect(Service.count).to eq(1)
       method = "$evm.root['#{@ae_result_key}'] = $evm.root['service'].remove_from_vmdb"

--- a/spec/service_models/miq_ae_service_storage_spec.rb
+++ b/spec/service_models/miq_ae_service_storage_spec.rb
@@ -1,0 +1,13 @@
+describe MiqAeMethodService::MiqAeServiceStorage do
+  let(:storage) { FactoryGirl.create(:storage) }
+  let(:svc_storage) { MiqAeMethodService::MiqAeServiceStorage.find(storage.id) }
+
+  it "#show_url" do
+    ui_url = "https://www.example.com"
+    miq_region = FactoryGirl.create(:miq_region)
+    allow(MiqRegion).to receive(:my_region).and_return(miq_region)
+    allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+
+    expect(svc_storage.show_url).to eq("#{ui_url}/storage/show/#{storage.id}")
+  end
+end

--- a/spec/service_models/miq_ae_service_storage_spec.rb
+++ b/spec/service_models/miq_ae_service_storage_spec.rb
@@ -3,10 +3,7 @@ describe MiqAeMethodService::MiqAeServiceStorage do
   let(:svc_storage) { MiqAeMethodService::MiqAeServiceStorage.find(storage.id) }
 
   it "#show_url" do
-    ui_url = "https://www.example.com"
-    miq_region = FactoryGirl.create(:miq_region)
-    allow(MiqRegion).to receive(:my_region).and_return(miq_region)
-    allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+    ui_url = stub_remote_ui_url
 
     expect(svc_storage.show_url).to eq("#{ui_url}/storage/show/#{storage.id}")
   end

--- a/spec/service_models/miq_ae_service_vm_spec.rb
+++ b/spec/service_models/miq_ae_service_vm_spec.rb
@@ -17,6 +17,15 @@ module MiqAeServiceVmSpec
       MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?Vm::vm=#{@vm.id}", @user)
     end
 
+    it "#show_url" do
+      ui_url = "https://www.example.com"
+      miq_region = FactoryGirl.create(:miq_region)
+      allow(MiqRegion).to receive(:my_region).and_return(miq_region)
+      allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+
+      expect(service_vm.show_url).to eq("#{ui_url}/vm/show/#{vm.id}")
+    end
+
     it "#ems_custom_keys" do
       method   = "$evm.root['#{@ae_result_key}'] = $evm.root['vm'].ems_custom_keys"
       @ae_method.update_attributes(:data => method)

--- a/spec/service_models/miq_ae_service_vm_spec.rb
+++ b/spec/service_models/miq_ae_service_vm_spec.rb
@@ -18,11 +18,7 @@ module MiqAeServiceVmSpec
     end
 
     it "#show_url" do
-      ui_url = "https://www.example.com"
-      miq_region = FactoryGirl.create(:miq_region)
-      allow(MiqRegion).to receive(:my_region).and_return(miq_region)
-      allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
-
+      ui_url = stub_remote_ui_url
       expect(service_vm.show_url).to eq("#{ui_url}/vm/show/#{vm.id}")
     end
 

--- a/spec/support/stub_remote_ui_url.rb
+++ b/spec/support/stub_remote_ui_url.rb
@@ -1,0 +1,7 @@
+def stub_remote_ui_url
+  ui_url = "https://www.example.com"
+  miq_region = FactoryGirl.create(:miq_region)
+  allow(MiqRegion).to receive(:my_region).and_return(miq_region)
+  allow(miq_region).to receive(:remote_ui_url).and_return(ui_url)
+  ui_url
+end


### PR DESCRIPTION
Added a new public method show_url to the following service model objects
  - vm
  - service
  -  miq_request
  -  host
  -  ems_cluster
  -  storage
 
When we send links in emails we might need reference to the above objects

svc_miq_request.show_url

Instead of

https://${/#miq_server.ipaddress}/miq_request/show/${/#svc_miq_request.id}