### PR TITLE
Bump rubyzip minimum version to 1.2.2

### DIFF
--- a/manageiq-automation_engine.gemspec
+++ b/manageiq-automation_engine.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
-  s.add_dependency "rubyzip", "~>1.2.1"
+  s.add_dependency "rubyzip", "~>1.2.2"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Includes https://github.com/rubyzip/rubyzip/pull/371 (Fix CVE-2018-1000544)