### PR TITLE
MiqAeMethodCopy: fix for broken copy method

### DIFF
--- a/app/models/miq_ae_method_copy.rb
+++ b/app/models/miq_ae_method_copy.rb
@@ -55,6 +55,7 @@ class MiqAeMethodCopy
     validate
     create_method
     @dest_method.inputs << add_inputs
+    @dest_method.options = @src_method.options
     @dest_method.save!
     @dest_method
   end

--- a/spec/models/miq_ae_method_copy_spec.rb
+++ b/spec/models/miq_ae_method_copy_spec.rb
@@ -84,6 +84,32 @@ describe MiqAeMethodCopy do
       method_copy = MiqAeMethodCopy.new(src_fqname).to_domain(@dest_domain, @dest_ns, true)
       expect(method_copy.embedded_methods).to(eq(method.embedded_methods))
     end
+
+    it 'copy playbook method' do
+      method = MiqAeMethod.create(
+        :name             => 'playbook_method',
+        :embedded_methods => [],
+        :class_id         => MiqAeClass.first.id,
+        :scope            => 'instance',
+        :language         => 'ruby',
+        :location         => 'playbook',
+        :options          => {
+          :repository_id       => "23",
+          :playbook_id         => "304",
+          :credential_id       => "10",
+          :vault_credential_id => "",
+          :verbosity           => "1",
+          :cloud_credential_id => "123",
+          :execution_ttl       => "2",
+          :hosts               => "201",
+          :log_output          => "always",
+          :become_enabled      => true
+        }
+      )
+      src_fqname  = "#{@src_domain}/#{@src_ns}/#{@src_class}/#{method.name}"
+      method_copy = MiqAeMethodCopy.new(src_fqname).to_domain(@dest_domain, @dest_ns, true)
+      expect(method_copy.options).to(eq(method.options))
+    end
   end
 
   context 'copy onto itself' do


### PR DESCRIPTION
Adding the missing option hash for a new `MiqAeMethod` created by `MiqAeMethodCopy#copy`. 

Steps for QA:
----------------------
(Option hash is used for playbook attributes)
1) Go to Automation -> Automate -> Explorer
2) Create a new `MiqAeMethod` with the `playbook` type
3) Set some playbook attributes (for example: repository).
4) Save this new method
5) Copy this method

* **old result:** New method with blank playbook attributes
* **new result:** New method with all playbook attributes