### PR TITLE
Allow for embedded methods to contain embedded methods

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -286,7 +286,7 @@ module MiqAeEngine
     private_class_method :embedded_method_name
 
     def self.loaded?(current_items, fqname)
-      current_items.any? { |item| item[:fqname].casecmp(fqname) == 0 }
+      current_items.any? { |item| item[:fqname].casecmp(fqname).zero? }
     end
   end
 end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -239,7 +239,9 @@ module MiqAeEngine
     private_class_method :cleanup
 
     def self.bodies_and_line_numbers(obj, aem)
-      embeds = embedded_methods(obj.workspace, aem) << {:data => aem.data, :fqname => aem.fqname}
+      embeds = []
+      embedded_methods(obj.workspace, aem, embeds, aem.fqname)
+      embeds << {:data => aem.data, :fqname => aem.fqname}
       code_start = 0
       script_info = {}
       bodies = []
@@ -254,16 +256,24 @@ module MiqAeEngine
     end
     private_class_method :bodies_and_line_numbers
 
-    def self.embedded_methods(workspace, method_obj)
-      method_obj.embedded_methods.collect do |name|
+    def self.embedded_methods(workspace, method_obj, current_items, top)
+      method_obj.embedded_methods.each do |name|
         method_name, klass, ns = embedded_method_name(name)
         match_ns = workspace.overlay_method(ns, klass, method_name)
         cls = ::MiqAeClass.find_by_fqname("#{match_ns}/#{klass}")
         aem = ::MiqAeMethod.find_by(:class_id => cls.id, :name => method_name) if cls
         raise MiqAeException::MethodNotFound, "Embedded method #{name} not found" unless aem
-        fqname = "#{match_ns}/#{klass}/#{method_name}"
-        $miq_ae_logger.info("Loading embedded method #{fqname}")
-        {:data => aem.data, :fqname => fqname}
+        fqname = "/#{match_ns}/#{klass}/#{method_name}"
+        if top == fqname
+          $miq_ae_logger.info("Skipping #{fqname}, cannot reference the top method")
+        elsif loaded?(current_items, fqname)
+          $miq_ae_logger.info("Already loaded embedded method #{fqname}")
+        else
+          current_items << {:data => aem.data, :fqname => fqname}
+          $miq_ae_logger.info("Loading embedded method #{fqname}")
+          # Get the embedded methods for the this method
+          embedded_methods(workspace, aem, current_items, top)
+        end
       end
     end
     private_class_method :embedded_methods
@@ -274,5 +284,9 @@ module MiqAeEngine
       return parts.pop, parts.pop, parts.join('/')
     end
     private_class_method :embedded_method_name
+
+    def self.loaded?(current_items, fqname)
+      current_items.any? { |item| item[:fqname].casecmp(fqname) == 0 }
+    end
   end
 end

--- a/spec/engine/miq_ae_method_spec.rb
+++ b/spec/engine/miq_ae_method_spec.rb
@@ -379,21 +379,21 @@ describe MiqAeEngine::MiqAeMethod do
       end
 
       context "Each level embeds a different file" do
-        let(:aem)    { double("Method", :fqname => '/Shared/Methods/Level1', :data => level1_script, :embedded_methods => level1_embeds) }
+        let(:aem) { double("Method", :fqname => '/Shared/Methods/Level1', :data => level1_script, :embedded_methods => level1_embeds) }
 
         it_behaves_like 'nested embeds'
       end
 
       context "Top level embeds all files" do
         let(:level1_embeds) { ['/Shared/Methods/Level2', '/Shared/Methods/Level3'] }
-        let(:aem)    { double("Method", :fqname => '/Shared/Methods/Level1', :data => level1_script, :embedded_methods => level1_embeds) }
+        let(:aem) { double("Method", :fqname => '/Shared/Methods/Level1', :data => level1_script, :embedded_methods => level1_embeds) }
 
         it_behaves_like 'nested embeds'
       end
 
       context "Remove duplicate embeds" do
         let(:level1_embeds) { ['/Shared/Methods/Level2', '/Shared/Methods/Level2'] }
-        let(:aem)    { double("Method", :fqname => '/Shared/Methods/Level1', :data => level1_script, :embedded_methods => level1_embeds) }
+        let(:aem) { double("Method", :fqname => '/Shared/Methods/Level1', :data => level1_script, :embedded_methods => level1_embeds) }
 
         it_behaves_like 'nested embeds'
       end
@@ -401,7 +401,7 @@ describe MiqAeEngine::MiqAeMethod do
       context "Handle Circular Reference" do
         let(:level1_embeds) { ['/Shared/Methods/Level2'] }
         let(:level3_embeds) { ['/Shared/Methods/Level1'] }
-        let(:aem)    { double("Method", :fqname => '/Shared/Methods/Level1', :data => level1_script, :embedded_methods => level1_embeds) }
+        let(:aem) { double("Method", :fqname => '/Shared/Methods/Level1', :data => level1_script, :embedded_methods => level1_embeds) }
 
         it_behaves_like 'nested embeds'
       end


### PR DESCRIPTION
Fixes #202

This PR allows for the embedded methods to embed other methods
It can handle if the methods are embedded multiple times
It can handle circular reference where any method can embed the top
level method.


Method A -> {Embeds Method B}
Method B -> {Embeds Method C and Method E}
Method C -> {Embeds Method D}
Method D -> {Embeds Method E}

_When the User uses Method A, we will automatically build a dependency list of (Method B, Method C, Method D and Method E). Even though Method E is embedded twice it will be only be listed once so the dependency list would be_

**Method B
Method C
Method D
Method E
Method A**

This whole payload is then fed to the ruby interpreter