### PR TITLE
Remove unneeded calls to stub_server_configuration

### DIFF
--- a/spec/service_models/miq_ae_service_tenant_quota_spec.rb
+++ b/spec/service_models/miq_ae_service_tenant_quota_spec.rb
@@ -1,5 +1,4 @@
 describe MiqAeMethodService::MiqAeServiceTenantQuota do
-  let(:settings)  { {} }
   let(:default_tenant) { Tenant.seed && Tenant.default_tenant }
   let(:tenant) { Tenant.create!(:name => 'fred', :domain => 'a.b', :parent => default_tenant) }
   let(:cpu_quota) { TenantQuota.create(:name => "cpu_allocated", :unit => "int", :value => 2, :tenant => tenant) }
@@ -7,10 +6,6 @@ describe MiqAeMethodService::MiqAeServiceTenantQuota do
 
   let(:st_cpu_quota) { MiqAeMethodService::MiqAeServiceTenantQuota.find(cpu_quota.id) }
   let(:st_storage_quota) { MiqAeMethodService::MiqAeServiceTenantQuota.find(storage_quota.id) }
-
-  before do
-    stub_server_configuration(settings)
-  end
 
   it "check max_cpu quota" do
     expect(st_cpu_quota.name).to eq('cpu_allocated')

--- a/spec/service_models/miq_ae_service_tenant_spec.rb
+++ b/spec/service_models/miq_ae_service_tenant_spec.rb
@@ -1,12 +1,7 @@
 describe MiqAeMethodService::MiqAeServiceTenant do
-  let(:settings) { {} }
   let(:tenant) { FactoryGirl.create(:tenant, :name => 'fred', :domain => 'a.b', :description => "Krueger") }
 
   let(:service_tenant) { MiqAeMethodService::MiqAeServiceTenant.find(tenant.id) }
-
-  before do
-    stub_server_configuration(settings)
-  end
 
   it "#name" do
     expect(service_tenant.name).to eq('fred')


### PR DESCRIPTION
Call was removed in https://github.com/ManageIQ/manageiq/pull/17970

Should get tests on master branch back to green.