### PR TITLE
Add orch stack retire task to vendor detect

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -216,7 +216,7 @@ module MiqAeEngine
     def self.detect_vendor(src_obj, attr)
       return unless src_obj
       case attr
-      when "orchestration_stack"
+      when "orchestration_stack", "orchestration_stack_retire_task"
         src_obj.ext_management_system.try(:provider_name)
       when "miq_request", "miq_provision", "vm_migrate_task"
         src_obj.source.try(:provider_name)


### PR DESCRIPTION
The vendor_detect method needs to be aware of orch stack retirement tasks, otherwise evm root thinks that it has an ```orchestrationstack```


The original bug is here: https://bugzilla.redhat.com/show_bug.cgi?id=1632239

## related
https://github.com/ManageIQ/manageiq-content/pull/437
https://github.com/ManageIQ/manageiq-automation_engine/pull/238
https://github.com/ManageIQ/manageiq-providers-vmware/pull/324
