### PR TITLE
Add method $evm.get_state_vars

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -88,6 +88,10 @@ module MiqAeMethodService
       @persist_state_hash.delete(name)
     end
 
+    def get_state_vars
+      @persist_state_hash
+    end
+
     def ansible_stats_vars
       MiqAeEngine::MiqAeAnsibleMethodBase.ansible_stats_from_hash(@persist_state_hash)
     end

--- a/spec/miq_ae_service_spec.rb
+++ b/spec/miq_ae_service_spec.rb
@@ -127,6 +127,13 @@ describe MiqAeMethodService::MiqAeService do
       end
     end
 
+    it 'get_state_vars' do
+      allow(workspace).to(receive(:disable_rbac))
+      expect(miq_ae_service.get_state_vars).to eq({})
+      miq_ae_service.instance_eval { @persist_state_hash = { 'var1' => 'value1', 'var2' => 'value2' } }
+      expect(miq_ae_service.get_state_vars).to eq('var1' => 'value1', 'var2' => 'value2')
+    end
+
     it 'ansible_stats_vars' do
       allow(workspace).to(receive(:disable_rbac))
       expect(miq_ae_service.ansible_stats_vars).to eq({})


### PR DESCRIPTION
New $evm.get_state_vars method to get all state_vars without having to know the names. 

https://bugzilla.redhat.com/show_bug.cgi?id=1734636

@miq-bot add_label enhancement, changelog/yes, ivanchuk/no