### PR TITLE
Enable cancelation_status to be updated for service model

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
@@ -4,6 +4,8 @@ module MiqAeMethodService
     expose :pre_ansible_playbook_service_template
     expose :post_ansible_playbook_service_template
     expose :mark_vm_migrated
+    expose :canceling
+    expose :canceled
 
     def transformation_destination(source_obj)
       ar_method do


### PR DESCRIPTION
Allow `cancelation_status` to be updated for service model.

https://bugzilla.redhat.com/show_bug.cgi?id=1614864

Related PRs:
https://github.com/ManageIQ/manageiq/pull/17825
https://github.com/ManageIQ/manageiq-schema/pull/254