### PR TITLE
Add helper method ansible_stats_vars

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_ansible_method_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_ansible_method_base.rb
@@ -13,6 +13,12 @@ module MiqAeEngine
       workspace.persist_state_hash.delete_if { |key, _| key.to_s.match(/#{METHOD_KEY_SUFFIX}$/) }
     end
 
+    def self.ansible_stats_from_hash(hash)
+      hash.each_with_object({}) do |(attr, val), obj|
+        obj[attr[ANSIBLE_STATS_PREFIX_LEN..-1]] = val if attr.start_with?(ANSIBLE_STATS_PREFIX)
+      end
+    end
+
     def initialize(aem, obj, inputs)
       @workspace = obj.workspace
       @inputs    = inputs
@@ -139,11 +145,7 @@ module MiqAeEngine
     end
 
     def ansible_stats_from_ws
-      @workspace.persist_state_hash.each_with_object({}) do |(attr, val), obj|
-        if attr.start_with?(ANSIBLE_STATS_PREFIX)
-          obj[attr[ANSIBLE_STATS_PREFIX_LEN..-1]] = val
-        end
-      end
+      self.class.ansible_stats_from_hash(@workspace.persist_state_hash)
     end
 
     def miq_request_task

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -88,6 +88,10 @@ module MiqAeMethodService
       @persist_state_hash.delete(name)
     end
 
+    def ansible_stats_vars
+      MiqAeEngine::MiqAeAnsibleMethodBase.ansible_stats_from_hash(@persist_state_hash)
+    end
+
     def prepend_namespace=(ns)
       @workspace.prepend_namespace = ns
     end

--- a/spec/miq_ae_service_spec.rb
+++ b/spec/miq_ae_service_spec.rb
@@ -126,6 +126,13 @@ describe MiqAeMethodService::MiqAeService do
         expect(miq_ae_service.state_var_exist?('name')).to(be_truthy)
       end
     end
+
+    it 'ansible_stats_vars' do
+      allow(workspace).to(receive(:disable_rbac))
+      expect(miq_ae_service.ansible_stats_vars).to eq({})
+      miq_ae_service.instance_eval { @persist_state_hash = { 'ansible_stats_var1' => 'value1', 'ansible_stats_var2' => 'value2', 'var3' => 'value3' } }
+      expect(miq_ae_service.ansible_stats_vars).to eq('var1' => 'value1', 'var2' => 'value2')
+    end
   end
 end
 


### PR DESCRIPTION
Add helper method ansible_stats_vars to get all ansible set_stats variables in automate workspace.

Followup of https://github.com/ManageIQ/manageiq-automation_engine/pull/333

@miq-bot add_label enhancement

