### PR TITLE
Start the drb server with a unix socket

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
@@ -38,7 +38,12 @@ module MiqAeEngine
       require 'drb/timeridconv'
       global_id_conv = DRb::TimerIdConv.new(drb_cache_timeout)
       drb_front = MiqAeMethodService::MiqAeServiceFront.new(@workspace)
-      self.drb_server = DRb::DRbServer.new("druby://127.0.0.1:0", drb_front, :idconv => global_id_conv)
+
+      require 'tmpdir'
+      Dir::Tmpname.create("automation_engine", nil) do |path|
+        self.drb_server = DRb.start_service("drbunix://#{path}", drb_front, :idconv => global_id_conv)
+        FileUtils.chmod(0o750, path)
+      end
     end
 
     def teardown


### PR DESCRIPTION
Use a temp file location and set permissions so only the current system
user can access it.

CVE-2018-10905
https://bugzilla.redhat.com/show_bug.cgi?id=1599389