### PR TITLE
Expose ConversionHost and ServiceTemplateTransformationPlanTask methods

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_conversion_host.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_conversion_host.rb
@@ -1,0 +1,9 @@
+module MiqAeMethodService
+  class MiqAeServiceServiceConversionHost < MiqAeServiceModelBase
+    expose :active_tasks
+    expose :eligible?
+    expose :check_conversion_host_role
+    expose :enable_conversion_host_role
+    expose :disable_conversion_host_role
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
@@ -6,6 +6,21 @@ module MiqAeMethodService
     expose :mark_vm_migrated
     expose :canceling
     expose :canceled
+    expose :preflight_check
+    expose :source_cluster
+    expose :destination_cluster
+    expose :source_ems
+    expose :destination_ems
+    expose :transformation_type
+    expose :virtv2v_disks
+    expose :network_mappings
+    expose :destination_flavor
+    expose :destination_security_group
+    expose :conversion_host
+    expose :conversion_options
+    expose :run_conversion
+    expose :get_conversion_state
+    expose :kill_virtv2v
 
     def transformation_destination(source_obj)
       ar_method do


### PR DESCRIPTION
This PR aims at exposing methods created in [ManageIQ/manageiq#18033](https://github.com/ManageIQ/manageiq/pull/18033) and [ManageIQ/manageiq#18064/](https://github.com/ManageIQ/manageiq/pull/18064/).

Depends on:

- [ManageIQ/manageiq#18033](https://github.com/ManageIQ/manageiq/pull/18033)
- [ManageIQ/manageiq#18064/](https://github.com/ManageIQ/manageiq/pull/18064/)

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1634029