### PR TITLE
Add resource to conversion_host to pass validation

### DIFF
--- a/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
@@ -1,6 +1,8 @@
 describe MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask do
-  let(:conversion_host_1) { FactoryGirl.create(:conversion_host) }
-  let(:conversion_host_2) { FactoryGirl.create(:conversion_host) }
+  let(:host) { FactoryBot.create(:host) }
+  let(:vm) { FactoryBot.create(:vm_or_template) }
+  let(:conversion_host_1) { FactoryBot.create(:conversion_host, :resource => host) }
+  let(:conversion_host_2) { FactoryBot.create(:conversion_host, :resource => vm) }
   let(:service_conversion_host_2) { MiqAeMethodService::MiqAeServiceConversionHost.find(conversion_host_2.id) }
   let(:task) { FactoryGirl.create(:service_template_transformation_plan_task, :conversion_host => conversion_host_1) }
   let(:service_task) { MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask.find(task.id) }


### PR DESCRIPTION
Fixed spec based on new validations added to `ConversionHost` model in https://github.com/ManageIQ/manageiq/pull/18277

Should fix failing tests.