### PR TITLE
Make disconnect_storage a no-op

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -142,8 +142,9 @@ module MiqAeEngine
       event_object_from_workspace(obj).src_vm_destroy_all_snapshots
     end
 
-    def self.miq_src_vm_disconnect_storage(obj, _inputs)
-      event_object_from_workspace(obj).src_vm_disconnect_storage
+    def self.miq_src_vm_disconnect_storage(_obj, _inputs)
+      # Logic for storage disconnect has been moved to VmOrTemplate#disconnect_inv
+      # This method is kept for compatibility and will be removed in a future version
     end
 
     def self.miq_event_enforce_policy(obj, _inputs)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_ems_event.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_ems_event.rb
@@ -33,7 +33,8 @@ module MiqAeMethodService
     end
 
     def src_vm_disconnect_storage
-      ar_method { @object.src_vm_disconnect_storage }
+      # Logic for storage disconnect has been moved to VmOrTemplate#disconnect_inv
+      # This method is kept for compatibility and will be removed in a future version
     end
   end
 end

--- a/spec/service_models/miq_ae_service_ems_event_spec.rb
+++ b/spec/service_models/miq_ae_service_ems_event_spec.rb
@@ -177,7 +177,7 @@ describe MiqAeMethodService::MiqAeServiceEmsEvent do
   end
 
   it "#src_vm_disconnect_storage" do
-    expect_any_instance_of(VmOrTemplate).to receive("disconnect_storage".to_sym).once
+    expect_any_instance_of(VmOrTemplate).not_to receive("disconnect_storage".to_sym).once
     @service_event.src_vm_disconnect_storage
   end
 end


### PR DESCRIPTION
Disconnect_storage no longer needs to be called from the event_handler
and can be removed.  Making these no-ops for backport.

https://bugzilla.redhat.com/show_bug.cgi?id=1644770