### PR TITLE
Removing empty option hash from automate method export.

### DIFF
--- a/app/models/miq_ae_yaml_export.rb
+++ b/app/models/miq_ae_yaml_export.rb
@@ -178,12 +178,9 @@ class MiqAeYamlExport
   def write_method_attributes(method_obj, export_file_hash)
     envelope_hash = setup_envelope(method_obj, METHOD_OBJ_TYPE)
     envelope_hash['object']['inputs'] = method_obj.method_inputs
-    if method_obj.location == "inline"
-      envelope_hash['object']['attributes'].delete('data')
-    end
-    if method_obj.embedded_methods.empty?
-      envelope_hash['object']['attributes'].delete('embedded_methods')
-    end
+    envelope_hash['object']['attributes'].delete('data') if method_obj.location == "inline"
+    envelope_hash['object']['attributes'].delete('embedded_methods') if method_obj.embedded_methods.empty?
+    envelope_hash['object']['attributes'].delete('options') if method_obj.options.empty?
     export_file_hash['output_filename'] = "#{method_obj.name}.yaml"
     export_file_hash['export_data']     = envelope_hash.to_yaml
     @counts['method_instances'] += 1

--- a/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -177,14 +177,20 @@ describe MiqAeDatastore do
     end
   end
 
-  context "embeded_methods" do
-    it "if no embedded methods the attribute should be missing" do
+  context "deleting empty attributes from export" do
+    before do
       export_model(@manageiq_domain.name)
       method_file = File.join(@export_dir, @manageiq_domain.name, @aen1.name,
                               "manageiq_test_class_1.class/__methods__/test1.yaml")
-      data = YAML.load_file(method_file)
+      @data = YAML.load_file(method_file)
+    end
 
-      expect(data.fetch_path('object', 'attributes', 'embedded_methods')).to be_nil
+    it "if no options the attribute should be missing" do
+      expect(@data.fetch_path('object', 'attributes', 'options')).to(be_nil)
+    end
+
+    it "if no embedded methods the attribute should be missing" do
+      expect(@data.fetch_path('object', 'attributes', 'embedded_methods')).to(be_nil)
     end
   end
 


### PR DESCRIPTION
Removing empty Option hash inside the method attributes in automate export. 

Fixes #273