### PR TITLE
Exposes cancelation status to client side

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
@@ -13,6 +13,9 @@ module MiqAeMethodService
     expose :approve,   :override_return => true
     expose :deny,      :override_return => true
     expose :pending,   :override_return => true
+    expose :cancel_requested?
+    expose :canceling?
+    expose :canceled?
 
     # For backward compatibility
     def miq_request

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_request_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_request_task.rb
@@ -10,6 +10,10 @@ module MiqAeMethodService
     expose :source,            :association => true
     expose :destination,       :association => true
     expose :tenant,            :association => true
+    expose :cancel_requested?
+    expose :canceling?
+    expose :canceled?
+
     undef :phase_context
 
     def message=(msg)


### PR DESCRIPTION
Exposes the `cancelation_status` of MIQ request/task to outside.

The `cancelation_status` is added in PR:
https://github.com/ManageIQ/manageiq/pull/17825