### PR TITLE
Fix for ae_method copy with embedded methods.

### DIFF
--- a/app/models/miq_ae_method_copy.rb
+++ b/app/models/miq_ae_method_copy.rb
@@ -72,14 +72,15 @@ class MiqAeMethodCopy
       @dest_method.destroy if @overwrite
       raise "Instance #{@target_name} exists in #{@target_ns_fqname} class #{@target_class_name}" unless @overwrite
     end
-    @dest_method = MiqAeMethod.create!(:name         => @target_name,
-                                       :display_name => @src_method.display_name,
-                                       :description  => @src_method.description,
-                                       :scope        => @src_method.scope,
-                                       :language     => @src_method.language,
-                                       :location     => @src_method.location,
-                                       :data         => @src_method.data,
-                                       :class_id     => @dest_class.id)
+    @dest_method = MiqAeMethod.create!(:display_name     => @src_method.display_name,
+                                       :description      => @src_method.description,
+                                       :scope            => @src_method.scope,
+                                       :language         => @src_method.language,
+                                       :location         => @src_method.location,
+                                       :data             => @src_method.data,
+                                       :embedded_methods => @src_method.embedded_methods,
+                                       :class_id         => @dest_class.id,
+                                       :name             => @target_name)
   end
 
   def validate

--- a/spec/models/miq_ae_method_copy_spec.rb
+++ b/spec/models/miq_ae_method_copy_spec.rb
@@ -70,6 +70,20 @@ describe MiqAeMethodCopy do
       meth2  = MiqAeMethod.find_by_class_id_and_name(class2.id, @src_method)
       validate_method(@meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
     end
+
+    it 'copy method with embedded_methods' do
+      method = MiqAeMethod.create(
+        :name             => 'embedded_methods_test_method',
+        :embedded_methods => [@src_fqname],
+        :class_id         => MiqAeClass.first.id,
+        :scope            => 'instance',
+        :language         => 'ruby',
+        :location         => 'inline'
+      )
+      src_fqname  = "#{@src_domain}/#{@src_ns}/#{@src_class}/#{method.name}"
+      method_copy = MiqAeMethodCopy.new(src_fqname).to_domain(@dest_domain, @dest_ns, true)
+      expect(method_copy.embedded_methods).to(eq(method.embedded_methods))
+    end
   end
 
   context 'copy onto itself' do


### PR DESCRIPTION
Fix for missing embedded methods parameter after the method copying in MiqAeDatastore.

based on: [BZ#1592140](https://bugzilla.redhat.com/show_bug.cgi?id=1592140)