### PR TITLE
[WIP] Fixing ae_method calls for miq_ae_service_generic_object

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
@@ -28,8 +28,7 @@ module MiqAeMethodService
     def method_missing(method_name, *args)
       ae_user_identity unless @ae_user
       args = convert_params_to_ar_model(args)
-      results = object_send(method_name, *args)
-      wrap_results(results)
+      wrap_results(@object.go_send(method_name, *args))
     end
 
     def convert_params_to_ar_model(args)


### PR DESCRIPTION
Purpose
---------------------
Fix for calling the user specified methods on service models for `generic_object`(GO) with the name from native built-in `ative_record` methods. We are changing the method call priority and making the GO to call custom methods at the first place and then native built-in methods. This is provided by calling the new method `go_send` from GO model inside the `method_missing` method.

This PR is based on https://bugzilla.redhat.com/show_bug.cgi?id=1607940 and it also depends on https://github.com/ManageIQ/manageiq/pull/18149.