### PR TITLE
Release a connection causes test thread problem - Support Rails 5-1

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -139,7 +139,7 @@ module MiqAeEngine
     private_class_method :verbose_rc
 
     def self.run_ruby_method(code)
-      ActiveRecord::Base.connection_pool.release_connection
+      ActiveRecord::Base.connection_pool.release_connection unless Rails.env.test?
       with_automation_env do
         ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
           run_method(Gem.ruby) do |stdin|


### PR DESCRIPTION
- [x] relies on core PR https://github.com/ManageIQ/manageiq/pull/18076 [DONE]

For now, let's skip releasing the connection in test.

Note, it looks like they added support for tracking a test transaction
across threads, which conflicts with us trying to release a connection in a
thread since it's owned by another test thread.

I was seeing this in tests with rails 5.1:

```
  2) MiqAeMethodService::MiqAeServiceMethods #tag_create
     Failure/Error: EvmSpecHelper.clear_caches { example.run }

     ActiveRecord::ActiveRecordError:
       Cannot expire connection, it is owned by a different thread: #<Thread:0x00007fd4ac112028@/Users/joerafaniello/.rubies/ruby-2.5.5/lib/ruby/2.5.0/drb/drb.rb:1662 dead>. Current thread: #<Thread:0x00007fd49d865ca8 run>.
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract_adapter.rb:197:in `expire'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/connection_pool.rb:516:in `block (3 levels) in checkin'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activesupport-5.1.7/lib/active_support/callbacks.rb:131:in `run_callbacks'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activesupport-5.1.7/lib/active_support/callbacks.rb:827:in `_run_checkin_callbacks'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/connection_pool.rb:515:in `block (2 levels) in checkin'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/connection_pool.rb:512:in `block in checkin'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/connection_pool.rb:511:in `checkin'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/connection_pool.rb:397:in `release_connection'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/connection_pool.rb:912:in `each'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/connection_adapters/abstract/connection_pool.rb:912:in `clear_active_connections!'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/connection_handling.rb:140:in `clear_active_connections!'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/fixtures.rb:1019:in `teardown_fixtures'
     # /Users/joerafaniello/.gem/ruby/2.5.5/gems/activerecord-5.1.7/lib/active_record/fixtures.rb:857:in `after_teardown'
```

We added this pre-ruby method release connection logic 9 years ago.
Perhaps it's no longer needed:
a4f5ab9f18fb816190f5cb473424821aed1b4c34

Here is the rails commit that landed in 5.1 that added support for
tracking transactions across test threads:

https://github.com/rails/rails/pull/28083/files

"Ensure test threads share a DB connection

This ensures multiple threads inside a transactional test to see
consistent
database state.

When a system test starts Puma spins up one thread and Capybara spins up
another thread. Because of this when tests are run the database cannot
see what was inserted into the database on teardown. This is because
there are two threads using two different connections."