### PR TITLE
[WIP]delete_state_var method for MiqAeService.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -84,6 +84,10 @@ module MiqAeMethodService
       @persist_state_hash[name]
     end
 
+    def delete_state_var(name)
+      @persist_state_hash.delete(name)
+    end
+
     def prepend_namespace=(ns)
       @workspace.prepend_namespace = ns
     end

--- a/spec/miq_ae_service_spec.rb
+++ b/spec/miq_ae_service_spec.rb
@@ -89,6 +89,14 @@ describe MiqAeMethodService::MiqAeService do
       end
     end
 
+    it 'sets, gets and removes state_var' do
+      allow(workspace).to receive(:disable_rbac)
+      miq_ae_service.set_state_var('name', 'value')
+      expect(miq_ae_service.get_state_var('name')).to(eq('value'))
+      miq_ae_service.delete_state_var('name')
+      expect(miq_ae_service.get_state_var('name')).to(eq(nil))
+    end
+
     it "loads cloud networks" do
       allow(workspace).to receive(:disable_rbac)
       items = %w(


### PR DESCRIPTION
Adding the method for removing a state_var field from an instance variable `@persist_state_hash` inside the MiqAeService object.