### PR TITLE
[HAMMER] Expose switches on hammer infra_managers

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-infra_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-infra_manager.rb
@@ -1,0 +1,5 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_InfraManager < MiqAeServiceManageIQ_Providers_BaseManager
+    expose :switches, :association => true
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_Redhat_InfraManager < MiqAeServiceEmsInfra
+  class MiqAeServiceManageIQ_Providers_Redhat_InfraManager < MiqAeServiceManageIQ_Providers_InfraManager
     expose :supports_vm_import?
     expose :submit_import_vm
     expose :submit_configure_imported_vm_networks


### PR DESCRIPTION
There was a 5.10 RFE for switches to be exposed thru Automate on emses. 

For upstream, we're dynamically generating the models, so we can dynamically generate the associations too, see the work in progress at https://github.com/ManageIQ/manageiq-automation_engine/pull/308. But for hammer we have to do this manually. 

For RFE https://bugzilla.redhat.com/show_bug.cgi?id=1688900
