### PR TITLE
[WIP] Add submit_workflow option to provision request creation

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -111,7 +111,7 @@ module MiqAeMethodService
     end
 
     def self.create_service_provision_request(svc_template, options = nil)
-      result = svc_template.object_send(:provision_request, User.current_user, options)
+      result = svc_template.object_send(:provision_request, User.current_user, options, options[:submit_workflow] => true)
       MiqAeServiceModelBase.wrap_results(result)
     end
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1613935

The submit_workflow option forces a specific path for how dialog field values are set up since everything gets funneled to the resource action workflow. Having this option in the create_service_provision_request allows the dialog options to be correctly passed to the service provisioning request. 


## Related to
https://github.com/ManageIQ/manageiq/pull/17839