### PR TITLE
Prevent git import to overwrite base system domain in datastore.

### DIFF
--- a/app/models/miq_ae_yaml_import.rb
+++ b/app/models/miq_ae_yaml_import.rb
@@ -15,8 +15,9 @@ class MiqAeYamlImport
   def import
     if @options.key?('import_dir') && !File.directory?(@options['import_dir'])
       raise MiqAeException::DirectoryNotFound, "Directory [#{@options['import_dir']}] not found"
-    elsif !User.current_user.nil? && @options['zip_file'] && domain_locked?(@options['import_as'])
-      # raises exception only for a local import into the locked domain
+    elsif (!User.current_user.nil? && @options['zip_file'] && domain_locked?(@options['import_as'])) ||
+          (@options['git_repository_id'] && system_domain?(File.dirname(sorted_domain_files.first)))
+      # exception for local import into the locked domain or git import into the base system domain
       raise MiqAeException::DomainNotAccessible, 'locked domain'
     end
     start_import(@options['preview'], @domain_name)
@@ -320,5 +321,9 @@ class MiqAeYamlImport
 
   def domain_locked?(domain_name)
     MiqAeDomain.find_by(:name => domain_name)&.contents_locked? ? true : false
+  end
+
+  def system_domain?(domain_name)
+    MiqAeDomain.find_by(:name => domain_name)&.source == MiqAeDomain::SYSTEM_SOURCE
   end
 end


### PR DESCRIPTION
Description
------------------
Since it is not allowed to edit the base system domain in datastore(image1) or overwrite it by importing *.zip file(image2), we are also going to prevent overwriting by git import. 

Screenshots
-----------------
image1(domain edit):
![Screenshot from 2019-08-28 17-51-59](https://user-images.githubusercontent.com/19405716/63871682-a45b6b00-c9bc-11e9-9d7c-59af5d42c2ed.png)

image2(*.zip file import):
![Screenshot from 2019-08-28 17-53-38](https://user-images.githubusercontent.com/19405716/63871765-c81eb100-c9bc-11e9-9bbf-73a06834cecd.png)

git import(new):
![Screenshot from 2019-08-28 17-32-57](https://user-images.githubusercontent.com/19405716/63871195-bee11480-c9bb-11e9-87e4-b0b25da62553.png)

Steps
-----------
1) Create some Automate domain git repo with domain name same as the base system domain('ManageIQ')
2) Go to Automation -> Automate -> Import/Export
3) Import the git repo from step1 to see the error message

@gmcculloug @mkanoor @tinaafitz 