### PR TITLE
Incorporating the deliver method change into the refactoring

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -78,7 +78,7 @@ module MiqAeEngine
       automate_attrs = automate_attrs_from_options(options)
 
       if options[:object_type]
-        vmdb_object = options[:object_type].constantize.find_by(:id => options[:object_id])
+        vmdb_object = options[:object_type].constantize.find_by!(:id => options[:object_id])
         automate_attrs[create_automation_attribute_key(vmdb_object)] = options[:object_id]
         vmdb_object.before_ae_starts(options) if vmdb_object.respond_to?(:before_ae_starts)
         vmdb_object.mark_execution_servers if vmdb_object.respond_to?(:mark_execution_servers)

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -814,7 +814,7 @@ describe MiqAeEngine do
     it "#before_ae_starts" do
       allow(MiqAeEngine).to receive(:create_automation_object).with(any_args).and_return(nil)
       expect(test_class_name).to receive(:constantize).and_return(test_class)
-      expect(test_class).to receive(:find_by).with(any_args).and_return(test_class_instance)
+      expect(test_class).to receive(:find_by!).with(any_args).and_return(test_class_instance)
       allow(MiqAeEngine).to receive(:resolve_automation_object).with(any_args).and_return(workspace)
       allow(MiqAeEngine).to receive(:create_automation_attribute_key).with(any_args).and_return("abc")
       expect(test_class_instance).to receive(:before_ae_starts).once.with(options)
@@ -824,11 +824,17 @@ describe MiqAeEngine do
     it 'raises error while delivering' do
       allow(MiqAeEngine).to receive(:create_automation_object).with(any_args).and_return('_ wong_uri _')
       expect(test_class_name).to receive(:constantize).and_return(test_class)
-      expect(test_class).to receive(:find_by).with(any_args).and_return(test_class_instance)
+      expect(test_class).to receive(:find_by!).with(any_args).and_return(test_class_instance)
       allow(MiqAeEngine).to receive(:create_automation_attribute_key)
       expect(MiqAeEngine._log).to receive(:error)
         .with("Error delivering {\"User::user\"=>#{user.id}, nil=>nil} for object [TestClass.] with state [] to Automate: bad URI(is not URI?): _ wong_uri _")
       MiqAeEngine.deliver(options)
+    end
+
+    it 'raises RecordNotFound for missing vmdb_object' do
+      options[:object_type] = 'Vm'
+      options[:object_id] = -1
+      expect { MiqAeEngine.deliver(options) }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end


### PR DESCRIPTION
Fix for missing PR change from https://github.com/ManageIQ/manageiq-automation_engine/pull/84 due to my refactoring PR https://github.com/ManageIQ/manageiq-automation_engine/pull/169 with spec changes. Tina changed the `find_by` method into the `find_by!`, which raises an error when an object is not found.

https://bugzilla.redhat.com/show_bug.cgi?id=1467537