### PR TITLE
Use URI.parse instead of URI.split, make some error handling prettier

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -24,9 +24,17 @@ module MiqAeEngine
     end
 
     def self.invoke_uri(aem, obj, _inputs)
-      scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(aem.data)
-      raise  MiqAeException::MethodNotFound, "Specified URI [#{aem.data}] in Method [#{aem.name}] has unsupported scheme of #{scheme}; supported scheme is file" unless scheme.downcase == "file"
-      raise  MiqAeException::MethodNotFound, "Invalid file specification -- #{aem.data}" if path.nil?
+      uri = URI.parse(aem.data)
+
+      unless uri.scheme.casecmp?("file")
+        msg = "Specified URI [#{aem.data}] in Method [#{aem.name}] has unsupported scheme of #{scheme}; supported scheme is file"
+        raise MiqAeException::MethodNotFound, msg
+      end
+
+      if uri.path.blank?
+        raise  MiqAeException::MethodNotFound, "Invalid file specification -- #{aem.data}"
+      end
+
       # Create the filename corresponding to the URI specification
       fname = ae_methods_dir.join(path)
       raise  MiqAeException::MethodNotFound, "Method [#{aem.data}] Not Found (fname=#{fname})" unless File.exist?(fname)

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -36,7 +36,7 @@ module MiqAeEngine
       end
 
       # Create the filename corresponding to the URI specification
-      fname = ae_methods_dir.join(path)
+      fname = ae_methods_dir.join(uri.path)
       raise  MiqAeException::MethodNotFound, "Method [#{aem.data}] Not Found (fname=#{fname})" unless File.exist?(fname)
       cmd = "#{aem.language} #{fname}"
       invoke_external(cmd, obj.workspace)


### PR DESCRIPTION
This updates the MiqAeMethod#invoke_uri method, modifying the code so that it uses a URI object instead of URI.split.

Partly this was because most of the split variables were not being used and caused a warning when warnings are enabled, and partly because it's just easier to read. I also did some minor formatting for the error handling.

```
/Users/dberger/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/bundler/gems/manageiq-automation_engine-993c02c24ade/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb:27: warning: assigned but unused variable - userinfo
/Users/dberger/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/bundler/gems/manageiq-automation_engine-993c02c24ade/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb:27: warning: assigned but unused variable - host
/Users/dberger/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/bundler/gems/manageiq-automation_engine-993c02c24ade/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb:27: warning: assigned but unused variable - port
/Users/dberger/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/bundler/gems/manageiq-automation_engine-993c02c24ade/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb:27: warning: assigned but unused variable - registry
/Users/dberger/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/bundler/gems/manageiq-automation_engine-993c02c24ade/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb:27: warning: assigned but unused variable - opaque
/Users/dberger/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/bundler/gems/manageiq-automation_engine-993c02c24ade/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb:27: warning: assigned but unused variable - query
/Users/dberger/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/bundler/gems/manageiq-automation_engine-993c02c24ade/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb:27: warning: assigned but unused variable - fragment
```

On a side note, I noticed that elsewhere the `MiqAeUri` class is used instead. Was that meant to be used here as well?