### PR TITLE
Clean up the password field and value in automate and evm.log

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -8,9 +8,9 @@ module MiqAeEngine
   DEFAULT_ATTRIBUTES = %w( User::user MiqServer::miq_server object_name )
 
   def self.instantiate(uri, user)
-    $miq_ae_logger.info("MiqAeEngine: Instantiating Workspace for URI=#{uri}")
+    $miq_ae_logger.info("MiqAeEngine: Instantiating Workspace for URI=#{MiqPassword.sanitize_string(uri)}")
     workspace, t = Benchmark.realtime_block(:total_time) { MiqAeWorkspaceRuntime.instantiate(uri, user) }
-    $miq_ae_logger.info("MiqAeEngine: Instantiating Workspace for URI=#{uri}...Complete - Counts: #{format_benchmark_counts(t)}, Timings: #{format_benchmark_times(t)}")
+    $miq_ae_logger.info("MiqAeEngine: Instantiating Workspace for URI=#{MiqPassword.sanitize_string(uri)}...Complete - Counts: #{format_benchmark_counts(t)}, Timings: #{format_benchmark_times(t)}")
     workspace
   end
 
@@ -78,7 +78,7 @@ module MiqAeEngine
     begin
       miq_task&.state_active
       object_name = "#{options[:object_type]}.#{options[:object_id]}"
-      _log.info("Delivering #{options[:attrs].inspect} for object [#{object_name}] with state [#{state}] to Automate")
+      _log.info("Delivering #{MiqPassword.sanitize_string(options[:attrs].inspect)} for object [#{object_name}] with state [#{state}] to Automate")
       automate_attrs = automate_attrs_from_options(options)
 
       if options[:object_type]
@@ -92,7 +92,7 @@ module MiqAeEngine
       ws  = resolve_automation_object(uri, user_obj)
 
       if ws.nil? || ws.root.nil?
-        message = "Error delivering #{options[:attrs].inspect} for object [#{object_name}] with state [#{state}] to Automate: Empty Workspace"
+        message = "Error delivering #{MiqPassword.sanitize_string(options[:attrs].inspect)} for object [#{object_name}] with state [#{state}] to Automate: Empty Workspace"
         _log.error(message)
         return nil
       end
@@ -105,7 +105,7 @@ module MiqAeEngine
           deliver_on = Time.now.utc + ae_retry_interval
           change_options_by_ws(options, ws)
 
-          message = "Requeuing #{options.inspect} for object [#{object_name}] with state [#{options[:state]}] to Automate for delivery in [#{ae_retry_interval}] seconds"
+          message = "Requeuing #{MiqPassword.sanitize_string(options.inspect)} for object [#{object_name}] with state [#{options[:state]}] to Automate for delivery in [#{ae_retry_interval}] seconds"
           _log.info(message)
           queue_options = {:deliver_on => deliver_on}
           queue_options[:server_guid] = MiqServer.my_guid if ws.root['ae_retry_server_affinity']

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
@@ -57,7 +57,7 @@ module MiqAeEngine
       if matching_domain
         parts[0]   = matching_domain
         updated_ns = parts.join('/')
-        $miq_ae_logger.info("Updated namespace [#{uri}  #{updated_ns}]")
+        $miq_ae_logger.info("Updated namespace [#{MiqPassword.sanitize_string(uri)}  #{updated_ns}]")
       end
       updated_ns
     end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -271,7 +271,7 @@ module MiqAeEngine
       if args_key.include?(CLASS_SEPARATOR)
         key, klass = get_key_name_and_klass_from_key(args_key)
         value = args.delete(args_key)
-        args["#{key}_id"] = value unless @attributes.key?(key)
+        args["#{key}_id"] = value if attribute_for_vmdb_object?(klass, value) && !@attributes.key?(key)
         args[key] = MiqAeObject.convert_value_based_on_datatype(value, klass)
       else
         args[args_key.downcase] = args.delete(args_key) if args_key != args_key.downcase
@@ -853,6 +853,10 @@ module MiqAeEngine
       else
         return self[value]
       end
+    end
+
+    def attribute_for_vmdb_object?(klass, value)
+      klass.safe_constantize && value.to_i.nonzero?
     end
   end
 end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -96,7 +96,7 @@ module MiqAeEngine
     end
 
     def instantiate(uri, user, root = nil)
-      $miq_ae_logger.info("Instantiating [#{uri}]") if root.nil?
+      $miq_ae_logger.info("Instantiating [#{MiqPassword.sanitize_string(uri)}]") if root.nil?
       @ae_user = user
       @dom_search.ae_user = user
       scheme, userinfo, host, port, registry, path, opaque, query, fragment = MiqAeUri.split(uri, "miqaedb")

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -69,7 +69,7 @@ module MiqAeMethodService
 
     def log(level, msg)
       Thread.current["tracking_label"] = @tracking_label
-      $miq_ae_logger.send(level, "<AEMethod #{current_method}> #{msg}")
+      $miq_ae_logger.send(level, "<AEMethod #{current_method}> #{MiqPassword.sanitize_string(msg)}")
     end
 
     def set_state_var(name, value)


### PR DESCRIPTION
Hide password values in automate.log and evm.log.
Add "_id" attribute only for VMDB objects.

Depends on https://github.com/ManageIQ/manageiq-gems-pending/pull/373.
Includes https://github.com/ManageIQ/manageiq/pull/17986.

https://bugzilla.redhat.com/show_bug.cgi?id=1619385

@miq-bot add_label bug, gaprindashvili/yes