### PR TITLE
Add external_url= capability to Tenant.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_tenant.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_tenant.rb
@@ -1,0 +1,6 @@
+module MiqAeMethodService
+  class MiqAeServiceTenant < MiqAeServiceModelBase
+    require_relative "mixins/miq_ae_external_url_mixin"
+    include MiqAeExternalUrlMixin
+  end
+end


### PR DESCRIPTION
Add `external_url=` capability to Tenant.

Relevant BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1550002

This PR extends the work done in #328 in support of changes from ManageIQ/manageiq#18849

### Tested automate code for "Tenant":
```
$evm.log(:info, $evm.root['vmdb_object_type'])
$evm.log(:info, "tenant_id: #{$evm.root['tenant_id'].inspect}")

# t = $evm.root['tenant'] # this will give the LOGGGED IN tenant, not the target object tenant
t = $evm.vmdb($evm.root['vmdb_object_type']).find_by(:id => $evm.root['tenant_id'])
$evm.log(:info, "tenant: #{t.inspect}")
t.external_url = "https://www.redhat.com"
```