### PR TITLE
Add some helper methods for MiqAeObject.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_object_common.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_object_common.rb
@@ -29,6 +29,14 @@ module MiqAeMethodService
       MiqAePassword.decrypt_if_password(@object[attr.downcase])
     end
 
+    def encrypted?(attr)
+      @object[attr.downcase].class == MiqAePassword
+    end
+
+    def encrypted_string(attr)
+      @object[attr.downcase].encStr if encrypted?(attr)
+    end
+
     def current_field_name
       @object.current_field_name
     end

--- a/spec/engine/miq_ae_method_service/miq_ae_service_object_common_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_object_common_spec.rb
@@ -1,0 +1,44 @@
+describe MiqAeMethodService::MiqAeServiceObjectCommon do
+  let(:wrapper_class) do
+    Class.new do
+      include MiqAeMethodService::MiqAeServiceObjectCommon
+      def initialize(hash = {})
+        @object = Spec::Support::MiqAeMockObject.new(hash)
+      end
+    end
+  end
+
+  let(:test_hash) { {} }
+  let(:wrapper) { wrapper_class.new(test_hash) }
+
+  describe "#attributes" do
+    context "password fields" do
+      let(:test_hash) do
+        { 'fred'   => MiqAePassword.new("wilma") }
+      end
+
+      it "#attributes" do
+        enc_hash = {'fred' => MiqPassword::MASK, 'barney' => 'betty' }
+
+        wrapper['barney'] = 'betty'
+        expect(wrapper.attributes).to eq(enc_hash)
+      end
+
+      it "#decrypt" do
+        expect(wrapper.decrypt('fred')).to eq('wilma')
+      end
+
+      it "#[]" do
+        expect(wrapper['fred']).to eq(MiqPassword::MASK)
+      end
+
+      it "#encrypted?" do
+        expect(wrapper.encrypted?('fred')).to be true
+      end
+
+      it "#encrypted_string" do
+        expect(wrapper.encrypted_string('fred')).to eq(test_hash['fred'].encStr)
+      end
+    end
+  end
+end


### PR DESCRIPTION
These methods will be used by ```OrderAnsiblePlaybook``` method when an ansible playbook service is called via custom button.

Blocks https://github.com/ManageIQ/manageiq-content/pull/435.

https://bugzilla.redhat.com/show_bug.cgi?id=1602883

@miq-bot add_label bug, gaprindashvili/yes, hammer/yes