### PR TITLE
Update specs to conform to ConversionHost validations

### DIFF
--- a/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
@@ -1,6 +1,7 @@
 describe MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask do
-  let(:host) { FactoryBot.create(:host) }
-  let(:vm) { FactoryBot.create(:vm_or_template) }
+  let(:ems) { FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+  let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
+  let(:vm) { FactoryBot.create(:vm_openstack) }
   let(:conversion_host_1) { FactoryBot.create(:conversion_host, :resource => host) }
   let(:conversion_host_2) { FactoryBot.create(:conversion_host, :resource => vm) }
   let(:service_conversion_host_2) { MiqAeMethodService::MiqAeServiceConversionHost.find(conversion_host_2.id) }


### PR DESCRIPTION
The ConversionHost model added validations in https://github.com/ManageIQ/manageiq/pull/18434 which broke this repo. This PR fixes it.