### PR TITLE
Expose storage_profiles association in Storage's service model.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
@@ -5,6 +5,7 @@ module MiqAeMethodService
     expose :vms,                    :association => true
     expose :unregistered_vms,       :association => true
     expose :storage_files,          :association => true
+    expose :storage_profiles,       :association => true
     expose :files,                  :association => true
     expose :storage_clusters,       :association => true
     expose :to_s


### PR DESCRIPTION
To enable a call like ```storage.storage_profiles```.

Blocks https://github.com/ManageIQ/manageiq-content/pull/420.
https://bugzilla.redhat.com/show_bug.cgi?id=1617520

@miq-bot add_label bug, gaprindashvili/yes