### PR TITLE
Add helper method #create_job for Ansible Tower Job/Workflow template.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_script.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_script.rb
@@ -1,5 +1,9 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_ConfigurationScript < MiqAeServiceManageIQ_Providers_ExternalAutomationManager_ConfigurationScript
     expose :run
+
+    def create_job(args)
+      ar_method { wrap_results(ManageIQ::Providers::AnsibleTower::AutomationManager::Job.create_job(@object, args)) }
+    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_workflow.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_workflow.rb
@@ -1,5 +1,9 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_ConfigurationWorkflow < MiqAeServiceManageIQ_Providers_ExternalAutomationManager_ConfigurationScript
     expose :run
+
+    def create_job(args)
+      ar_method { wrap_results(ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob.create_job(@object, args)) }
+    end
   end
 end

--- a/spec/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_script_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_script_spec.rb
@@ -6,4 +6,12 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_Automat
   it "#run" do
     expect(described_class.instance_methods).to include(:run)
   end
+
+  it "#create_job" do
+    template = FactoryBot.create(:ansible_configuration_script)
+    svc_template = described_class.find(template.id)
+    expect(ManageIQ::Providers::AnsibleTower::AutomationManager::Job).to receive(:create_job)
+
+    svc_template.create_job({})
+  end
 end

--- a/spec/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_workflow_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_workflow_spec.rb
@@ -6,4 +6,12 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_Automat
   it "#run" do
     expect(described_class.instance_methods).to include(:run)
   end
+
+  it "#create_job" do
+    workflow_template = FactoryBot.create(:configuration_workflow)
+    svc_workflow_template = described_class.find(workflow_template.id)
+    expect(ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob).to receive(:create_job)
+
+    svc_workflow_template.create_job({})
+  end
 end


### PR DESCRIPTION
To run Ansible Tower workflow template from a custom button.

Blocks https://github.com/ManageIQ/manageiq-content/pull/490
https://bugzilla.redhat.com/show_bug.cgi?id=1658172