### PR TITLE
Add MiqWidget service model and expose queue_generate_content method

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_widget.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_widget.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceMiqWidget < MiqAeServiceModelBase
+    expose :queue_generate_content
+  end
+end

--- a/spec/service_models/miq_ae_service_miq_widget_spec.rb
+++ b/spec/service_models/miq_ae_service_miq_widget_spec.rb
@@ -1,0 +1,12 @@
+module MiqAeServiceMiqWidgetSpec
+  describe MiqAeMethodService::MiqAeServiceMiqWidget do
+    it "#queue_generate_content" do
+      miq_widget = FactoryGirl.create(:miq_widget)
+      allow(MiqWidget).to receive(:find).with(miq_widget.id).and_return(miq_widget)
+      service_miq_widget = MiqAeMethodService::MiqAeServiceMiqWidget.find(miq_widget.id)
+
+      expect(miq_widget).to receive(:queue_generate_content)
+      service_miq_widget.queue_generate_content
+    end
+  end
+end


### PR DESCRIPTION
Add MiqWidget service_model and expose queue_generate_content method for asynchronous Widget updates.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1445932