### PR TITLE
Take out detect vendor changes for orch stack retire tasks

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -216,7 +216,7 @@ module MiqAeEngine
     def self.detect_vendor(src_obj, attr)
       return unless src_obj
       case attr
-      when "orchestration_stack", "orchestration_stack_retire_task"
+      when "orchestration_stack"
         src_obj.ext_management_system.try(:provider_name)
       when "miq_request", "miq_provision", "vm_migrate_task"
         src_obj.source.try(:provider_name)


### PR DESCRIPTION
This isn't necessary due to the change made in https://github.com/ManageIQ/manageiq/pull/18084/files. If we're formatting the automation attributes correctly when deliver_to_automate is run on an orchestration stack, finding the orchestration stack's vendor will work.

It's a revert of https://github.com/ManageIQ/manageiq-automation_engine/pull/242

and is associated with this fun:  https://bugzilla.redhat.com/show_bug.cgi?id=1632239