### PR TITLE
Add `$evm.ansible_runner` method to miq_ae_service

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -316,6 +316,10 @@ module MiqAeMethodService
       aec.ae_instances.detect { |i| instance.casecmp(i.name) == 0 }
     end
 
+    def ansible_runner(env_vars, extra_vars, playbook_path)
+      Ansible::Runner.run(env_vars, extra_vars, playbook_path)
+    end
+
     private
 
     def editable_instance?(path)

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -316,8 +316,8 @@ module MiqAeMethodService
       aec.ae_instances.detect { |i| instance.casecmp(i.name) == 0 }
     end
 
-    def ansible_runner(env_vars, extra_vars, playbook_path)
-      Ansible::Runner.run(env_vars, extra_vars, playbook_path)
+    def ansible_runner(env_vars, extra_vars, playbook_path, queue_opts)
+      Ansible::Runner.run_queue(env_vars, extra_vars, playbook_path, @workspace.ae_user.name, queue_opts)
     end
 
     private

--- a/spec/miq_ae_service_spec.rb
+++ b/spec/miq_ae_service_spec.rb
@@ -205,4 +205,31 @@ describe MiqAeMethodService::MiqAeService do
       end
     end
   end
+  context "run ansible playbooks with ansible-runner" do
+    before do
+      allow(User).to receive_messages(:server_timezone => 'UTC')
+      allow(workspace).to receive(:disable_rbac)
+    end
+
+    let(:options) { {} }
+    let(:workspace) do
+      double("MiqAeEngine::MiqAeWorkspaceRuntime", :root               => options,
+                                                   :ae_user            => user,
+                                                   :persist_state_hash => {})
+    end
+    let(:miq_ae_service) { described_class.new(workspace) }
+    let(:user) { FactoryGirl.create(:user_with_group) }
+
+    context "#ansible_runner" do
+      it "calls Ansible::Runner.run" do
+        env_vars = {'ENV1' => 'VAL1', 'ENV2' => 'VAL2'}
+        extra_vars = {:ems_refs => %s(vm1 vm2)}
+        playbook_path = "/path/to/playbook"
+
+        expect(Ansible::Runner).to receive(:run).with(env_vars, extra_vars, playbook_path)
+
+        miq_ae_service.ansible_runner(env_vars, extra_vars, playbook_path)
+      end
+    end
+  end
 end

--- a/spec/miq_ae_service_spec.rb
+++ b/spec/miq_ae_service_spec.rb
@@ -225,10 +225,11 @@ describe MiqAeMethodService::MiqAeService do
         env_vars = {'ENV1' => 'VAL1', 'ENV2' => 'VAL2'}
         extra_vars = {:ems_refs => %s(vm1 vm2)}
         playbook_path = "/path/to/playbook"
+        queue_opts = {:role => "ems_operations"}
 
-        expect(Ansible::Runner).to receive(:run).with(env_vars, extra_vars, playbook_path)
+        expect(Ansible::Runner).to receive(:run_queue).with(env_vars, extra_vars, playbook_path, workspace.ae_user.name, queue_opts)
 
-        miq_ae_service.ansible_runner(env_vars, extra_vars, playbook_path)
+        miq_ae_service.ansible_runner(env_vars, extra_vars, playbook_path, queue_opts)
       end
     end
   end


### PR DESCRIPTION
Allow ansible playbooks to be invoked from automate methods via
ansible-runner.

The `Ansible::Runner` class is defined here https://github.com/ManageIQ/manageiq/blob/master/lib/ansible/runner.rb

Depends on: https://github.com/ManageIQ/manageiq/pull/17705