### PR TITLE
Adds tracking label back to AeMethod lines

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -33,6 +33,7 @@ module MiqAeMethodService
     end
 
     def initialize(ws, inputs = {}, logger = $miq_ae_logger)
+      @tracking_label        = Thread.current["tracking_label"]
       @drb_server_references = []
       @inputs                = inputs
       @workspace             = ws
@@ -67,6 +68,7 @@ module MiqAeMethodService
     ####################################################
 
     def log(level, msg)
+      Thread.current["tracking_label"] = @tracking_label
       $miq_ae_logger.send(level, "<AEMethod #{current_method}> #{msg}")
     end
 


### PR DESCRIPTION
After recent changes to how we handle the task_id, the logging stopped including the information put in here: https://github.com/ManageIQ/manageiq/pull/17013/files in certain places. This puts the task_id back into Automate method log lines. 

Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1592428