### PR TITLE
Add support to redhat VM for set_memory and set_number_of_cpus

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager-vm.rb
@@ -1,5 +1,13 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_Redhat_InfraManager_Vm < MiqAeServiceManageIQ_Providers_InfraManager_Vm
+    def set_number_of_cpus(count, options = {})
+      sync_or_async_ems_operation(options[:sync], "set_number_of_cpus", [count])
+    end
+
+    def set_memory(size_mb, options = {})
+      sync_or_async_ems_operation(options[:sync], "set_memory", [size_mb])
+    end
+
     def add_disk(disk_name, disk_size_mb, options = {})
       sync_or_async_ems_operation(options[:sync], "add_disk", [disk_name, disk_size_mb, options])
     end

--- a/spec/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager-vm_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager-vm_spec.rb
@@ -14,6 +14,26 @@ module MiqAeServiceManageIQ_Providers_Redhat_InfraManager_VmSpec
       }
     end
 
+    it "#set_number_of_cpus" do
+      service_vm.set_number_of_cpus(1)
+
+      expect(MiqQueue.first).to have_attributes(
+        @base_queue_options.merge(
+          :method_name => 'set_number_of_cpus',
+          :args        => [1])
+      )
+    end
+
+    it "#set_memory" do
+      service_vm.set_memory(100)
+
+      expect(MiqQueue.first).to have_attributes(
+        @base_queue_options.merge(
+          :method_name => 'set_memory',
+          :args        => [100])
+      )
+    end
+
     it "#add_disk" do
       service_vm.add_disk('disk_1', 100, :interface => "IDE", :bootable => true)
 

--- a/spec/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager-vm_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager-vm_spec.rb
@@ -20,7 +20,8 @@ module MiqAeServiceManageIQ_Providers_Redhat_InfraManager_VmSpec
       expect(MiqQueue.first).to have_attributes(
         @base_queue_options.merge(
           :method_name => 'set_number_of_cpus',
-          :args        => [1])
+          :args        => [1]
+        )
       )
     end
 
@@ -30,7 +31,8 @@ module MiqAeServiceManageIQ_Providers_Redhat_InfraManager_VmSpec
       expect(MiqQueue.first).to have_attributes(
         @base_queue_options.merge(
           :method_name => 'set_memory',
-          :args        => [100])
+          :args        => [100]
+        )
       )
     end
 


### PR DESCRIPTION
VMware provider has support to set memory and number of CPUs from Automate code. This PR add support for the same methods to oVirt provider.

Depends on: https://github.com/ManageIQ/manageiq-providers-ovirt/pull/280
Associated RHZ: https://bugzilla.redhat.com/show_bug.cgi?id=1623021