### PR TITLE
Don't overwrite message in create_automation_object

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -258,7 +258,6 @@ module MiqAeEngine
     options[:instance_name] = name
 
     options[:attrs] = create_ae_attrs(attrs, name, options[:vmdb_object])
-    options[:message] = options[:attrs][:message]
 
     # uri
     path = MiqAePath.new(:ae_namespace => options[:namespace],

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -281,6 +281,15 @@ describe MiqAeEngine do
       expect(MiqAeEngine.create_automation_object("AUTOMATION", attrs, :vmdb_object => host)).to eq(uri)
     end
 
+    it "has both message from request and message from attrs" do
+      host = FactoryBot.create(:host)
+      message = "request_message"
+      attrs = {"Host::host" => host.id, :message => "attr_message"}
+      extras = "MiqServer%3A%3Amiq_server=#{@miq_server_id}"
+      uri = "/System/Process/AUTOMATION?Host%3A%3Ahost=#{host.id}&#{extras}&message=attr_message&object_name=AUTOMATION&vmdb_object_type=host#request_message"
+      expect(MiqAeEngine.create_automation_object("AUTOMATION", attrs, :vmdb_object => host, :message => message)).to eq(uri)
+    end
+
     it "will process an array of objects" do
       FactoryBot.create(:host)
       hash       = {"hosts" => Host.all}


### PR DESCRIPTION
Creation of a custom button to request call_instance_with_message is overwriting the message in  create_automation_object and we shouldn't do that. We can have one message stored in ```attrs``` and the other in ```options[:message]``` and they are distinct entities and should remain so. This appears to have been wrong for _quite a while_ (https://github.com/ManageIQ/manageiq-automation_engine/commit/9c5233b21455f5cc06af132e67f30c998f149c9b) (and also slightly less relevant but still worth noting, https://github.com/ManageIQ/manageiq/commit/227afe61061296de7d90f743fdf54a9bb0e13232). This worked in most cases because we don't usually have a message attribute in the attr value pairs, just the request message (which defaults to ```create```), so the message in the attrs was nil.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1651099

This is coming back into the edit screen for the button, note the fact that the messages are different, one hasn't been overwritten by the other. 
![screen shot 2019-01-15 at 9 59 36 am](https://user-images.githubusercontent.com/16326669/51188618-502bcc80-18ac-11e9-8f04-ab1c6b10cce8.png)
