### PR TITLE
Move GIT_REPO_DIRECTORY constant from MiqAeDatastore to GitRepository

### DIFF
--- a/app/models/miq_ae_datastore.rb
+++ b/app/models/miq_ae_datastore.rb
@@ -4,7 +4,6 @@ module MiqAeDatastore
   MANAGEIQ_DOMAIN = "ManageIQ"
   MANAGEIQ_PRIORITY = 0
   DATASTORE_DIRECTORY = Rails.root.join('db/fixtures/ae_datastore')
-  GIT_REPO_DIRECTORY = Rails.root.join('data/git_repos')
   DEFAULT_OBJECT_NAMESPACE = "$"
   TEMP_DOMAIN_PREFIX = "TEMP_DOMAIN"
   ALL_DOMAINS = "*"


### PR DESCRIPTION
See https://github.com/ManageIQ/manageiq/pull/18669

@mkanoor Please review.

 https://github.com/ManageIQ/manageiq/pull/18669 should be merged first.