### PR TITLE
Add create_retire_request in the miq_ae_service_methods.rb

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -117,6 +117,11 @@ module MiqAeMethodService
       MiqAeServiceModelBase.wrap_results(result)
     end
 
+    def self.create_retire_request(obj)
+      result = obj.object_send(:make_retire_request, User.current_user)
+      MiqAeServiceModelBase.wrap_results(result)
+    end
+
     def self.drb_undumped(klass)
       _log.info "Entered: klass=#{klass.name}"
       klass.include(DRbUndumped) unless klass.ancestors.include?(DRbUndumped)

--- a/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
@@ -189,4 +189,30 @@ describe MiqAeMethodService::MiqAeServiceMethods do
       expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
     end
   end
+
+  context "#create_retire_request" do
+    let(:options) { {:fred => :flintstone} }
+    let(:user) { FactoryBot.create(:user_with_group) }
+    let(:service) { FactoryBot.create(:service) }
+    let(:miq_request) { FactoryBot.create(:service_retire_request, :userid => user.id) }
+    let(:svc_service) do
+      MiqAeMethodService::MiqAeServiceService.find(service.id)
+    end
+    let(:workspace) do
+      double("MiqAeEngine::MiqAeWorkspaceRuntime",
+             :root               => options,
+             :persist_state_hash => {},
+             :ae_user            => user)
+    end
+    let(:miq_ae_service) { MiqAeMethodService::MiqAeService.new(workspace) }
+
+    it "create retire request" do
+      allow(workspace).to receive(:disable_rbac)
+      allow(Service).to receive(:find).with(service.id).and_return(service)
+      expect(service).to receive(:make_retire_request).with(user).and_return(miq_request)
+
+      result = miq_ae_service.execute(:create_retire_request, svc_service)
+      expect(result).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
+    end
+  end
 end


### PR DESCRIPTION
This RFE-BUG involves the ability to call retirement as a request from Automate, and that requires exposing the retirement_request method on the engine. This handles that exposing the same way we do with provision requests.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1700524

# Depends on
https://github.com/ManageIQ/manageiq/pull/18685