### PR TITLE
Don't set User.current_user

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -45,7 +45,10 @@ module MiqAeEngine
     end
 
     def self.instantiate(uri, user, attrs = {})
-      User.current_user = user
+       User.with_user(user) { instantiate_with_user(uri, user, attrs) }
+    end
+
+    def self.instantiate_with_user(uri, user, attrs)
       workspace = MiqAeWorkspaceRuntime.new(attrs)
       self.current = workspace
       workspace.instantiate(uri, user, nil)

--- a/spec/engine/miq_ae_workspace_runtime_spec.rb
+++ b/spec/engine/miq_ae_workspace_runtime_spec.rb
@@ -5,10 +5,9 @@ describe MiqAeEngine::MiqAeWorkspaceRuntime do
     EvmSpecHelper.local_miq_server
   end
 
-  it "sets current_user" do
-    allow_any_instance_of(MiqAeEngine::MiqAeWorkspaceRuntime).to receive(:instantiate)
-    MiqAeEngine::MiqAeWorkspaceRuntime.instantiate("/a/b/c", user)
-
-    expect(User.current_user).to eq(user)
+  describe "#instantiate" do
+    it "returns workspace" do
+      expect(MiqAeEngine::MiqAeWorkspaceRuntime.instantiate("/a/b/c", user)).to be_a_kind_of(MiqAeEngine::MiqAeWorkspaceRuntime) 
+    end
   end
 end


### PR DESCRIPTION
We have three assignments to User.current_user inside this repo and they're problematic because it isn't getting properly reset between threads. We should be using the ```with_user``` block for this. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1671563