### PR TITLE
Adjust Travis postgresql from 9.4 to 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - RUBY_GC_HEAP_INIT_SLOTS=600000
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 addons:
-  postgresql: '9.4'
+  postgresql: '9.5'
 install: bin/setup
 after_script: bundle exec codeclimate-test-reporter
 after_failure:


### PR DESCRIPTION
From 9.4 to 9.5 to fix test failures.