### PR TITLE
Log warning if RH domain version on disk and db version differ

### DIFF
--- a/config/initializers/version_check.rb
+++ b/config/initializers/version_check.rb
@@ -1,0 +1,4 @@
+rh_domain = MiqAeDomain.find_by(:name => "RedHat")
+if rh_domain.version != rh_domain.available_version
+  $log.warn "Current version - #{rh_domain.version}, Available version - #{rh_domain.available_version}"
+end


### PR DESCRIPTION
The RedHat domain on disk version and the version in the db can differ. At the moment we only run this check via the UI after an upgrade if the worker role is on. We've had requests to log the information instead and it maybe makes more sense to do it as part of the plugin setup.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1693362