### PR TITLE
Refactoring automate system domain list to include legacy domains

### DIFF
--- a/spec/models/miq_ae_datastore/data/automate_domain_list_tests/not_system/__domain__.yaml
+++ b/spec/models/miq_ae_datastore/data/automate_domain_list_tests/not_system/__domain__.yaml
@@ -1,0 +1,11 @@
+---
+object_type: domain
+version: 1.0
+object:
+  attributes:
+    name: drew_test_not_system
+    description:
+    display_name:
+    system:
+    priority: 100
+    enabled:

--- a/spec/models/miq_ae_datastore/data/automate_domain_list_tests/system/__domain__.yaml
+++ b/spec/models/miq_ae_datastore/data/automate_domain_list_tests/system/__domain__.yaml
@@ -1,0 +1,12 @@
+---
+object_type: domain
+version: 1.0
+object:
+  attributes:
+    name: drew_test_system
+    description:
+    display_name:
+    system: true
+    source: system
+    priority: 100
+    enabled:

--- a/spec/models/miq_ae_datastore_spec.rb
+++ b/spec/models/miq_ae_datastore_spec.rb
@@ -94,8 +94,24 @@ describe MiqAeDatastore do
     expect(MiqAeMethod.count).to         eq(3)
   end
 
-  it ".default_domain_names" do
-    expect(MiqAeDatastore.default_domain_names).to include("ManageIQ")
+  describe ".default_domain_names" do
+    describe "vmdb plugin domains" do
+      it "includes MIQ" do
+        expect(MiqAeDatastore.default_domain_names).to include('ManageIQ')
+      end
+    end
+
+    describe "legacy domains" do
+      it "includes system domain" do
+        stub_const("MiqAeDatastore::DATASTORE_DIRECTORY", ManageIQ::AutomationEngine::Engine.root.join('spec/models/miq_ae_datastore/data/automate_domain_list_tests'))
+        expect(MiqAeDatastore.default_domain_names).to include('drew_test_system')
+      end
+
+      it "doesn't include non-system domain" do
+        stub_const("MiqAeDatastore::DATASTORE_DIRECTORY", ManageIQ::AutomationEngine::Engine.root.join('spec/models/miq_ae_datastore/data/automate_domain_list_tests'))
+        expect(MiqAeDatastore.default_domain_names).not_to include('drew_test_not_system')
+      end
+    end
   end
 
   it "temporary file cleanup for unsuccessful import" do


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1651497. 

We're only currently listing MIQ in the list of domains to be reset, and it should include the RH domain. 

Jason and I and GM discussed pulling out the domain list itself into a separate method. 

The UI call is here: https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/views/miq_ae_tools/_import_export.html.haml#L73.