### PR TITLE
Undefine Kernel#display which would be called over service#display for DRbObject

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
@@ -117,6 +117,8 @@ begin
 
   DRbObject.send(:undef_method, :inspect)
   DRbObject.send(:undef_method, :id) if DRbObject.respond_to?(:id)
+  # undefine Object#display which would be called over service#display
+  DRbObject.send(:undef_method, :display)
 
   DRb.start_service
   $evmdrb = DRbObject.new_with_uri(MIQ_URI)


### PR DESCRIPTION
Display is a column in MIQ services table. But Kernel has a method named as display. 

When running an automation inline method, ```service.display``` would call ```Kernel#display``` instead of getting the value from the table column.

https://bugzilla.redhat.com/show_bug.cgi?id=1737559

@miq-bot add_label bug, hammer/yes, Ivanchuk/yes, changelog/yes