### PR TITLE
Add MiqAeEngine.return_result.

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -121,7 +121,7 @@ module MiqAeEngine
         end
       end
 
-      return ws
+      return_result(ws, options[:attrs])
     rescue MiqAeException::Error => err
       message = "Error delivering #{automate_attrs.inspect} for object [#{object_name}] with state [#{state}] to Automate: #{err.message}"
       miq_task&.error(MiqTask::MESSAGE_TASK_COMPLETED_UNSUCCESSFULLY)
@@ -132,6 +132,13 @@ module MiqAeEngine
         miq_task.update_message(MiqTask::MESSAGE_TASK_COMPLETED_SUCCESSFULLY) if miq_task.message == MiqTask::DEFAULT_MESSAGE
         miq_task.state_finished
       end
+    end
+  end
+
+  def self.return_result(workspace, options)
+    case options["result_format"]
+    when 'ignore' then options["result_on_success"] || 'Ok'
+    when nil then workspace
     end
   end
 

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -793,6 +793,20 @@ describe MiqAeEngine do
     expect(my_objects_array.length).to eq(0)
     expect(my_objects_array).to eq([])
   end
+
+  context ".return_result" do
+    let(:workspace) { double('MiqAeEngine::MiqAeWorkspaceRuntime') }
+
+    it "returns workspace if result_format=nil" do
+      expect(MiqAeEngine.return_result(workspace, {})).to eq(workspace)
+    end
+
+    it "returns not workspace if result_format='ignore'" do
+      expect(MiqAeEngine.return_result(workspace, "result_format" => 'ignore')).to eq('Ok')
+      msg = "return value on success"
+      expect(MiqAeEngine.return_result(workspace, "result_format" => 'ignore', "result_on_success" => msg)).to eq(msg)
+    end
+  end
 end
 
 describe MiqAeEngine do


### PR DESCRIPTION
Returning back workspace breaks the custom button for generic objects.

Add new options that can be passed in as ```args``` to ```MiqAeEngine.deliver```.
- result_format 
       ```ignore``` - To stop automate send back workspace object as return value
       ```nil```        - Default value, workspace object would be returned by ```MiqAeEngine.deliver```
- result_on_success
User can use this option to set the expected return value from ```MiqAeEngine.deliver```. 
Used together with ```result_format```.

Blocks https://github.com/ManageIQ/manageiq/pull/19195.

Replace https://github.com/ManageIQ/manageiq-automation_engine/pull/352.

Reported by https://github.com/ManageIQ/manageiq-ui-classic/pull/6040#issuecomment-522771465.
https://bugzilla.redhat.com/show_bug.cgi?id=1550002

@miq-bot add_label bug, Ivanchuk/yes, changelog/yes