### PR TITLE
Ruby 2.5 won't escape tilde as per RFC3986 Section 2.3

### DIFF
--- a/spec/miq_ae_uri_spec.rb
+++ b/spec/miq_ae_uri_spec.rb
@@ -16,9 +16,9 @@ describe MiqAeEngine::MiqAeUri do
   end
 
   it "escape non-ASCII Numeric characters" do
-    hash = {"test://dev?lab$~" => "OU=serverbuildingtest, OU=dev2"}
+    hash = {"test://dev?lab$" => "OU=serverbuildingtest, OU=dev2"}
     query = described_class.hash2query(hash)
-    expect(query).to eq("test%3A%2F%2Fdev%3Flab%24%7E=OU%3Dserverbuildingtest%2C%20OU%3Ddev2")
+    expect(query).to eq("test%3A%2F%2Fdev%3Flab%24=OU%3Dserverbuildingtest%2C%20OU%3Ddev2")
 
     result_hash = described_class.query2hash(query)
     expect(result_hash).to eq(hash)


### PR DESCRIPTION
This landed in ruby 2.5.0:
https://github.com/ruby/ruby/commit/e1b432754553423008a14d39d0901eabc99e7ddb

Hopefully we weren't relying on this because ruby 2.4 will escape ~ but
2.5 will not.

Looks like this was added in this commit back on old pre-manageiq:

```
commit b87b70c826c1e20badf2b9afd25acfa385b54583
Author: Gilly
Date:   Tue Jun 25 17:24:26 2013 -0400

    Fully escape attributes and their values passed to automate.

    hash2query method now escapes both key and value as well as escaping any
    non-alphanumeric.

    Bug 971596, 976901
    Issue #553
```

cc @gmcculloug @bdunne