### PR TITLE
Add conversion_host= method to MiqAeServiceServiceTemplateTransformationPlanTask

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
@@ -31,8 +31,8 @@ module MiqAeMethodService
     def conversion_host=(conversion_host)
       raise ArgumentError, "conversion_host must be nil or a MiqAeServiceConversionHost" unless conversion_host.nil? || conversion_host.kind_of?(MiqAeMethodService::MiqAeServiceConversionHost)
       ar_method do
-        return wrap_results(@object.conversion_host = nil) if conversion_host.nil?
-        @object.conversion_host = ConversionHost.find_by(:id => conversion_host.id)
+        conversion_host = ConversionHost.find_by(:id => conversion_host.id) if conversion_host
+        @object.conversion_host = conversion_host
         @object.save
       end
     end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
@@ -29,7 +29,7 @@ module MiqAeMethodService
     end
 
     def conversion_host=(conversion_host)
-      raise ArgumentError, "conversion_host must be a MiqAeServiceConversionHost" unless conversion_host.kind_of?(MiqAeMethodService::MiqAeServiceConversionHost)
+      raise ArgumentError, "conversion_host must be nil or a MiqAeServiceConversionHost" unless conversion_host.nil? || conversion_host.kind_of?(MiqAeMethodService::MiqAeServiceConversionHost)
       ar_method { wrap_results(@object.conversion_host = ConversionHost.find(conversion_host.id)) }
     end
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
@@ -27,5 +27,15 @@ module MiqAeMethodService
         wrap_results(@object.transformation_destination(source_obj.object_class.find(source_obj.id)))
       end
     end
+
+    def conversion_host=(conversion_host)
+      raise ArgumentError, "conversion_host must be nil or a MiqAeServiceConversionHost" unless conversion_host.nil? || conversion_host.kind_of?(MiqAeMethodService::MiqAeServiceConversionHost)
+
+      ar_method do
+        @object.conversion_host = conversion_host && conversion_host.instance_variable_get("@object")
+        _log.info "Setting Conversion Host on #{@object.class.name} id:<#{@object.id}> to #{@object.conversion_host.inspect}"
+        @object.save
+      end 
+    end 
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
@@ -31,6 +31,6 @@ module MiqAeMethodService
     def conversion_host=(conversion_host)
       raise ArgumentError, "conversion_host must be a MiqAeServiceConversionHost" unless conversion_host.kind_of?(MiqAeMethodService::MiqAeServiceConversionHost)
       ar_method { wrap_results(@object.conversion_host = ConversionHost.find(conversion_host.id)) }
-    end 
+    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
@@ -29,13 +29,8 @@ module MiqAeMethodService
     end
 
     def conversion_host=(conversion_host)
-      raise ArgumentError, "conversion_host must be nil or a MiqAeServiceConversionHost" unless conversion_host.nil? || conversion_host.kind_of?(MiqAeMethodService::MiqAeServiceConversionHost)
-
-      ar_method do
-        @object.conversion_host = conversion_host && conversion_host.instance_variable_get("@object")
-        _log.info "Setting Conversion Host on #{@object.class.name} id:<#{@object.id}> to #{@object.conversion_host.inspect}"
-        @object.save
-      end 
+      raise ArgumentError, "conversion_host must be a MiqAeServiceConversionHost" unless conversion_host.kind_of?(MiqAeMethodService::MiqAeServiceConversionHost)
+      ar_method { wrap_results(@object.conversion_host = ConversionHost.find(conversion_host.id)) }
     end 
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
@@ -30,7 +30,11 @@ module MiqAeMethodService
 
     def conversion_host=(conversion_host)
       raise ArgumentError, "conversion_host must be nil or a MiqAeServiceConversionHost" unless conversion_host.nil? || conversion_host.kind_of?(MiqAeMethodService::MiqAeServiceConversionHost)
-      ar_method { wrap_results(@object.conversion_host = ConversionHost.find(conversion_host.id)) }
+      ar_method do
+        return wrap_results(@object.conversion_host = nil) if conversion_host.nil?
+        @object.conversion_host = ConversionHost.find_by(:id => conversion_host.id)
+        @object.save
+      end
     end
   end
 end

--- a/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 describe MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask do
   let(:user) { FactoryGirl.create(:user_with_group) }
   let(:task) { FactoryGirl.create(:service_template_transformation_plan_task) }

--- a/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
@@ -1,6 +1,5 @@
 describe MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask do
   let(:conversion_host_1) { FactoryGirl.create(:conversion_host) }
-  let(:service_conversion_host_1) { MiqAeMethodService::MiqAeServiceConversionHost.find(conversion_host_1.id) }
   let(:conversion_host_2) { FactoryGirl.create(:conversion_host) }
   let(:service_conversion_host_2) { MiqAeMethodService::MiqAeServiceConversionHost.find(conversion_host_2.id) }
   let(:task) { FactoryGirl.create(:service_template_transformation_plan_task, :conversion_host => conversion_host_1) }

--- a/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
@@ -6,7 +6,7 @@ describe MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask d
 
   before(:each) do
     Spec::Support::MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM', 'AUTOMATE', 'test1', 'test')
-    @ae_method     = ::MiqAeMethod.first
+    @ae_method = ::MiqAeMethod.first
   end
 
   def invoke_ae

--- a/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
@@ -1,0 +1,36 @@
+require 'byebug'
+
+describe MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask do
+  let(:user) { FactoryGirl.create(:user_with_group) }
+  let(:task) { FactoryGirl.create(:service_template_transformation_plan_task) }
+
+  before(:each) do
+    Spec::Support::MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM', 'AUTOMATE', 'test1', 'test')
+    @ae_method     = ::MiqAeMethod.first
+  end
+
+  def invoke_ae
+    MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?ServiceTemplateTransformationPlanTask::service_template_transformation_plan_task=#{task.id}", user)
+  end
+
+  describe "#conversion_host=" do
+    before(:each) do
+      @conversion_host = FactoryGirl.create(:conversion_host)
+    end
+
+    it "removes the conversion host if arg is nil" do
+      task.conversion_host = @conversion_host
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_transformation_plan_task'].conversion_host = nil"
+      @ae_method.update_attributes(:data => method)
+      invoke_ae
+      expect(task.reload.conversion_host).to be_nil
+    end
+
+    it "sets the conversion host if arg is not nil" do
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_transformation_plan_task'].conversion_host = $evm.vmdb('conversion_host').first"
+      @ae_method.update_attributes(:data => method)
+      invoke_ae
+      expect(task.reload.conversion_host).to eq(@conversion_host)
+    end
+  end
+end

--- a/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
@@ -1,34 +1,20 @@
 describe MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask do
-  let(:user) { FactoryGirl.create(:user_with_group) }
-  let(:task) { FactoryGirl.create(:service_template_transformation_plan_task) }
-
-  before(:each) do
-    Spec::Support::MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM', 'AUTOMATE', 'test1', 'test')
-    @ae_method = ::MiqAeMethod.first
-  end
-
-  def invoke_ae
-    MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?ServiceTemplateTransformationPlanTask::service_template_transformation_plan_task=#{task.id}", user)
-  end
+  let(:conversion_host_1) { FactoryGirl.create(:conversion_host) }
+  let(:service_conversion_host_1) { MiqAeMethodService::MiqAeServiceConversionHost.find(conversion_host_1.id) }
+  let(:conversion_host_2) { FactoryGirl.create(:conversion_host) }
+  let(:service_conversion_host_2) { MiqAeMethodService::MiqAeServiceConversionHost.find(conversion_host_2.id) }
+  let(:task) { FactoryGirl.create(:service_template_transformation_plan_task, :conversion_host => conversion_host_1) }
+  let(:service_task) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask.find(task.id) }
 
   describe "#conversion_host=" do
-    before(:each) do
-      @conversion_host = FactoryGirl.create(:conversion_host)
-    end
-
     it "removes the conversion host if arg is nil" do
-      task.conversion_host = @conversion_host
-      method = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_transformation_plan_task'].conversion_host = nil"
-      @ae_method.update_attributes(:data => method)
-      invoke_ae
+      service_task.conversion_host = nil
       expect(task.reload.conversion_host).to be_nil
     end
 
     it "sets the conversion host if arg is not nil" do
-      method = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_transformation_plan_task'].conversion_host = $evm.vmdb('conversion_host').first"
-      @ae_method.update_attributes(:data => method)
-      invoke_ae
-      expect(task.reload.conversion_host).to eq(@conversion_host)
+      service_task.conversion_host = service_conversion_host_2
+      expect(task.reload.conversion_host).to eq(conversion_host_2)
     end
   end
 end


### PR DESCRIPTION
This PR adds a `conversion_host=` method to allow setting the conversion host of a task from Automate.

Associated RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1634029