### PR TITLE
Fix Embedded Ansible playbook method retries in an automate state machine

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -15,10 +15,8 @@ module MiqAeEngine
       if @workspace.persist_state_hash[method_key].present?
         task_id = @workspace.persist_state_hash[method_key]
         @aw = AutomateWorkspace.find_by(:guid => @workspace.persist_state_hash['automate_workspace_guid'])
-        check_task_status(task_id)
-      else
-        execute
       end
+      @aw ? check_task_status(task_id) : execute
     end
 
     def self.cleanup(workspace)

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -91,6 +91,7 @@ module MiqAeEngine
       @workspace.root['ae_retry_interval'] = retry_interval
       @workspace.persist_state_hash['automate_workspace_guid'] = @aw.guid
       @workspace.persist_state_hash[method_key] = task_id
+      @workspace.root['ae_state_retries'] = @workspace.root['ae_state_retries'].to_i - 1
       $miq_ae_logger.info("Setting State Machine Auto Retry Interval: #{@workspace.root['ae_retry_interval']}")
     end
 


### PR DESCRIPTION
This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=1625047

I have successfully tested the following scenarios:
* result=ok on first run
* X number of retries followed by result=ok
* max retries reached resulting in error
* playbook faliure resulting in error

The PR also fixes a retry count issue caused by entering the method twice in order to set status to 'async_launch'