### PR TITLE
Allow an Automate method to set a custom log prefix

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -39,6 +39,7 @@ module MiqAeMethodService
       @workspace             = ws
       @persist_state_hash    = ws.persist_state_hash
       @logger                = logger
+      @log_prefix            = ""
       self.class.add(self)
       ws.disable_rbac
     end
@@ -69,11 +70,23 @@ module MiqAeMethodService
 
     def log(level, msg)
       Thread.current["tracking_label"] = @tracking_label
-      $miq_ae_logger.send(level, "<AEMethod #{current_method}> #{msg}")
+      if @log_prefix.blank?
+        $miq_ae_logger.send(level, "<AEMethod #{current_method}> #{msg}")
+      else
+        $miq_ae_logger.send(level, "<AEMethod #{current_method}> #{@log_prefix} #{msg}")
+      end
     end
 
     def set_state_var(name, value)
       @persist_state_hash[name] = value
+    end
+
+    def set_log_prefix(prefix)
+      @log_prefix = prefix
+    end
+
+    def get_log_prefix
+      @log_prefix
     end
 
     def state_var_exist?(name)

--- a/spec/engine/miq_ae_method_spec.rb
+++ b/spec/engine/miq_ae_method_spec.rb
@@ -230,6 +230,30 @@ describe MiqAeEngine::MiqAeMethod do
       end
     end
 
+    context "with a custom log prefix" do
+      let(:script) do
+        <<-RUBY
+          $evm.set_log_prefix "Flintstones"
+          $evm.log(:info, "This is a test message")
+          $evm.log(:info, "This is a warning message")
+          $evm.log(:error, "This is a error message")
+          $evm.log(:info, "The current prefix is \#{$evm.get_log_prefix}")
+        RUBY
+      end
+
+      it "does not log but raises an exception" do
+        expect($miq_ae_logger).to receive(:info).with(/Flintstones This is a test message/)
+        expect($miq_ae_logger).to receive(:info).with(/Flintstones This is a warning message/)
+        expect($miq_ae_logger).to receive(:error).with(/Flintstones This is a error message/)
+        expect($miq_ae_logger).to receive(:info).with(/Flintstones The current prefix is Flintstones/)
+        allow($miq_ae_logger).to receive(:info).with("<AEMethod [/my/automate/method]> Starting ")
+        allow($miq_ae_logger).to receive(:info).with("<AEMethod [/my/automate/method]> Ending")
+        allow($miq_ae_logger).to receive(:info).with("Method exited with rc=MIQ_OK")
+
+        expect(subject).to eq(0)
+      end
+    end
+
     context "embed other methods into a method" do
       let(:script) do
         <<-RUBY

--- a/spec/engine/miq_ae_method_spec.rb
+++ b/spec/engine/miq_ae_method_spec.rb
@@ -236,7 +236,7 @@ describe MiqAeEngine::MiqAeMethod do
           $evm.set_log_prefix "Flintstones"
           $evm.log(:info, "This is a test message")
           $evm.log(:info, "This is a warning message")
-          $evm.log(:error, "This is a error message")
+          $evm.log(:error, "This is an error message")
           $evm.log(:info, "The current prefix is \#{$evm.get_log_prefix}")
         RUBY
       end
@@ -244,7 +244,7 @@ describe MiqAeEngine::MiqAeMethod do
       it "does not log but raises an exception" do
         expect($miq_ae_logger).to receive(:info).with(/Flintstones This is a test message/)
         expect($miq_ae_logger).to receive(:info).with(/Flintstones This is a warning message/)
-        expect($miq_ae_logger).to receive(:error).with(/Flintstones This is a error message/)
+        expect($miq_ae_logger).to receive(:error).with(/Flintstones This is an error message/)
         expect($miq_ae_logger).to receive(:info).with(/Flintstones The current prefix is Flintstones/)
         allow($miq_ae_logger).to receive(:info).with("<AEMethod [/my/automate/method]> Starting ")
         allow($miq_ae_logger).to receive(:info).with("<AEMethod [/my/automate/method]> Ending")


### PR DESCRIPTION
This PR allows customers method to set the log prefix.
Previously we have seen customers writing a custom log method to
add an additional string to the message.

2 new methods have been added

1. **$evm.set_log_prefix(string)**
2. **$evm.get_log_prefix**
 

e.g.

``` ruby
$evm.set_log_prefix("Custom Prefix")
$evm.log(:info, "Informational Message")
$evm.log(:error, "Error Message")
$evm.log(:warn, "Warning Message")
$evm.log(:info, "Current prefix is #{$evm.get_log_prefix}")
```

This would append the 'Custom Prefix' to every log info, warn, error and
debug