### PR TITLE
Remove check for nil zone during MiqQueue.put of GenericMailer

### DIFF
--- a/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
@@ -51,8 +51,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
         :class_name  => 'GenericMailer',
         :method_name => "deliver",
         :args        => [:automation_notification, options],
-        :role        => "notifier",
-        :zone        => nil
+        :role        => "notifier"
       ).once
       ae_object = invoke_ae.root(@ae_result_key)
       expect(ae_object).to be_truthy


### PR DESCRIPTION
Required after changes from PR https://github.com/ManageIQ/manageiq/pull/18041 

https://bugzilla.redhat.com/show_bug.cgi?id=1629945