### PR TITLE
Set current user for exposed methods in automate.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -164,13 +164,17 @@ module MiqAeMethodService
         self.association = method_name if options[:association]
         define_method(method_name) do |*params|
           method = options[:method] || method_name
-          ret = object_send(method, *params)
+          ret = User.with_user(self.class.workspace&.ae_user) { object_send(method, *params) }
           return options[:override_return] if options.key?(:override_return)
           options[:association] ? wrap_results(self.class.filter_objects(ret)) : wrap_results(ret)
         end
       end
     end
     private_class_method :expose
+
+    def self.workspace
+      MiqAeEngine::MiqAeWorkspaceRuntime.current || MiqAeEngine::DrbRemoteInvoker.workspace
+    end
 
     def self.wrap_results(results)
       ar_method do

--- a/spec/service_models/miq_ae_service_service_template_provision_request_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_provision_request_spec.rb
@@ -15,15 +15,26 @@ describe MiqAeMethodService::MiqAeServiceServiceTemplateProvisionRequest do
     MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?ServiceTemplateProvisionRequest::service_template_provision_request=#{@service_template_provision_request.id}", @user)
   end
 
-  it "#approve" do
-    approver = 'wilma'
-    reason   = "Why Not?"
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_request'].approve('#{approver}', '#{reason}')"
-    @ae_method.update_attributes(:data => method)
-    expect(MiqRequest).to receive(:find).with(@service_template_provision_request.id.to_s)
-      .and_return(@service_template_provision_request)
-    expect(@service_template_provision_request).to receive(:approve).with(approver, reason).once
-    expect(invoke_ae.root(@ae_result_key)).to be_truthy
+  context "#approve" do
+    it "gets called by method" do
+      approver = 'wilma'
+      reason   = "Why Not?"
+      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_request'].approve('#{approver}', '#{reason}')"
+      @ae_method.update_attributes(:data => method)
+      expect(MiqRequest).to receive(:find).with(@service_template_provision_request.id.to_s).and_return(@service_template_provision_request)
+      expect(@service_template_provision_request).to receive(:approve).with(approver, reason).once
+      expect(invoke_ae.root(@ae_result_key)).to be_truthy
+    end
+
+    it "sets current user" do
+      user = FactoryBot.create(:user_with_group)
+      ws = double(:ae_user => user)
+      allow(service_service_template_provision_request.class).to receive(:workspace).and_return(ws)
+      approver = FactoryBot.create(:user_miq_request_approver)
+
+      expect(User).to receive(:with_user).with(user)
+      service_service_template_provision_request.approve(approver, "for test")
+    end
   end
 
   it "#user_message" do


### PR DESCRIPTION
So when the methods run from an automate script, it would have the current user set properly.
 
Followup of https://github.com/ManageIQ/manageiq-automation_engine/pull/293.

Related to https://github.com/ManageIQ/manageiq/pull/18545.