### PR TITLE
Override equality comparison method for MiqAeServiceModelBase

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -363,7 +363,7 @@ module MiqAeMethodService
     end
 
     def ==(other)
-      self.id == other.id && self.class == other.class
+      self.class == other.class && id == other.id
     end
   end
 end

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -361,5 +361,9 @@ module MiqAeMethodService
     def ar_method(&block)
       self.class.ar_method(&block)
     end
+
+    def ==(other)
+      self.id == other.id && self.class == other.class
+    end
   end
 end


### PR DESCRIPTION
When implementing https://github.com/ManageIQ/manageiq-content/pull/559, we identified that the object comparison fails on MiqAeMethodService objects. This is because the instances may have the same id but be different objects in RSpec context. This PR overrides the `==` comparison to validate the class and id rather than the whole object.

See reference in https://github.com/ManageIQ/manageiq-content/pull/559#discussion_r312762932

https://bugzilla.redhat.com/show_bug.cgi?id=1739247 based on related PR above.