### PR TITLE
Add vm.remove_disk method for a VMware VM

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm.rb
@@ -11,5 +11,9 @@ module MiqAeMethodService
     def add_disk(disk_name, disk_size_mb, options = {})
       sync_or_async_ems_operation(options[:sync], "add_disk", [disk_name, disk_size_mb, options])
     end
+
+    def remove_disk(disk_name, options = {})
+      sync_or_async_ems_operation(options[:sync], "remove_disk", [disk_name, options])
+    end
   end
 end


### PR DESCRIPTION
Add a method to remove a disk by name to a VMware VM.

Depends on ManageIQ/manageiq-providers-vmware#290