### PR TITLE
 Redirect writable_storages to writable_accessible_storages

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_host.rb
@@ -9,7 +9,7 @@ module MiqAeMethodService
 
     expose :storages,              :association => true
     expose :read_only_storages
-    expose :writable_storages
+    expose :writable_storages,                                :method => :writable_accessible_storages
     expose :vms,                   :association => true
     expose :ext_management_system, :association => true
     expose :hardware,              :association => true


### PR DESCRIPTION
"Redirect the existing writable_storages method exposed to automate to call writable_accessible_storages.  This would avoid having to update automate methods to use the new method.  From automate I'm not sure a user would need to distinguish between writable_storages and writable_accessible_storages." - The Estimable Mr Greg McCullough himself

Per https://bugzilla.redhat.com/show_bug.cgi?id=1668020

specs: https://github.com/ManageIQ/manageiq-content/pull/506