### PR TITLE
Remove tags from dynamic association creation

### DIFF
--- a/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
@@ -93,6 +93,31 @@ describe MiqAeMethodService::MiqAeServiceModelBase do
       end
     end
   end
+
+  context 'with a VM service model' do
+    let(:service_model) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_InfraManager_Vm }
+
+    describe '.ar_subclass_associations' do
+      it `does not return the tags association` do
+        expect(service_model.ar_model_associations).to_not include(:tags)
+      end
+
+      it `does not include associations from superclass` do
+        expect(service_model.ar_model_associations).to_not include(service_model.superclass.ar_model_associations)
+      end
+    end
+
+    describe '.associations' do
+      it 'does not contain duplicate associations' do
+        associations = service_model.associations
+        expect(associations.count).to eq(associations.uniq.count)
+      end
+
+      it 'does not return the tags associations' do
+        expect(service_model.associations).to_not include(:tags)
+      end
+    end
+  end
 end
 
 module MiqAeServiceModelSpec


### PR DESCRIPTION
Followup PR to https://github.com/ManageIQ/manageiq-automation_engine/pull/308

Tags were previously implemented in the miq_ae_service_model_base.rb different then just a regular association.  See https://github.com/ManageIQ/manageiq-automation_engine/blob/2b67358364e4bf826eb49ee469cf90b5210a3f84/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb#L284-L288

This PR removes the `tags` association from the list so it does not override the method above.

Additionally, it fixes an issue where the `@associations` array was collecting duplicate names since any subclassed model would get the association names from the parent and then apply all the same associations again.  Depending on the depth of the sub-classing this would result in several references to the same association.  For example, a VMware VM contained 4 references to any association that existed in the base `VmOrTemplate` model.

While no tests were failing on this repo there were a number of tests in https://github.com/ManageIQ/manageiq-content:
```
rspec ./spec/automation/unit/method_validation/calculate_limits_spec.rb:34 # Quota Validation limits, using group as quota source
rspec ./spec/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes_spec.rb[1:2:1:2] # ManageIQ::Automate::Transformation::Infrastructure::VM::Common::RestoreVmAttributes restore when source is vmware and destination openstack behaves like restore identity restore tags
rspec ./spec/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes_spec.rb[1:2:1:6] # ManageIQ::Automate::Transformation::Infrastructure::VM::Common::RestoreVmAttributes restore when source is vmware and destination openstack behaves like restore identity restore identity
rspec ./spec/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes_spec.rb[1:1:1:2] # ManageIQ::Automate::Transformation::Infrastructure::VM::Common::RestoreVmAttributes restore when source is vmware and destination redhat behaves like restore identity restore tags
rspec ./spec/content/automate/ManageIQ/Transformation/Infrastructure/VM/Common.class/__methods__/restorevmattributes_spec.rb[1:1:1:6] # ManageIQ::Automate::Transformation::Infrastructure::VM::Common::RestoreVmAttributes restore when source is vmware and destination redhat behaves like restore identity restore identity
rspec ./spec/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object_spec.rb:171 # ManageIQ::Automate::System::CommonMethods::Utils::LogObject log ar_objects  with My Database Object string
rspec ./spec/content/automate/ManageIQ/System/CommonMethods/Utils.class/__methods__/log_object_spec.rb:144 # ManageIQ::Automate::System::CommonMethods::Utils::LogObject log ar_objects with default VMDB Object string
```