### PR TITLE
[WIP] convert_value_based_on_datatype won't take args unless they're downcase

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -282,7 +282,7 @@ module MiqAeEngine
       objects_str.split(',').collect do |element|
         if element.include?(CLASS_SEPARATOR)
           klass, str_value = element.split(CLASS_SEPARATOR)
-          MiqAeObject.convert_value_based_on_datatype(str_value.strip, klass.strip)
+          MiqAeObject.convert_value_based_on_datatype(str_value.strip, klass.strip.downcase)
         else
           element.presence
         end
@@ -567,7 +567,7 @@ module MiqAeEngine
       if datatype &&
          (service_model = "MiqAeMethodService::MiqAeService#{SM_LOOKUP[datatype]}".safe_constantize)
         return service_model.find(value)
-      end
+      end 
 
       (raise MiqAeException::InvalidClass unless MiqAeField.available_datatypes.include?(datatype)) if datatype
 


### PR DESCRIPTION
We call automate with the array of objects that a custom button is run on, which looks something like this: ```Integer::ID``` and ... integer needs to be downcased so it doesn't hit https://github.com/ManageIQ/manageiq-automation_engine/blob/f294b5636db07acfea58391230a7e8e41be73b1b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb#L572 and barf. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1628224