### PR TITLE
convert_value_based_on_datatype won't take "Integer" 

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -559,7 +559,7 @@ module MiqAeEngine
       return false                                           if datatype == 'FalseClass'
       return Time.parse(value)                               if datatype == 'time' || datatype == 'Time'
       return value.to_sym                                    if datatype == 'symbol' || datatype == 'Symbol'
-      return value.to_i                                      if datatype == 'integer' || datatype == 'Fixnum'
+      return value.to_i                                      if %w(integer Integer Fixnum).include?(datatype)
       return value.to_f                                      if datatype == 'float' || datatype == 'Float'
       return value.gsub(/[\[\]]/, '').strip.split(/\s*,\s*/)  if datatype == 'array' && value.class == String
       return decrypt_password(value) if datatype == 'password'

--- a/spec/miq_ae_object_spec.rb
+++ b/spec/miq_ae_object_spec.rb
@@ -316,4 +316,10 @@ describe MiqAeEngine::MiqAeObject do
       end.to raise_exception(MiqPassword::MiqPasswordError)
     end
   end
+
+  context "integer" do
+    it "returns value to_i" do
+      %w(Integer integer Fixnum).each { |type| expect(described_class.convert_value_based_on_datatype("45", type)).to eq(45) }
+    end
+  end
 end


### PR DESCRIPTION
This is the last PR I need to fix https://bugzilla.redhat.com/show_bug.cgi?id=1628224. Custom Buttons on multiple objects aren't being run because the engine won't take "Integer" ... which I think it should. This hackiness seems to be the convention for Time and Symbol. 


## related
already merged ~~https://github.com/ManageIQ/manageiq/pull/18056~~