### PR TITLE
Fix class name for conversion host

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_conversion_host.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_conversion_host.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceServiceConversionHost < MiqAeServiceModelBase
+  class MiqAeServiceConversionHost < MiqAeServiceModelBase
     expose :active_tasks
     expose :eligible?
     expose :check_conversion_host_role


### PR DESCRIPTION
The class name contains `Service` twice. This PR fixes it.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1634029