### PR TITLE
[WIP] Fix an issue with uninitialized constant ManageIQ::Automate::System::CommonMethods.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -242,6 +242,7 @@ module MiqAeEngine
     def self.bodies_and_line_numbers(obj, aem)
       embeds = []
       embedded_methods(obj.workspace, aem, embeds, aem.fqname)
+      embeds.reverse!
       embeds << {:data => aem.data, :fqname => aem.fqname}
       code_start = 0
       script_info = {}

--- a/spec/engine/miq_ae_method_spec.rb
+++ b/spec/engine/miq_ae_method_spec.rb
@@ -259,6 +259,7 @@ describe MiqAeEngine::MiqAeMethod do
               Level3.log_me
             end
           end
+          Level3.log_me
         RUBY
       end
       let(:level2_embeds) { ['/Shared/Methods/Level3'] }


### PR DESCRIPTION
Fix an issue with uninitialized constant ManageIQ::Automate::System::CommonMethods when an automate method calls /System/Request/InspectMe as an embedded method.

The error was thrown out because InspectMe ran methods on /System/CommonMethods/Utils/LogObject before the class was loaded.

@miq-bot add_label bug