### PR TITLE
Patch DRb to prevent protocols other than UNIX

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
@@ -36,6 +36,8 @@ module MiqAeEngine
 
     def setup
       require 'drb/timeridconv'
+      require_relative 'miq_ae_drb_patches'
+
       global_id_conv = DRb::TimerIdConv.new(drb_cache_timeout)
       drb_front = MiqAeMethodService::MiqAeServiceFront.new(@workspace)
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_drb_patches.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_drb_patches.rb
@@ -1,0 +1,19 @@
+require "drb/drb"
+require "drb/unix"
+
+# We are only interested in using UNIX Sockets, but the "feature" of looping
+# through all available protocols leads to issues where the default, TCP socket
+# is tried when a UNIX socket should be used.
+#
+# To prevent this we override the default protocol from TCP to UNIX and
+# prevent the addition of new protocols by overriding add_protocol.
+module DRb
+  module DRbProtocol
+    @protocol = [DRb::DRbUNIXSocket]
+
+    def add_protocol(_prot)
+      @protocol
+    end
+    module_function :add_protocol
+  end
+end


### PR DESCRIPTION
To prevent the DRbTCPSocket protocol from being used patch
DRb::DRbProtocol to change the default to DRbUNIXSocket and prevent
add_protocol from being able to add other protocols.