### PR TITLE
Physical server provisioning via StateMachine

### DIFF
--- a/spec/engine/miq_ae_builtin_method_spec.rb
+++ b/spec/engine/miq_ae_builtin_method_spec.rb
@@ -16,4 +16,55 @@ describe MiqAeEngine::MiqAeBuiltinMethod do
       expect { subject }.to raise_error(MiqAeException::StopInstantiation)
     end
   end
+
+  describe 'AE entrypoint calculation' do
+    let(:obj)       { double('OBJ', :workspace => workspace) }
+    let(:workspace) { double('WORKSPACE', :root => root) }
+    let(:root)      { {} }
+
+    context '/PhysicalInfrastructure/PhysicalServer/Lifecycle/Provisioning' do
+      before do
+        allow(obj).to receive(:[]).with(anything).and_return(nil)
+        allow(obj).to receive(:[]).with('request').and_return('physical_server_provision')
+      end
+
+      let(:root)           { { 'miq_request' => miq_request, 'physical_server_provision_task' => provision_task } }
+      let(:options)        { { :request_type => 'provision_physical_server' } }
+      let(:miq_request)    { nil }
+      let(:provision_task) { nil }
+
+      context 'when physical_server_provision_request' do
+        before { allow(PhysicalServerProvisionRequest).to receive(:===).with(miq_request).and_return(true) }
+        let(:miq_request) { instance_double('MIQ_REQUEST', :source => nil) }
+
+        it '.miq_parse_provider_category' do
+          expect(root).to receive(:[]=).with('ae_provider_category', described_class::PHYSICAL_INFRA)
+          described_class.miq_parse_provider_category(obj, nil)
+        end
+
+        it '.miq_parse_automation_request' do
+          expect(obj).to receive(:[]=).with('target_component', 'PhysicalServer')
+          expect(obj).to receive(:[]=).with('target_class', 'Lifecycle')
+          expect(obj).to receive(:[]=).with('target_instance', 'Provisioning')
+          described_class.miq_parse_automation_request(obj, nil)
+        end
+      end
+
+      context 'when physical_server_provision_task' do
+        let(:provision_task) { double('MIQ_TASK', 'options' => options, :base_model => PhysicalServerProvisionTask) }
+
+        it '.miq_parse_provider_category' do
+          expect(root).to receive(:[]=).with('ae_provider_category', described_class::PHYSICAL_INFRA)
+          described_class.miq_parse_provider_category(obj, nil)
+        end
+
+        it '.miq_parse_automation_request' do
+          expect(obj).to receive(:[]=).with('target_component', 'PhysicalServer')
+          expect(obj).to receive(:[]=).with('target_class', 'Lifecycle')
+          expect(obj).to receive(:[]=).with('target_instance', 'Provisioning')
+          described_class.miq_parse_automation_request(obj, nil)
+        end
+      end
+    end
+  end
 end

--- a/spec/service_models/miq_ae_service_physical_server_spec.rb
+++ b/spec/service_models/miq_ae_service_physical_server_spec.rb
@@ -1,0 +1,30 @@
+describe MiqAeMethodService::MiqAeServicePhysicalServer do
+  it '#turn_on_loc_led' do
+    expect(described_class.instance_methods).to include(:turn_on_loc_led)
+  end
+
+  it '#turn_off_loc_led' do
+    expect(described_class.instance_methods).to include(:turn_off_loc_led)
+  end
+
+  it '#power_on' do
+    expect(described_class.instance_methods).to include(:power_on)
+  end
+
+  it '#power_off' do
+    expect(described_class.instance_methods).to include(:power_off)
+  end
+
+  describe '#emstype' do
+    before { allow(ems.class).to receive(:ems_type).and_return('THE_EMS_TYPE') }
+
+    let(:server) { FactoryBot.create(:physical_server, :ext_management_system => ems) }
+    let(:ems)    { FactoryBot.create(:ems_physical_infra) }
+
+    subject { MiqAeMethodService::MiqAeServicePhysicalServer.find(server.id) }
+
+    it 'passes on to ems' do
+      expect(subject.emstype).to eq('THE_EMS_TYPE')
+    end
+  end
+end


### PR DESCRIPTION
With this commit we make sure that AE engine calculates correct    entrypoint when PhysicalServer provisioning request is created,     namely:
    
```
PhysicalInfrastructure/PhysicalServer/Lifecycle/Provisioning
```
    
Furthermore, we enhance PhysicalServer AE service model with `ems_type`     method that is used for execution routing inside StateMachine     (i.e. via messages).

Depends on https://github.com/ManageIQ/manageiq/pull/18573
Related to https://github.com/ManageIQ/manageiq-content/pull/516

@miq-bot assign @gmcculloug 
@miq-bot add_label enhancement