### PR TITLE
Add method to delete tag

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -99,6 +99,27 @@ module MiqAeMethodService
       end
     end
 
+    def self.tag_delete!(category, entry)
+      ar_method do
+        cat = Classification.find_by_name(category)
+        raise "Category <#{category}> does not exist" if cat.nil?
+
+        ent = cat.find_entry_by_name(entry)
+        raise "Entry <#{entry}> does not exist" if ent.nil?
+
+        raise "This tag has assignments. Please delete assignments before deleting the tag." if AssignmentMixin.all_assignments(ent.tag.name).present?
+
+        ent.destroy!
+      end
+    end
+
+    def self.tag_delete(category, entry)
+      tag_delete!(category, entry)
+      true
+    rescue StandardError
+      false
+    end
+
     def self.create_provision_request(*args)
       # Need to add the username into the array of params
       # TODO: This code should pass a real username, similar to how the web-service


### PR DESCRIPTION
Add method to delete tag
    
Both tag_delete and tag_delete! are added.
    
For tag_delete!
1. When tag is found and not assigned, it would be deleted and return the entry;
2. When tag is assigned, user will be warned and tag could not be deleted;
3. When entry is not found, user will be warned, in case of e.g. typo;
    
tag_delete behaves similar to tag_delete! except that it returns true when
execution succeeds and will suppress all exceptions and return false.
    
RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1744514#c4