### PR TITLE
Drop 2.3.x from test matrix, add 2.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
 - 2.4.5
-- 2.3.8
+- 2.5.3
 sudo: false
 cache: bundler
 env:


### PR DESCRIPTION
Drop Ruby 2.3.6 from the test matrix and add 2.5.3. All the cool kids are doing it:

https://github.com/ManageIQ/manageiq/blob/master/.travis.yml