### PR TITLE
Change Fixnum to Integer

### DIFF
--- a/spec/models/miq_ae_class_copy_spec.rb
+++ b/spec/models/miq_ae_class_copy_spec.rb
@@ -105,7 +105,7 @@ describe MiqAeClassCopy do
       new_ids = [miq_ae_class.id] * ids.length
       expect(miq_ae_class_copy).to receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { miq_ae_class }
       expect(miq_ae_class).to receive(:fqname).with(no_args).exactly(ids.length).times { fqname }
-      expect(MiqAeClass).to receive(:find).with(an_instance_of(Fixnum)).exactly(ids.length).times { miq_ae_class }
+      expect(MiqAeClass).to receive(:find).with(an_instance_of(Integer)).exactly(ids.length).times { miq_ae_class }
       expect(MiqAeClassCopy).to receive(:new).with(anything).exactly(ids.length).times { miq_ae_class_copy }
       expect(MiqAeClassCopy.copy_multiple(ids, domain)).to match_array(new_ids)
     end

--- a/spec/models/miq_ae_instance_copy_spec.rb
+++ b/spec/models/miq_ae_instance_copy_spec.rb
@@ -102,7 +102,7 @@ describe MiqAeInstanceCopy do
       expect(ins_copy).to receive(:to_domain).with(domain, nil, false).exactly(ids.length).times { ins }
       new_ids = [ins.id] * ids.length
       expect(ins).to receive(:fqname).with(no_args).exactly(ids.length).times { fqname }
-      expect(MiqAeInstance).to receive(:find).with(an_instance_of(Fixnum)).exactly(ids.length).times { ins }
+      expect(MiqAeInstance).to receive(:find).with(an_instance_of(Integer)).exactly(ids.length).times { ins }
       expect(MiqAeInstanceCopy).to receive(:new).with(fqname, true).exactly(1).times { ins_copy }
       expect(MiqAeInstanceCopy).to receive(:new).with(fqname, false).exactly(ids.length - 1).times { ins_copy }
       expect(MiqAeInstanceCopy.copy_multiple(ids, domain)).to match_array(new_ids)


### PR DESCRIPTION
This PR fixes a couple warnings I saw when running the full test suite by changing `Fixnum` to `Integer`.