### PR TITLE
Clear stale data from ae_state_data and ae_state_previous

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -57,6 +57,8 @@ module MiqAeEngine
   end
 
   private_class_method def self.change_options_by_ws(options, ws)
+    options.delete(:ae_state_data)
+    options.delete(:ae_state_previous)
     options[:state]             = ws.root['ae_state'] || options[:state]
     options[:ae_fsm_started]    = ws.root['ae_fsm_started']
     options[:ae_state_started]  = ws.root['ae_state_started']

--- a/spec/engine/miq_ae_state_machine_retry_spec.rb
+++ b/spec/engine/miq_ae_state_machine_retry_spec.rb
@@ -280,6 +280,6 @@ describe "MiqAeStateMachineRetry" do
     expect(MiqQueue.count).to eq(2)
     q = MiqQueue.where(:state => 'ready').first
     expect(q[:server_guid]).to be_nil
-    expect(YAML.load(q.args.first[:ae_state_data])).to eq(ae_state_data)
+    expect(YAML.safe_load(q.args.first[:ae_state_data])).to eq(ae_state_data)
   end
 end

--- a/spec/engine/miq_ae_state_machine_retry_spec.rb
+++ b/spec/engine/miq_ae_state_machine_retry_spec.rb
@@ -269,4 +269,17 @@ describe "MiqAeStateMachineRetry" do
     q = MiqQueue.where(:state => 'ready').first
     expect(q[:server_guid]).to be_nil
   end
+
+  it "it can preserve old state data" do
+    ae_state_data = {'old' => 1}
+    setup_model(retry_script)
+    send_ae_request_via_queue(@automate_args.merge(:ae_state_data => ae_state_data.to_yaml))
+    status, _message, ws = deliver_ae_request_from_queue
+    expect(status).not_to eq(MiqQueue::STATUS_ERROR)
+    expect(ws).not_to be_nil
+    expect(MiqQueue.count).to eq(2)
+    q = MiqQueue.where(:state => 'ready').first
+    expect(q[:server_guid]).to be_nil
+    expect(YAML.load(q.args.first[:ae_state_data])).to eq(ae_state_data)
+  end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1625047

The ansible playbook was one of the first times we have cared
about what is in the ae_state_data, the playbook method clears out
the key ae_state_data fields regarding the automate_workspace and
the taskid that was used to track the playbook on a completion of the
playbook (either with 'ok' or 'retry'). Since the stale state data
wasn't being cleared the playbook wasn't getting successfully launched
on a retry and would bail looking for stale automate workspaces.