### PR TITLE
Adding the `storages` attribute to be exposed.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
@@ -13,6 +13,7 @@ module MiqAeMethodService
 
     expose :ext_management_system, :association => true
     expose :storage,               :association => true
+    expose :storages,              :association => true
     expose :host,                  :association => true
     expose :hardware,              :association => true
     expose :operating_system,      :association => true


### PR DESCRIPTION
Adding the `storages` attribute from MiqAeServiceVmOrTemplate to be exposed.

based on: https://bugzilla.redhat.com/show_bug.cgi?id=1574444

@miq-bot add_label bug