### PR TITLE
Emses in tests should only be leaf classes otherwise they lack types

### DIFF
--- a/spec/miq_ae_discovery_spec.rb
+++ b/spec/miq_ae_discovery_spec.rb
@@ -4,7 +4,7 @@ describe "MiqAeDiscovery" do
     @admin  = User.super_admin || FactoryBot.create(:user_with_group, :userid => "admin")
     @tenant = Tenant.root_tenant
     @group  = FactoryBot.create(:miq_group, :tenant => @tenant)
-    @ems    = FactoryBot.create(:ext_management_system, :tenant => @tenant)
+    @ems    = FactoryBot.create(:ems_vmware, :tenant => @tenant)
     @vm     = FactoryBot.create(:vm_vmware, :miq_group => @group)
     @event  = FactoryBot.create(:ems_event, :event_type => "CreateVM_Task_Complete",
                                 :source => "VC", :ems_id => @ems.id, :vm_or_template_id => @vm.id)

--- a/spec/miq_ae_event_spec.rb
+++ b/spec/miq_ae_event_spec.rb
@@ -4,7 +4,7 @@ describe MiqAeEvent do
   # admin user is needed to process Events
   let(:admin)    { FactoryBot.create(:user_with_group, :userid => "admin") }
   let(:user)     { FactoryBot.create(:user_with_group, :userid => "test", :miq_groups => [group]) }
-  let(:ems)      { FactoryBot.create(:ext_management_system, :tenant => tenant) }
+  let(:ems)      { FactoryBot.create(:ems_vmware, :tenant => tenant) }
 
   describe ".raise_ems_event" do
     context "with VM event" do

--- a/spec/service_models/miq_ae_service_orchestration_stack_spec.rb
+++ b/spec/service_models/miq_ae_service_orchestration_stack_spec.rb
@@ -34,7 +34,7 @@ describe MiqAeMethodService::MiqAeServiceOrchestrationStack do
   end
 
   context "refresh" do
-    before { stack.update(:ext_management_system => FactoryBot.create(:ext_management_system)) }
+    before { stack.update(:ext_management_system => FactoryBot.create(:ems_vmware)) }
 
     it "calls a refresh on OrchestrationStack object" do
       expect(stack.class).to receive(:refresh_ems).with(stack.ext_management_system.id, stack.ems_ref)

--- a/spec/service_models/miq_ae_service_physical_server_spec.rb
+++ b/spec/service_models/miq_ae_service_physical_server_spec.rb
@@ -19,7 +19,7 @@ describe MiqAeMethodService::MiqAeServicePhysicalServer do
     before { allow(ems.class).to receive(:ems_type).and_return('THE_EMS_TYPE') }
 
     let(:server) { FactoryBot.create(:physical_server, :ext_management_system => ems) }
-    let(:ems)    { FactoryBot.create(:ems_physical_infra) }
+    let(:ems)    { FactoryBot.create(:ems_redfish_physical_infra) }
 
     subject { MiqAeMethodService::MiqAeServicePhysicalServer.find(server.id) }
 

--- a/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_transformation_plan_task_spec.rb
@@ -1,5 +1,5 @@
 describe MiqAeMethodService::MiqAeServiceServiceTemplateTransformationPlanTask do
-  let(:ems) { FactoryBot.create(:ext_management_system, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
+  let(:ems) { FactoryBot.create(:ems_vmware, :zone => FactoryBot.create(:zone), :api_version => '4.2.4') }
   let(:host) { FactoryBot.create(:host_redhat, :ext_management_system => ems) }
   let(:vm) { FactoryBot.create(:vm_openstack) }
   let(:conversion_host_1) { FactoryBot.create(:conversion_host, :resource => host) }


### PR DESCRIPTION
And we should only be able to add ones with a type, so this fixes specs broken by https://github.com/ManageIQ/manageiq/pull/18842. 