### PR TITLE
Expose encode_with to generic object.

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
@@ -18,6 +18,11 @@ module MiqAeMethodService
       ar_method { wrap_results(@object.remove_from_service(Service.find_by(:id => service.id))) }
     end
 
+    # This method is called by YAML.dump when miq_task#queue_callback sets the result into miq_task.task_results.
+    def encode_with(*args)
+      ar_method { wrap_results(@object.encode_with(*args)) }
+    end
+
     private
 
     def ae_user_identity


### PR DESCRIPTION
This method is called by YAML.dump when miq_queue sets the callback result into miq_task.task_results.

Reported by https://github.com/ManageIQ/manageiq-ui-classic/pull/6040#issuecomment-522771465.

@miq-bot add_label bug, Ivanchuk/yes
