### PR TITLE
Adding a domain lock check for automate import.

### DIFF
--- a/app/models/miq_ae_yaml_import.rb
+++ b/app/models/miq_ae_yaml_import.rb
@@ -15,6 +15,9 @@ class MiqAeYamlImport
   def import
     if @options.key?('import_dir') && !File.directory?(@options['import_dir'])
       raise MiqAeException::DirectoryNotFound, "Directory [#{@options['import_dir']}] not found"
+    elsif !User.current_user.nil? && @options['zip_file'] && domain_locked?(@options['import_as'])
+      # raises exception only for a local import into the locked domain
+      raise MiqAeException::DomainNotAccessible, 'locked domain'
     end
     start_import(@options['preview'], @domain_name)
   end
@@ -246,5 +249,11 @@ class MiqAeYamlImport
     return if domain_obj.name.downcase == MiqAeDatastore::MANAGEIQ_DOMAIN.downcase
     attrs = @options.slice('enabled', 'source')
     domain_obj.update_attributes(attrs) unless attrs.empty?
+  end
+
+  private
+
+  def domain_locked?(domain_name)
+    MiqAeDomain.find_by(:name => domain_name)&.contents_locked? ? true : false
   end
 end # class


### PR DESCRIPTION
Removes an option to import into the locked domain in automate with local or git import. This check runs only for enviroment with selected user. If there is no user it means that the import is from the console or bin/update script. This PR is part of the https://github.com/ManageIQ/manageiq-ui-classic/pull/4912.