### PR TITLE
Added support to decrypt options & dialog options

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_request.rb
@@ -2,6 +2,8 @@ module MiqAeMethodService
   class MiqAeServiceMiqRequest < MiqAeServiceModelBase
     require_relative "mixins/miq_ae_service_miq_request_mixin"
     include MiqAeServiceMiqRequestMixin
+    require_relative "mixins/miq_ae_service_dialog_option_mixin"
+    include MiqAeServiceDialogOptionMixin
 
     expose :miq_request_tasks, :association => true
     expose :resource,          :association => true

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_request_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_request_task.rb
@@ -2,6 +2,8 @@ module MiqAeMethodService
   class MiqAeServiceMiqRequestTask < MiqAeServiceModelBase
     require_relative "mixins/miq_ae_service_miq_request_mixin"
     include MiqAeServiceMiqRequestMixin
+    require_relative "mixins/miq_ae_service_dialog_option_mixin"
+    include MiqAeServiceDialogOptionMixin
 
     expose :execute, :method => :execute_queue, :override_return => true
     expose :cancel_requested?

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -6,6 +6,8 @@ module MiqAeMethodService
     include MiqAeServiceCustomAttributeMixin
     require_relative "mixins/miq_ae_service_remove_from_vmdb_mixin"
     include MiqAeServiceRemoveFromVmdb
+    require_relative "mixins/miq_ae_service_dialog_option_mixin"
+    include MiqAeServiceDialogOptionMixin
 
     expose :retire_service_resources
     expose :automate_retirement_entrypoint
@@ -32,10 +34,6 @@ module MiqAeMethodService
 
     def dialog_options
       @object.options[:dialog] || {}
-    end
-
-    def get_dialog_option(key)
-      dialog_options[key]
     end
 
     def set_dialog_option(key, value)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_provision_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_provision_task.rb
@@ -6,10 +6,6 @@ module MiqAeMethodService
       options[:dialog] || {}
     end
 
-    def get_dialog_option(key)
-      dialog_options[key]
-    end
-
     def group_sequence_run_now?
       ar_method { @object.group_sequence_run_now? }
     end

--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_dialog_option_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_dialog_option_mixin.rb
@@ -1,0 +1,13 @@
+module MiqAeServiceDialogOptionMixin
+  def get_dialog_option(key)
+    object_send(:get_dialog_option, key)
+  end
+
+  def get_dialog_option_decrypted(key)
+    object_send(:get_dialog_option_decrypted, key)
+  end
+
+  def dialog_option_encrypted?(key)
+    object_send(:dialog_option_encrypted?, key)
+  end
+end

--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_miq_request_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_miq_request_mixin.rb
@@ -7,6 +7,14 @@ module MiqAeServiceMiqRequestMixin
     object_send(:get_option, key)
   end
 
+  def get_option_decrypted(key)
+    object_send(:get_option_decrypted, key)
+  end
+
+  def option_encrypted?(key)
+    object_send(:option_encrypted?, key)
+  end
+
   def get_option_last(key)
     object_send(:get_option_last, key)
   end


### PR DESCRIPTION
This delegates to methods in the real model
Depends on PR https://github.com/ManageIQ/manageiq/pull/18739

Methods added to **Service** object & **ServiceTemplateProvisionTask**

1. get_dialog_option_decrypted(key_as_symbol_or_string)
2. dialog_option_encrypted?(key_as_symbol_or_string)

Methods added to **MiqProvision**
1. get_option_decrypted(key_as_symbol)
2. option_encrypted?(key_as_symbol)


Sample Automate Methods to fetch dialog_options from Service and ServiceTemplateProvisionTask 

```ruby
#
# Description: This automate method shows how to decrypt encrypted fields
# stored from a service dialog. It works on the service object as well as on
# the service_template_provision_task
# The keys can be either in symbols or they can be strings. It handles both
# the scenarios
#
task = $evm.root['service_template_provision_task']
service = task.destination
if service.dialog_option_encrypted?(:ldap_password)
  pwd = service.get_dialog_option_decrypted(:ldap_password)
end
user = service.get_dialog_option(:user_name)
email = service.get_dialog_option(:email)
$evm.log(:info, "SERVICE password : #{pwd} user: #{user} email: #{email}")


pwd = task.get_dialog_option_decrypted(:ldap_password)
user = task.get_dialog_option(:user_name)
email = task.get_dialog_option(:email)
  
$evm.log(:info, "STP password: #{pwd} user: #{user} email: #{email}")

other_pwd = @task.get_dialog_option_decrypted('option_1_vm_password')
$evm.log(:info, "option_1_vm_password: #{other_pwd}")
```


Sample Method to get options from MiqProvision object

```ruby
#
# Description: This method demonstrates how to decrypt passwords
#              stored in options hash
#
#

task = $evm.root['miq_provision']
# Check if the attribute is encrypted 
if task.option_encrypted?(:ldap_password)
  pwd = task.get_option_decrypted(:ldap_password)
end
# Get a regular attribute
user = task.get_option(:user_name)
email = task.get_option(:email)
$evm.log(:info, "Provision task:  password #{pwd} user #{user} email #{email}") 

```

Before this if you need to decrypt options you had to do this

```ruby
def old_approach
  require 'manageiq-password'
  old_way = MiqPassword.decrypt($evm.root['miq_provision'].options[:'password::ldap_password'])
  $evm.log(:info, "Provision task:  Old way password #{old_way}") 
end
```

http://talk.manageiq.org/t/decrypting-dialog-fields/2649
http://talk.manageiq.org/t/decrypting-text-box-in-customizerequest-method/4171