### PR TITLE
[IVANCHUK] Change travis.yml to use the only supported ruby, 2.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
+---
 dist: xenial
 language: ruby
 rvm:
-- 2.4.6
 - 2.5.3
 sudo: false
 cache: bundler


### PR DESCRIPTION
Change travis.yml to use the only supported ruby, 2.5.3

Related to ManageIQ/manageiq#19050