### PR TITLE
Rubocop run with `--fix-layout` option.

### DIFF
--- a/app/models/miq_ae_browser.rb
+++ b/app/models/miq_ae_browser.rb
@@ -35,6 +35,7 @@ class MiqAeBrowser
 
   def initialize(user = User.current_user)
     raise "Must be authenticated before using #{self.class.name}" unless user
+
     @user = user
     @waypoint_ids = MiqAeClass.waypoint_ids_for_state_machines
   end
@@ -115,11 +116,13 @@ class MiqAeBrowser
   def find_domain(domain_name, options)
     domain = domains(options).find { |d| domain_name.casecmp(d[:ae_object].name).zero? }
     raise "Invalid Automate Domain #{domain_name} specified" if domain.blank?
+
     domain
   end
 
   def children(object, options = {})
     return [] unless object
+
     filter_ae_objects(ae_children(object.ae_object), options).collect do |ae_object|
       object_from_ae_object("#{object.fqname}/#{ae_object.name}", ae_object)
     end
@@ -134,6 +137,7 @@ class MiqAeBrowser
 
   def filter_ae_objects(ae_objects, options)
     return ae_objects unless options[:state_machines]
+
     ae_objects.select do |obj|
       klass_name = obj.class.name
       if klass_name == "MiqAeInstance"

--- a/app/models/miq_ae_class_compare_fields.rb
+++ b/app/models/miq_ae_class_compare_fields.rb
@@ -30,6 +30,7 @@ class MiqAeClassCompareFields
   def status
     return CONGRUENT_SCHEMA if congruent?
     return COMPATIBLE_SCHEMA if compatible?
+
     INCOMPATIBLE_SCHEMA
   end
 
@@ -76,6 +77,7 @@ class MiqAeClassCompareFields
     old_field.each do |property, value|
       next if IGNORE_PROPERTY_NAMES.include?(property)
       next if value == new_field[property]
+
       hash = {'property'   => property,
               'old_value'  => value,
               'new_value'  => new_field[property],

--- a/app/models/miq_ae_class_copy.rb
+++ b/app/models/miq_ae_class_copy.rb
@@ -42,6 +42,7 @@ class MiqAeClassCopy
 
   def target_ns(domain, ns)
     return "#{domain}/#{@partial_ns}" if ns.nil?
+
     ns_obj = MiqAeNamespace.lookup_by_fqname(ns, false)
     ns_obj && !ns_obj.domain? ? ns : "#{domain}/#{ns}"
   end

--- a/app/models/miq_ae_class_yaml.rb
+++ b/app/models/miq_ae_class_yaml.rb
@@ -7,13 +7,16 @@ class MiqAeClassYaml
 
   def field_names
     raise "class object has not been set" unless @ae_class_obj
+
     @ae_class_obj['object']['schema'].collect { |x| x['field']['name'].downcase }
   end
 
   def field_hash(name)
     raise "class object has not been set" unless @ae_class_obj
+
     field = @ae_class_obj['object']['schema'].detect { |f| f['field']['name'].casecmp(name).zero? }
     raise "field #{name} not found in yaml class #{@filename}" if field.nil?
+
     field['field']
   end
 end

--- a/app/models/miq_ae_datastore.rb
+++ b/app/models/miq_ae_datastore.rb
@@ -51,7 +51,7 @@ module MiqAeDatastore
 
   def self.upload(fd, name = nil, domain_name = ALL_DOMAINS)
     name ||= fd.original_filename
-    name      = Pathname(name).basename.sub_ext('.zip')
+    name = Pathname(name).basename.sub_ext('.zip')
     upload_to = TMP_DIR.join(name)
     TMP_DIR.mkpath
 
@@ -232,6 +232,7 @@ module MiqAeDatastore
 
   def self.get_homonymic_across_domains(user, arclass, fqname, enabled = nil)
     return [] if fqname.blank?
+
     options = arclass == ::MiqAeClass ? {:has_instance_name => false} : {}
     _, ns, klass, name = ::MiqAeEngine::MiqAePath.get_domain_ns_klass_inst(fqname, options)
     name = klass if arclass == ::MiqAeClass
@@ -250,6 +251,7 @@ module MiqAeDatastore
   def self.get_domain_index_object(domains, obj, klass, ns, enabled, options)
     domain, nsd, klass_name, = ::MiqAeEngine::MiqAePath.get_domain_ns_klass_inst(obj.fqname, options)
     return if !klass_name.casecmp(klass).zero? || !nsd.casecmp(ns).zero?
+
     domain_index = get_domain_index(domains, domain, enabled)
     {:obj => obj, :index => domain_index} if domain_index
   end
@@ -263,6 +265,7 @@ module MiqAeDatastore
   def self.preserved_attrs_for_domains
     MiqAeDomain.all.each_with_object({}) do |dom, h|
       next if dom.name.downcase == MANAGEIQ_DOMAIN.downcase
+
       h[dom.name] = PRESERVED_ATTRS.each_with_object({}) { |attr, ih| ih[attr] = dom[attr] }
     end
   end

--- a/app/models/miq_ae_datastore/xml_export.rb
+++ b/app/models/miq_ae_datastore/xml_export.rb
@@ -52,7 +52,7 @@ module MiqAeDatastore
     end
 
     def self.export_all_classes_for_namespace(ns, xml)
-      MiqAeClass.where(:namespace_id => ns.id.to_i).sort_by(&:fqname).each  do  |c|
+      MiqAeClass.where(:namespace_id => ns.id.to_i).sort_by(&:fqname).each do |c|
         c.to_export_xml(:builder => xml, :skip_instruct => true, :indent => 2)
       end
     end

--- a/app/models/miq_ae_datastore/xml_import.rb
+++ b/app/models/miq_ae_datastore/xml_import.rb
@@ -7,7 +7,7 @@ module MiqAeDatastore
       methods   = input.delete("MiqAeMethod")
 
       # Create the AEClass
-      aec       = MiqAeClass.new(input)
+      aec = MiqAeClass.new(input)
 
       Benchmark.realtime_block(:process_class_schema_time) do
         # Find or Create the AEFields
@@ -35,10 +35,10 @@ module MiqAeDatastore
       fields             = input.delete("MiqAeField")
       input["data"]      = input.delete("content")
       input["data"]&.strip!
-      aem                = MiqAeMethod.new(input)
+      aem = MiqAeMethod.new(input)
 
       # Find or Create the Method Input Definitions
-      aem.inputs = process_method_inputs(fields)        unless fields.nil?
+      aem.inputs = process_method_inputs(fields) unless fields.nil?
       aem
     end
 
@@ -70,7 +70,7 @@ module MiqAeDatastore
           f["default_value"] = default_value.strip unless f.key?("default_value") || default_value.nil?
 
           unless f["collect"].blank?
-            f["collect"] = f["collect"].first["content"]            if f["collect"].kind_of?(Array)
+            f["collect"] = f["collect"].first["content"] if f["collect"].kind_of?(Array)
             f["collect"] = REXML::Text.unnormalize(f["collect"].strip)
           end
 
@@ -98,12 +98,14 @@ module MiqAeDatastore
       fname = field["name"]
       ae_field = aei.ae_class.ae_fields.detect { |f| fname.casecmp(f.name).zero? }
       raise MiqAeException::FieldNotFound, "Field [#{fname}] not found in MiqAeDatastore" if ae_field.nil?
+
       options[:ae_field] = ae_field
       value = field["value"] || field["content"]
       value.strip! unless value.blank?
-      options[:value]    = value
+      options[:value] = value
       %w[collect on_entry on_exit on_error max_retries max_time].each do |key|
         next if field[key].blank?
+
         options[key.to_sym] = REXML::Text.unnormalize(field[key].strip)
       end
       aei.ae_values << MiqAeValue.new(options)
@@ -127,6 +129,7 @@ module MiqAeDatastore
           version = doc.children[0].attributes[:version]
           _log.info("  with version '#{version}'")
           raise "Unsupported version '#{version}'.  Must be at least '#{MiqAeDatastore::XML_VERSION_MIN_SUPPORTED}'." unless check_version(version)
+
           classes = doc.to_h(:symbols => false)["MiqAeClass"]
           buttons = doc.to_h(:symbols => false)["MiqAeButton"]
         end
@@ -155,7 +158,7 @@ module MiqAeDatastore
 
     def self.create_domain(domain)
       MiqAeDomain.lookup_by_fqname(domain) ||
-      MiqAeDomain.create!(:enabled => true, :priority => 100, :tenant => Tenant.root_tenant, :name => domain)
+        MiqAeDomain.create!(:enabled => true, :priority => 100, :tenant => Tenant.root_tenant, :name => domain)
     end
 
     def self.load_xml_file(filename, domain)
@@ -166,7 +169,7 @@ module MiqAeDatastore
       _log.info("Importing file '#{f}'")
       ext = File.extname(f).downcase
       case ext
-      when ".xml"          then load_xml_file(f, domain)
+      when ".xml" then load_xml_file(f, domain)
       else raise "Unhandled File Extension [#{ext}] when trying to load #{f}"
       end
       _log.info("Import complete")

--- a/app/models/miq_ae_domain.rb
+++ b/app/models/miq_ae_domain.rb
@@ -58,6 +58,7 @@ class MiqAeDomain < MiqAeNamespace
   def lock_contents!
     return if source == USER_LOCKED_SOURCE # already locked
     raise MiqAeException::CannotLock, "Cannot lock non user domains" unless source == USER_SOURCE
+
     self.source = USER_LOCKED_SOURCE
     save!
   end
@@ -65,6 +66,7 @@ class MiqAeDomain < MiqAeNamespace
   def unlock_contents!
     return if source == USER_SOURCE # already unlocked
     raise MiqAeException::CannotUnlock, "Cannot unlock non user domains" unless source == USER_LOCKED_SOURCE
+
     self.source = USER_SOURCE
     save!
   end
@@ -114,6 +116,7 @@ class MiqAeDomain < MiqAeNamespace
   def self.version_from_schema(path)
     about_file = path.join("System/About#{CLASS_DIR_SUFFIX}/#{CLASS_YAML_FILENAME}")
     return unless about_file.file?
+
     class_yaml = YAML.load_file(about_file)
     fields = class_yaml.fetch_path('object', 'schema') if class_yaml.kind_of?(Hash)
     version_field = fields.try(:detect) { |f| f.fetch_path('field', 'name') == 'version' }
@@ -134,10 +137,10 @@ class MiqAeDomain < MiqAeNamespace
     self.ref_type = ref_type
     info = latest_ref_info
     update!(:last_import_on => Time.now.utc,
-                       :commit_sha     => info['commit_sha'],
-                       :commit_message => info['commit_message'],
-                       :commit_time    => info['commit_time'],
-                       :source         => REMOTE_SOURCE)
+            :commit_sha     => info['commit_sha'],
+            :commit_message => info['commit_message'],
+            :commit_time    => info['commit_time'],
+            :source         => REMOTE_SOURCE)
   end
 
   def git_enabled?
@@ -151,6 +154,7 @@ class MiqAeDomain < MiqAeNamespace
   def latest_ref_info
     raise MiqAeException::InvalidDomain, "Not Git enabled" unless git_enabled?
     raise "No branch or tag selected for this domain" if ref.nil? && ref_type.nil?
+
     case ref_type
     when MiqAeGitImport::BRANCH
       git_repository.branch_info(ref)
@@ -161,6 +165,7 @@ class MiqAeDomain < MiqAeNamespace
 
   def display_name
     return self[:display_name] unless git_enabled?
+
     "#{domain_name} (#{ref})"
   end
 

--- a/app/models/miq_ae_git_import.rb
+++ b/app/models/miq_ae_git_import.rb
@@ -22,9 +22,7 @@ class MiqAeGitImport
 
   def single_domain_import
     import_service = MiqAeYamlImportGitfs.new(@options['domain'] || '*', @options)
-    if import_service.domain_files('*').size > 1
-      raise MiqAeException::InvalidDomain, _("Multiple Domain import is not supported.")
-    end
+    raise MiqAeException::InvalidDomain, _("Multiple Domain import is not supported.") if import_service.domain_files('*').size > 1
 
     import_service.import
   end
@@ -89,6 +87,7 @@ class MiqAeGitImport
     unless match
       raise ArgumentError, "#{@options['ref_type'].titleize} #{@options['ref']} doesn't exist in repository"
     end
+
     @options['ref'] = match.name
   end
 end

--- a/app/models/miq_ae_instance_compare_values.rb
+++ b/app/models/miq_ae_instance_compare_values.rb
@@ -30,6 +30,7 @@ class MiqAeInstanceCompareValues
   def status
     return CONGRUENT_INSTANCE if congruent?
     return COMPATIBLE_INSTANCE if compatible?
+
     INCOMPATIBLE_INSTANCE
   end
 
@@ -76,6 +77,7 @@ class MiqAeInstanceCompareValues
     old_value.each do |property, data|
       next if IGNORE_PROPERTY_NAMES.include?(property)
       next if data == new_value[property]
+
       hash = {'property'   => property,
               'old_data'   => data,
               'new_data'   => new_value[property],

--- a/app/models/miq_ae_instance_yaml.rb
+++ b/app/models/miq_ae_instance_yaml.rb
@@ -7,13 +7,16 @@ class MiqAeInstanceYaml
 
   def field_names
     raise "ae instance object has not been initialize" unless @ae_instance_obj
+
     @ae_instance_obj['object']['fields'].collect(&:keys).flatten
   end
 
   def field_value_hash(name)
     raise "ae instance object has not been initialize" unless @ae_instance_obj
+
     value = @ae_instance_obj['object']['fields'].detect { |item| item.keys[0].casecmp(name).zero? }
     raise "field name #{name} not found in instance #{@filename}" if value.nil?
+
     value[name]
   end
 end

--- a/app/models/miq_ae_method_compare.rb
+++ b/app/models/miq_ae_method_compare.rb
@@ -32,6 +32,7 @@ class MiqAeMethodCompare
   def status
     return CONGRUENT_METHOD  if congruent?
     return COMPATIBLE_METHOD if compatible?
+
     INCOMPATIBLE_METHOD
   end
 
@@ -63,6 +64,7 @@ class MiqAeMethodCompare
     old_value = @old_method.send(method) if @old_method.respond_to?(method)
     new_value = @new_method.send(method) if @new_method.respond_to?(method)
     return if old_value == new_value
+
     @incompatibilities << {'attribute' => method, 'old_data' => old_value, 'new_data' => new_value}
   end
 
@@ -89,6 +91,7 @@ class MiqAeMethodCompare
     old_value.each do |property, data|
       next if IGNORE_PROPERTY_NAMES.include?(property)
       next if data == new_value[property]
+
       hash = {'property'   => property,
               'old_data'   => data,
               'new_data'   => new_value[property],

--- a/app/models/miq_ae_method_copy.rb
+++ b/app/models/miq_ae_method_copy.rb
@@ -8,8 +8,10 @@ class MiqAeMethodCopy
     @class_fqname = "#{@src_domain}/#{@partial_ns}/#{@ae_class}"
     @src_class = MiqAeClass.lookup_by_fqname("#{@src_domain}/#{@partial_ns}/#{@ae_class}")
     raise "Source class not found #{@class_fqname}" unless @src_class
+
     @src_method = MiqAeMethod.find_by(:name => @method_name, :class_id => @src_class.id)
     raise "Source method #{@method_name} not found #{@class_fqname}" unless @src_method
+
     @target_class_name = @ae_class
   end
 
@@ -48,6 +50,7 @@ class MiqAeMethodCopy
   def find_or_create_class
     @dest_class = MiqAeClass.lookup_by_fqname("#{@target_domain}/#{@target_ns}/#{@target_class_name}")
     return unless @dest_class.nil?
+
     @dest_class = MiqAeClassCopy.new(@class_fqname).to_domain(@target_domain, @target_ns)
   end
 

--- a/app/models/miq_ae_method_yaml.rb
+++ b/app/models/miq_ae_method_yaml.rb
@@ -31,15 +31,18 @@ class MiqAeMethodYaml
 
   def field_names
     raise "ae_method_obj has not been set" unless @ae_method_obj
+
     define_instance_variables
     @ae_method_obj['object']['inputs'].collect { |item| item['field']['name'] }.flatten
   end
 
   def field_value_hash(name)
     raise "ae_method_obj has not been set" unless @ae_method_obj
+
     define_instance_variables
     value = @ae_method_obj['object']['inputs'].detect { |item| item['field']['name'].casecmp(name).zero? }
     raise "field name #{name} not found in instance #{@filename}" if value.nil?
+
     value['field']
   end
 end

--- a/app/models/miq_ae_password.rb
+++ b/app/models/miq_ae_password.rb
@@ -3,6 +3,7 @@ require 'manageiq-password'
 class MiqAePassword < ManageIQ::Password
   def self.encrypt(str)
     return str if str.blank? || encrypted?(str)
+
     super
   end
 

--- a/app/models/miq_ae_yaml_export.rb
+++ b/app/models/miq_ae_yaml_export.rb
@@ -256,6 +256,7 @@ class MiqAeYamlExport
 
   def domain_object
     raise MiqAeException::DomainNotAccessible, "Domain [#{@domain}] not accessible" unless domain_accessible?
+
     MiqAeDomain.lookup_by_fqname(@domain).tap do |dom|
       if dom.nil?
         _log.error("Domain: <#{@domain}> not found.")
@@ -282,11 +283,13 @@ class MiqAeYamlExport
 
   def swap_domain_path(fqname)
     return fqname if @options['export_as'].blank?
+
     fqname.gsub(/^\/#{@domain}/, @options['export_as'])
   end
 
   def domain_accessible?
     return true unless @tenant
+
     @tenant.ae_domains.any? { |dom| dom.name.casecmp(@domain).zero? }
   end
 end

--- a/app/models/miq_ae_yaml_export_consolidated.rb
+++ b/app/models/miq_ae_yaml_export_consolidated.rb
@@ -10,12 +10,13 @@ class MiqAeYamlExportConsolidated < MiqAeYamlExport
     if File.exist?(@yaml_file_name) && !options['overwrite']
       raise MiqAeException::FileExists, "File [#{@yaml_file_name}] exists, to overwrite it use OVERWRITE=true"
     end
+
     @yaml_model = {}
   end
 
   def write_data(base_path, export_hash)
     path = File.join(base_path, export_hash['output_filename']).split('/')
-    path.shift  if base_path[0, 1] == '/'
+    path.shift if base_path[0, 1] == '/'
     data = export_hash['export_data']
     data = YAML.load(data) if export_hash['output_filename'].ends_with?('.yaml')
     path << data

--- a/app/models/miq_ae_yaml_export_fs.rb
+++ b/app/models/miq_ae_yaml_export_fs.rb
@@ -2,12 +2,14 @@
 class MiqAeYamlExportFs < MiqAeYamlExport
   def initialize(domain, options)
     raise ArgumentError, "Output directory not specified" if options['export_dir'].blank?
+
     options['overwrite'] ||= false
     dom_name = options['export_as'].present? ? options['export_as'] : domain
     dir_name = File.join(options['export_dir'], dom_name)
     if Dir.exist?(dir_name) && !options['overwrite']
       raise MiqAeException::DirectoryExists, "Directory [#{dir_name}] exists, use OVERWRITE=true"
     end
+
     super
   end
 
@@ -16,6 +18,7 @@ class MiqAeYamlExportFs < MiqAeYamlExport
     FileUtils.mkpath(fqpath) unless File.directory?(fqpath)
     fq_filename = File.join(fqpath, export_hash['output_filename'].downcase)
     raise MiqAeException::FileExists, "#{fq_filename} exists" if File.exist?(fq_filename) && !@options['overwrite']
+
     File.write(fq_filename, export_hash['export_data'])
   end
 

--- a/app/models/miq_ae_yaml_import.rb
+++ b/app/models/miq_ae_yaml_import.rb
@@ -16,6 +16,7 @@ class MiqAeYamlImport
     if @options.key?('import_dir') && !File.directory?(@options['import_dir'])
       raise MiqAeException::DirectoryNotFound, "Directory [#{@options['import_dir']}] not found"
     end
+
     start_import(@options['preview'], @domain_name)
   end
 
@@ -23,6 +24,7 @@ class MiqAeYamlImport
     if @options['import_as'] && !new_domain_name_valid?
       raise MiqAeException::InvalidDomain, "Error - New domain exists already, #{@options['import_as']}"
     end
+
     @preview = preview
     _log.info("Import options: <#{@options}> preview: <#{@preview}>")
     _log.info("Importing domain:    <#{domain_name}>")
@@ -253,6 +255,7 @@ class MiqAeYamlImport
     invalid_attributes = []
     %w[repository playbook credential vault_credential cloud_credential].each do |attr|
       next unless options["#{attr}_name".to_sym]
+
       convert_playbook_attribute(options, attr, invalid_attributes)
     end
 
@@ -330,6 +333,7 @@ class MiqAeYamlImport
 
   def update(domain_obj)
     return if domain_obj.name.downcase == MiqAeDatastore::MANAGEIQ_DOMAIN.downcase
+
     attrs = @options.slice('enabled', 'source')
     domain_obj.update(attrs) unless attrs.empty?
   end

--- a/app/models/miq_ae_yaml_import_consolidated.rb
+++ b/app/models/miq_ae_yaml_import_consolidated.rb
@@ -2,7 +2,7 @@ class MiqAeYamlImportConsolidated < MiqAeYamlImport
   include MiqAeYamlImportExportMixin
   def initialize(domain, options)
     super
-    @fn_flags  = File::FNM_CASEFOLD | File::FNM_PATHNAME
+    @fn_flags = File::FNM_CASEFOLD | File::FNM_PATHNAME
     load_yaml
   end
 
@@ -10,6 +10,7 @@ class MiqAeYamlImportConsolidated < MiqAeYamlImport
     unless File.exist?(@options['yaml_file'])
       raise MiqAeException::FileNotFound, "import file: #{@options['yaml_file']} not found"
     end
+
     @yaml_model = YAML.load_file(@options['yaml_file'])
   end
 
@@ -38,6 +39,7 @@ class MiqAeYamlImportConsolidated < MiqAeYamlImport
   def domain_files(domain)
     keys = @yaml_model.keys
     return [] if keys.empty?
+
     keys.select! do |key|
       File.fnmatch(domain, key, @fn_flags) && @yaml_model.has_key_path?(*[key, DOMAIN_YAML_FILENAME])
     end

--- a/app/models/miq_ae_yaml_import_fs.rb
+++ b/app/models/miq_ae_yaml_import_fs.rb
@@ -27,6 +27,7 @@ class MiqAeYamlImportFs < MiqAeYamlImport
   def load_class_schema(class_folder)
     raise MiqAeException::DirectoryNotFound, "Folder [#{class_folder}] not found" \
       unless File.directory?(class_folder)
+
     load_file(File.join(class_folder, CLASS_YAML_FILENAME))
   end
 

--- a/app/models/miq_ae_yaml_import_gitfs.rb
+++ b/app/models/miq_ae_yaml_import_gitfs.rb
@@ -9,6 +9,7 @@ class MiqAeYamlImportGitfs < MiqAeYamlImport
     unless Dir.exist?(@options['git_dir'])
       raise MiqAeException::DirectoryNotFound, "Git repo dir: #{@options['git_dir']} not found"
     end
+
     @gwt = GitWorktree.new(:path => @options['git_dir'])
     @gwt.branch = @options['branch'] if @options['branch']
     @gwt.tag = @options['tag'] if @options['tag']

--- a/app/models/miq_ae_yaml_import_zipfs.rb
+++ b/app/models/miq_ae_yaml_import_zipfs.rb
@@ -1,7 +1,7 @@
 class MiqAeYamlImportZipfs < MiqAeYamlImport
   def initialize(domain, options)
     super
-    @fn_flags  = File::FNM_CASEFOLD | File::FNM_PATHNAME
+    @fn_flags = File::FNM_CASEFOLD | File::FNM_PATHNAME
     load_zip
   end
 
@@ -9,6 +9,7 @@ class MiqAeYamlImportZipfs < MiqAeYamlImport
     require 'zip/filesystem'
     raise MiqAeException::FileNotFound, "import file: #{@options['zip_file']} not found" \
       unless File.exist?(@options['zip_file'])
+
     @zip = Zip::File.open(@options['zip_file'])
     @sorted_entries = @zip.entries.sort
   end

--- a/app/models/mixins/miq_ae_copy_mixin.rb
+++ b/app/models/mixins/miq_ae_copy_mixin.rb
@@ -8,6 +8,7 @@ module MiqAeCopyMixin
       domain = parts.shift
       partial_ns = parts.join('/')
       return domain, partial_ns, ae_class, ae_instance if has_instance_name
+
       return domain, partial_ns, ae_class
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_ansible_method_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_ansible_method_base.rb
@@ -108,6 +108,7 @@ module MiqAeEngine
     def wait_for_method(task_id)
       task = MiqTask.wait_for_taskid(task_id)
       raise MiqAeException::Error, task.message unless task.status == "Ok"
+
       process_result(task)
     ensure
       reset
@@ -117,6 +118,7 @@ module MiqAeEngine
       task = MiqTask.find(task_id)
       raise MiqAeException::Error, "Task id #{task_id} not found" unless task
       return mark_for_retry(task_id) unless task.state == MiqTask::STATE_FINISHED
+
       post_process_status(task)
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -24,7 +24,7 @@ module MiqAeEngine
       $miq_ae_logger.info("Dumping Object")
 
       $miq_ae_logger.info("Listing Object Attributes:")
-      obj.attributes.sort.each { |k, v|  $miq_ae_logger.info("\t#{k}: #{v}") }
+      obj.attributes.sort.each { |k, v| $miq_ae_logger.info("\t#{k}: #{v}") }
       $miq_ae_logger.info("===========================================")
     end
 
@@ -86,6 +86,7 @@ module MiqAeEngine
       vm = prov.vm_template
       ems = vm.ext_management_system
       raise "EMS not found for VM [#{vm.name}" if ems.nil?
+
       min_running_vms = nil
       result = {}
       ems.hosts.each do |h|
@@ -166,12 +167,14 @@ module MiqAeEngine
     def self.event_object_from_workspace(obj)
       event = obj.workspace.get_obj_from_path("/")['event_stream']
       raise MiqAeException::MethodParmMissing, "Event not specified" if event.nil?
+
       event
     end
     private_class_method :event_object_from_workspace
 
     def self.vm_detect_category(prov_obj_source)
       return nil unless prov_obj_source.respond_to?(:cloud)
+
       prov_obj_source.cloud ? CLOUD : INFRASTRUCTURE
     end
     private_class_method :vm_detect_category
@@ -231,6 +234,7 @@ module MiqAeEngine
 
     def self.detect_vendor(src_obj, attr)
       return unless src_obj
+
       case attr
       when "orchestration_stack"
         src_obj.ext_management_system.try(:provider_name)
@@ -243,12 +247,14 @@ module MiqAeEngine
 
     def self.emsevent_provider_name(event_stream)
       return nil if event_stream.ext_management_system.nil?
+
       event_stream.ext_management_system.try(:provider_name)
     end
     private_class_method :emsevent_provider_name
 
     def self.emsevent_manager_type(event_stream)
       return nil if event_stream.ext_management_system.nil?
+
       manager_type = event_stream.ext_management_system.try(:manager_type).downcase
       manager_type == "infra" ? INFRASTRUCTURE : manager_type
     end
@@ -266,8 +272,10 @@ module MiqAeEngine
       if emsevent?(event_stream)
         provider_name = emsevent_provider_name(event_stream)
         raise "EMS event - Invalid provider" if provider_name.blank?
+
         manager_type = emsevent_manager_type(event_stream)
         raise "EMS event - Invalid manager type" if manager_type.blank?
+
         obj.workspace.root['event_path'] = "/#{provider_name}/EMSEvent/#{manager_type}/Event"
       else
         obj.workspace.root['event_path'] = "/System/Event/#{event_stream.event_namespace}/#{event_stream.source}"

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_deserialize_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_deserialize_workspace.rb
@@ -9,6 +9,7 @@ module MiqAeEngine
       obj = path == "root" ? root : find_object(root, path)
       $miq_ae_logger.error("Object #{path} not found in workspace") unless obj
       raise MiqAeException::Error, "object not found #{path}" unless obj
+
       update_obj_attributes(obj, attributes, user)
     end
 
@@ -20,6 +21,7 @@ module MiqAeEngine
 
     def find_object(obj, object_name)
       return obj if obj.object_name == object_name
+
       obj.children.each do |child|
         found = find_object(child, object_name)
         return found if found

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
@@ -20,6 +20,7 @@ module MiqAeEngine
       return ns if ns.nil? || klass.nil?
       return ns if scheme != "miqaedb"
       return ns if @fqns_id_cache.key?(ns)
+
       search(uri, ns, klass, instance, nil)
     end
 
@@ -27,6 +28,7 @@ module MiqAeEngine
       return ns if ns.nil? || klass.nil?
       return ns if scheme != "miqaedb"
       return ns if @fqns_id_cache.key?(ns)
+
       search(uri, ns, klass, nil, method)
     end
 
@@ -85,16 +87,18 @@ module MiqAeEngine
 
     def find_class_id(class_name, ns_id)
       return nil if class_name.nil? || ns_id.nil?
+
       key_name = "#{class_name}#{ns_id}"
       return @fqns_id_class_cache[key_name] if @fqns_id_class_cache.key?(key_name)
 
       class_filter = MiqAeClass.arel_table[:name].lower.matches(class_name.downcase)
-      ae_class  = MiqAeClass.where(class_filter).where(:namespace_id => ns_id)
+      ae_class = MiqAeClass.where(class_filter).where(:namespace_id => ns_id)
       @fqns_id_class_cache[key_name] = ae_class.first.id if ae_class.any?
     end
 
     def find_instance_id(instance_name, class_id)
       return nil if instance_name.nil? || class_id.nil?
+
       instance_name = ::ActiveRecordQueryParts.glob_to_sql_like(instance_name.dup).downcase
       ae_instance_filter = MiqAeInstance.arel_table[:name].lower.matches(instance_name)
       ae_instances = MiqAeInstance.where(ae_instance_filter).where(:class_id => class_id)
@@ -103,6 +107,7 @@ module MiqAeEngine
 
     def find_method_id(method_name, class_id)
       return nil if method_name.nil? || class_id.nil?
+
       ae_method_filter = ::MiqAeMethod.arel_table[:name].lower.matches(method_name)
       ae_methods = ::MiqAeMethod.where(ae_method_filter).where(:class_id => class_id)
       ae_methods.first.try(:id)

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
@@ -22,6 +22,7 @@ module MiqAeEngine
 
     def load_expression(data)
       raise MiqAeException::MethodExpressionEmpty, "Empty expression" if data.blank?
+
       begin
         hash = YAML.load(data)
         if hash[:expression] && hash[:db]
@@ -66,6 +67,7 @@ module MiqAeEngine
 
     def result_simple(obj, attr)
       raise MiqAeException::MethodNotDefined, "Undefined method #{attr} in class #{obj.class}" unless obj.respond_to?(attr.to_sym)
+
       obj.send(attr.to_sym)
     end
 
@@ -104,6 +106,7 @@ module MiqAeEngine
 
     def set_default_value
       return unless @inputs.key?('default')
+
       target_object.attributes[attribute_name] = @inputs['default']
     end
 
@@ -138,6 +141,7 @@ module MiqAeEngine
       (1..num_token).each do |i|
         key = "arg#{i}"
         raise MiqAeException::MethodParameterNotFound, key unless @inputs.key?(key)
+
         params[i - 1] = @inputs[key]
       end
       params

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -8,6 +8,7 @@ module MiqAeEngine
 
     def self.invoke_inline(aem, obj, inputs)
       return invoke_inline_ruby(aem, obj, inputs) if aem.language.downcase.strip == "ruby"
+
       raise  MiqAeException::InvalidMethod, "Inline Method Language [#{aem.language}] not supported"
     end
 
@@ -41,14 +42,15 @@ module MiqAeEngine
 
       # Create the filename corresponding to the URI specification
       fname = ae_methods_dir.join(uri.path)
-      raise  MiqAeException::MethodNotFound, "Method [#{aem.data}] Not Found (fname=#{fname})" unless File.exist?(fname)
+      raise MiqAeException::MethodNotFound, "Method [#{aem.data}] Not Found (fname=#{fname})" unless File.exist?(fname)
+
       cmd = "#{aem.language} #{fname}"
       invoke_external(cmd, obj.workspace)
     end
 
     def self.invoke_builtin(aem, obj, inputs)
       mname = "miq_#{aem.data.blank? ? aem.name.downcase : aem.data.downcase}"
-      raise  MiqAeException::MethodNotFound, "Built-In Method [#{mname}] does not exist" unless MiqAeBuiltinMethod.public_methods.collect(&:to_s).include?(mname)
+      raise MiqAeException::MethodNotFound, "Built-In Method [#{mname}] does not exist" unless MiqAeBuiltinMethod.public_methods.collect(&:to_s).include?(mname)
 
       # Create service, since built-in method may be calling things that assume there is one
       svc = MiqAeMethodService::MiqAeService.new(obj.workspace)
@@ -224,7 +226,7 @@ module MiqAeEngine
           threads.each(&:join)
           wait_thread.value
         end
-        rc  = status.exitstatus
+        rc = status.exitstatus
         msg = "Method exited with rc=#{verbose_rc(rc)}"
         method_pid = nil
         threads = []
@@ -279,6 +281,7 @@ module MiqAeEngine
         cls = ::MiqAeClass.lookup_by_fqname("#{match_ns}/#{klass}")
         aem = ::MiqAeMethod.find_by(:class_id => cls.id, :name => method_name) if cls
         raise MiqAeException::MethodNotFound, "Embedded method #{name} not found" unless aem
+
         fqname = "/#{match_ns}/#{klass}/#{method_name}"
         if top == fqname
           $miq_ae_logger.info("Skipping #{fqname}, cannot reference the top method")

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object_lookup.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object_lookup.rb
@@ -46,6 +46,7 @@ module MiqAeEngine
     def parse_obj_path(path)
       parts = path.downcase.split('/')
       raise MiqAeException::InvalidPathFormat, "#{path} is invalid. Need at least Namespace/Class/Instance" if parts.length < 3
+
       {
         'instance'   => parts.pop,
         'class_name' => parts.pop,

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_path.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_path.rb
@@ -10,6 +10,7 @@ module MiqAeEngine
 
     def to_s
       return "" if parts.all?(&:blank?)
+
       parts.join("/")
     end
 
@@ -18,7 +19,7 @@ module MiqAeEngine
       parts_array << @ae_namespace
       parts_array << @ae_class
       parts_array << @ae_instance
-      parts_array << @ae_attribute    unless @ae_attribute.blank?
+      parts_array << @ae_attribute if @ae_attribute.present?
       parts_array
     end
 
@@ -32,13 +33,14 @@ module MiqAeEngine
 
     def self.join(ns, klass, instance, attribute_name = nil)
       return [nil, ns, klass, instance].join("/") if attribute_name.nil?
+
       [nil, ns, klass, instance, attribute_name].join("/")
     end
 
     def self.split(path, options = {})
       options[:has_instance_name] = true unless options.key?(:has_instance_name)
       parts = path.split('/')
-      parts << nil if path[-1, 1] == '/' && options[:has_instance_name]  # Nil instance if trailing /
+      parts << nil if path[-1, 1] == '/' && options[:has_instance_name] # Nil instance if trailing /
       parts.shift  if path[0, 1] == '/'                                 # Remove the leading blank piece
       attribute_name = options[:has_attribute_name] ? parts.pop : nil
       instance       = options[:has_instance_name] ? parts.pop : nil
@@ -50,6 +52,7 @@ module MiqAeEngine
 
     def self.wildcard?(path)
       return false if path.nil?
+
       path.last == "*"
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_serialize_workspace.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_serialize_workspace.rb
@@ -18,6 +18,7 @@ module MiqAeEngine
     def process_attributes(obj)
       obj.attributes.each_with_object({}) do |(k, v), hash|
         next if v.nil?
+
         hash[k.to_s] = MiqAeReference.encode(v)
       end
     end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_info.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_info.rb
@@ -4,15 +4,18 @@ module MiqAeEngine
 
     def save_current_state_info(key)
       return unless root && root['ae_state']
-      root_state_hash  = {}
+
+      root_state_hash = {}
       STATE_SALIENT_ATTRIBUTES.each { |k| root_state_hash[k] = root[k] }
       @current_state_info[key] = root_state_hash
     end
 
     def reset_state_info(key)
       return unless root
+
       STATE_SALIENT_ATTRIBUTES.each { |k| root[k] = nil }
       return unless @current_state_info.key?(key)
+
       @current_state_info[key].each { |k, v| root[k] = v }
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
@@ -33,13 +33,16 @@ module MiqAeEngine
     def enforce_max_retries(f)
       return if f['max_retries'].blank?
       return if f['max_retries'].to_i >= @workspace.root['ae_state_retries'].to_i
+
       raise "number of retries <#{@workspace.root['ae_state_retries']}> exceeded maximum of <#{f['max_retries']}>"
     end
 
     def enforce_max_time(f)
       return if f['max_time'].blank?
+
       lapsed = Time.zone.now.utc - Time.zone.parse(@workspace.root['ae_state_started'])
       return if f['max_time'].to_i_with_method > lapsed
+
       raise "time in state <#{lapsed} seconds> exceeded maximum of <#{f['max_time']}>"
     end
 
@@ -82,7 +85,7 @@ module MiqAeEngine
         process_state_step_with_error_handling(f) { process_state_relationship(f, message, args) } if state_runnable?(f)
 
         # Check the ae_result and set the next state appropriately
-        if   @workspace.root['ae_result'] == 'ok'
+        if @workspace.root['ae_result'] == 'ok'
           $miq_ae_logger.info("Processed State=[#{f['name']}]")
         elsif @workspace.root['ae_result'] == 'skip'
           $miq_ae_logger.warn("Skipping State=[#{f['name']}]")
@@ -157,8 +160,9 @@ module MiqAeEngine
       state_name = @workspace.root['ae_next_state'].presence || current
       states = fields(message).collect { |f| f['name'] if f['aetype'] == 'state' }.compact
       validate_state(states)
-      index  = states.index(state_name)
+      index = states.index(state_name)
       return nil if index.nil?
+
       @workspace.root['ae_next_state'].blank? ? states[index + 1] : states[index]
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_uri.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_uri.rb
@@ -7,6 +7,7 @@ module MiqAeEngine
       hash.keys.sort_by(&:to_s).each do |k|
         v = hash[k]
         next if v.nil?
+
         value = v.kind_of?(ActiveRecord::Base) ? v.id : v
         query.push([ERB::Util.url_encode(k), ERB::Util.url_encode(value.to_s)].join('='))
       end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -26,7 +26,7 @@ module MiqAeEngine
       initialize_obj_entries
     end
 
-    delegate :prepend_namespace=, :to =>  :@dom_search
+    delegate :prepend_namespace=, :to => :@dom_search
 
     def readonly?
       @readonly
@@ -45,7 +45,7 @@ module MiqAeEngine
     end
 
     def self.instantiate(uri, user, attrs = {})
-       User.with_user(user) { instantiate_with_user(uri, user, attrs) }
+      User.with_user(user) { instantiate_with_user(uri, user, attrs) }
     end
 
     def self.instantiate_with_user(uri, user, attrs)
@@ -74,7 +74,7 @@ module MiqAeEngine
     def datastore(klass, key)
       if DATASTORE_CACHE
         @datastore_cache[klass] ||= {}
-        @datastore_cache[klass][key] = yield      unless @datastore_cache[klass].key?(key)
+        @datastore_cache[klass][key] = yield unless @datastore_cache[klass].key?(key)
         @datastore_cache[klass][key]
       else
         yield
@@ -84,6 +84,7 @@ module MiqAeEngine
     def varget(uri)
       obj = current_object
       raise MiqAeException::ObjectNotFound, "Current Object Not Found" if obj.nil?
+
       obj.uri2value(uri)
     end
 
@@ -91,7 +92,8 @@ module MiqAeEngine
       scheme, userinfo, host, port, registry, path, opaque, query, fragment = MiqAeUri.split(uri)
       if scheme == "miqaews"
         o = get_obj_from_path(path)
-        raise MiqAeException::ObjectNotFound, "Object Not Found for path=[#{path}]"  if o.nil?
+        raise MiqAeException::ObjectNotFound, "Object Not Found for path=[#{path}]" if o.nil?
+
         o[fragment] = value
         return true
       end
@@ -120,7 +122,7 @@ module MiqAeEngine
       ns, klass, instance = MiqAePath.split(path)
       ns = overlay_namespace(scheme, uri, ns, klass, instance)
       current = @current.last
-      ns ||= current[:ns]    if current
+      ns ||= current[:ns] if current
       klass ||= current[:klass] if current
 
       pushed = false
@@ -151,6 +153,7 @@ module MiqAeEngine
           raise MiqAeException::ObjectNotFound, "Object [#{path}] not found" if obj.nil?
         elsif ["miqaemethod", "method"].include?(scheme)
           raise MiqAeException::MethodNotFound, "No Current Object" if current[:object].nil?
+
           return current[:object].process_method_via_uri(uri)
         end
         obj.process_fields(message)
@@ -219,6 +222,7 @@ module MiqAeEngine
 
     def obj_to_dot(g, obj)
       return nil if obj.nil?
+
       o = g.add_node(obj.object_name)
       # o["MiqAeClass"]     = obj.klass
       # o["MiqAeNamespace"] = obj.namespace
@@ -280,6 +284,7 @@ module MiqAeEngine
     def current(elem = nil)
       c = @current.last
       return c if elem.nil? || c.nil?
+
       c[elem]
     end
 
@@ -300,6 +305,7 @@ module MiqAeEngine
     def root(attrib = nil)
       return nil if roots.empty?
       return roots.first if attrib.nil?
+
       roots.first.attributes[attrib.downcase]
     end
 
@@ -316,9 +322,11 @@ module MiqAeEngine
 
       if path == "/"
         return roots[0] if obj.nil?
+
         loop do
           parent = obj.node_parent
           return obj if parent.nil?
+
           obj = parent
         end
       elsif path[0, 1] == "."
@@ -342,6 +350,7 @@ module MiqAeEngine
       path = path[1..-1] if path[0] == '/'
       plist = path.split("/")
       raise MiqAeException::InvalidPathFormat, "Unsupported Path [#{path}]" if plist[0].blank?
+
       klass = plist.pop
       ns    = plist.length.zero? ? "*" : plist.join('/')
 
@@ -349,6 +358,7 @@ module MiqAeEngine
       while (obj = obj.node_parent)
         next unless klass.casecmp(obj.klass).zero?
         break if ns == "*"
+
         ns_split = obj.namespace.split('/')
         ns_split.shift # sans domain
         break if ns.casecmp(ns_split.join('/')).zero?

--- a/lib/miq_automation_engine/engine/miq_ae_event.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_event.rb
@@ -45,6 +45,7 @@ module MiqAeEvent
     aevent.merge!(inputs)
     ws = call_automate(target, aevent, 'Alert', options)
     return nil if ws.nil? || ws.root.nil?
+
     ws.root['ae_result']
   end
 
@@ -76,11 +77,12 @@ module MiqAeEvent
         raise "Unexpected class #{inputs[hash[:key]].class.name} for #{hash[:key]} -- expected class=#{hash[:class].name}"
       end
 
-      aevent.merge!("#{hash[:class].name}::#{hash[:name]}" => vmdb_object.id, "#{hash[:key]}_id".to_sym  => vmdb_object.id)
+      aevent.merge!("#{hash[:class].name}::#{hash[:name]}" => vmdb_object.id, "#{hash[:key]}_id".to_sym => vmdb_object.id)
     end
 
     inputs.delete_if do |_k, value|
       next unless value.kind_of?(ApplicationRecord)
+
       klass = value.class.base_class.name
       aevent.merge!("#{klass}::#{klass.underscore}" => value.id, "#{klass.underscore}_id".to_sym => value.id)
     end

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -43,7 +43,7 @@ module MiqAeMethodService
       ws.disable_rbac
     end
 
-    delegate :enable_rbac, :disable_rbac, :rbac_enabled?, :to =>  :@workspace
+    delegate :enable_rbac, :disable_rbac, :rbac_enabled?, :to => :@workspace
 
     def stdout
       @stdout ||= Vmdb::Loggers::IoLogger.new(logger, :info, "Method STDOUT:")
@@ -130,6 +130,7 @@ module MiqAeMethodService
     def instantiate(uri)
       obj = @workspace.instantiate(uri, @workspace.ae_user, @workspace.current_object)
       return nil if obj.nil?
+
       MiqAeServiceObject.new(obj, self)
     rescue StandardError => e
       $miq_ae_logger.error("instantiate failed : #{e.message}")
@@ -139,6 +140,7 @@ module MiqAeMethodService
     def object(path = nil)
       obj = @workspace.get_obj_from_path(path)
       return nil if obj.nil?
+
       MiqAeServiceObject.new(obj, self)
     end
 
@@ -240,7 +242,7 @@ module MiqAeMethodService
     end
 
     def create_notification!(values_hash = {})
-       User.with_user(@workspace.ae_user) { create_notification_with_user!(values_hash) }
+      User.with_user(@workspace.ae_user) { create_notification_with_user!(values_hash) }
     end
 
     def create_notification_with_user!(values_hash)
@@ -377,8 +379,10 @@ module MiqAeMethodService
     def editable_instance?(path)
       dom, = MiqAeEngine::MiqAePath.get_domain_ns_klass_inst(path)
       return false unless owned_domain?(dom)
+
       domain = MiqAeDomain.lookup_by_fqname(dom, false)
       return false unless domain
+
       $log.warn "path=#{path.inspect} : is not editable" unless domain.editable?(@workspace.ae_user)
       domain.editable?(@workspace.ae_user)
     end
@@ -386,6 +390,7 @@ module MiqAeMethodService
     def owned_domain?(dom)
       domains = @workspace.ae_user.current_tenant.ae_domains.collect(&:name).map(&:upcase)
       return true if domains.include?(dom.upcase)
+
       $log.warn "domain=#{dom} : is not editable"
       false
     end
@@ -393,6 +398,7 @@ module MiqAeMethodService
     def visible_domain?(dom)
       domains = @workspace.ae_user.current_tenant.visible_domains.collect(&:name).map(&:upcase)
       return true if domains.include?(dom.upcase)
+
       $log.warn "domain=#{dom} : is not viewable"
       false
     end

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_object.rb
@@ -6,6 +6,7 @@ module MiqAeMethodService
 
     def initialize(obj, svc)
       raise "object cannot be nil" if obj.nil?
+
       @object  = obj
       @service = svc
     end
@@ -13,6 +14,7 @@ module MiqAeMethodService
     def children(name = nil)
       objs = @object.children(name)
       return nil if objs.nil?
+
       objs = @service.objects([objs].flatten)
       objs.length == 1 ? objs.first : objs
     end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_classification.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_classification.rb
@@ -1,6 +1,6 @@
 module MiqAeMethodService
   class MiqAeServiceClassification < MiqAeServiceModelBase
-    expose :namespace, :method      => :ns
+    expose :namespace, :method => :ns
     expose :category
     expose :name
     expose :to_tag

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_build.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_build.rb
@@ -1,4 +1,3 @@
-
 module MiqAeMethodService
   class MiqAeServiceContainerBuild < MiqAeServiceModelBase
     expose :is_tagged_with?

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_build_pod.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_build_pod.rb
@@ -1,4 +1,3 @@
-
 module MiqAeMethodService
   class MiqAeServiceContainerBuildPod < MiqAeServiceModelBase
     expose :is_tagged_with?

--- a/lib/miq_automation_engine/service_models/miq_ae_service_container_replicator.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_container_replicator.rb
@@ -1,6 +1,6 @@
 module MiqAeMethodService
   class MiqAeServiceContainerReplicator < MiqAeServiceModelBase
-    expose :metric_zones,             :association => true
+    expose :metric_zones, :association => true
     expose :is_tagged_with?
     expose :tags
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_generic_object.rb
@@ -9,12 +9,14 @@ module MiqAeMethodService
     def add_to_service(service)
       error_msg = "service must be a MiqAeServiceService"
       raise ArgumentError, error_msg unless service.kind_of?(MiqAeMethodService::MiqAeServiceService)
+
       ar_method { wrap_results(@object.add_to_service(Service.find_by(:id => service.id))) }
     end
 
     def remove_from_service(service)
       error_msg = "service must be a MiqAeServiceService"
       raise ArgumentError, error_msg unless service.kind_of?(MiqAeMethodService::MiqAeServiceService)
+
       ar_method { wrap_results(@object.remove_from_service(Service.find_by(:id => service.id))) }
     end
 
@@ -23,6 +25,7 @@ module MiqAeMethodService
     def ae_user_identity
       workspace = MiqAeEngine::MiqAeWorkspaceRuntime.current || MiqAeEngine::DrbRemoteInvoker.workspace
       raise 'Workspace not found when running generic object' unless workspace
+
       @ae_user = workspace.ae_user
       ar_method { @object.ae_user_identity(@ae_user, @ae_user.current_group, @ae_user.current_tenant) }
     end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_lan.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_lan.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
   class MiqAeServiceLan < MiqAeServiceModelBase
-    expose :templates,     :association => true, :method => :miq_templates
+    expose :templates, :association => true, :method => :miq_templates
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_load_balancer.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_load_balancer.rb
@@ -13,6 +13,7 @@ module MiqAeMethodService
     def add_to_service(service)
       error_msg = "service must be a MiqAeServiceService"
       raise ArgumentError, error_msg unless service.kind_of?(MiqAeMethodService::MiqAeServiceService)
+
       ar_method { wrap_results(Service.find_by(:id => service.id).add_resource!(@object)) }
     end
 

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm.rb
@@ -1,6 +1,5 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_Openstack_CloudManager_Vm < MiqAeServiceVmCloud
-
     expose :resize,         :override_return => nil
     expose :resize_confirm, :override_return => nil
     expose :resize_revert,  :override_return => nil

--- a/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision_request.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_miq_provision_request.rb
@@ -27,7 +27,8 @@ module MiqAeMethodService
     def get_retirement_days
       days = get_option(:retirement)
       return day if days.blank?
-      days / (60 * 60 * 24)   # Convert from seconds to days
+
+      days / (60 * 60 * 24) # Convert from seconds to days
     end
 
     def set_folder(folder_path)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_stack.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_orchestration_stack.rb
@@ -14,6 +14,7 @@ module MiqAeMethodService
     def add_to_service(service)
       error_msg = "service must be a MiqAeServiceService"
       raise ArgumentError, error_msg unless service.kind_of?(MiqAeMethodService::MiqAeServiceService)
+
       ar_method { wrap_results(Service.find_by(:id => service.id).add_resource!(@object)) }
     end
 

--- a/lib/miq_automation_engine/service_models/miq_ae_service_physical_server.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_physical_server.rb
@@ -1,6 +1,5 @@
 module MiqAeMethodService
   class MiqAeServicePhysicalServer < MiqAeServiceModelBase
-
     expose :turn_on_loc_led
     expose :turn_off_loc_led
     expose :power_on

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -26,6 +26,7 @@ module MiqAeMethodService
       if attributes[:service_template]
         raise ArgumentError, "service_template must be a MiqAeServiceServiceTemplate" unless
           attributes[:service_template].kind_of?(MiqAeMethodService::MiqAeServiceServiceTemplate)
+
         attributes[:service_template] = ServiceTemplate.find(attributes[:service_template].id)
       end
       ar_method { MiqAeServiceModelBase.wrap_results(Service.create!(attributes)) }
@@ -97,7 +98,9 @@ module MiqAeMethodService
       ar_method do
         if service
           raise ArgumentError, "service must be a MiqAeServiceService" unless service.kind_of?(
-            MiqAeMethodService::MiqAeServiceService)
+            MiqAeMethodService::MiqAeServiceService
+          )
+
           @object.add_to_service(Service.find(service.id))
         elsif @object.parent.present?
           @object.remove_from_service(@object.parent)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_transformation_plan_task.rb
@@ -30,6 +30,7 @@ module MiqAeMethodService
 
     def conversion_host=(conversion_host)
       raise ArgumentError, "conversion_host must be nil or a MiqAeServiceConversionHost" unless conversion_host.nil? || conversion_host.kind_of?(MiqAeMethodService::MiqAeServiceConversionHost)
+
       ar_method do
         conversion_host = ConversionHost.find_by(:id => conversion_host.id) if conversion_host
         @object.conversion_host = conversion_host

--- a/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_storage.rb
@@ -3,7 +3,7 @@ module MiqAeMethodService
     expose :ext_management_systems, :association => true
     expose :unregistered_vms,       :association => true
     expose :to_s
-    expose :scan,                   :override_return => true
+    expose :scan, :override_return => true
 
     def show_url
       URI.join(MiqRegion.my_region.remote_ui_url, "storage/show/#{@object.id}").to_s

--- a/lib/miq_automation_engine/service_models/miq_ae_service_user.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_user.rb
@@ -40,8 +40,10 @@ module MiqAeMethodService
     def find_ldap_user
       ldap = MiqLdap.new
       raise "Cannot bind to LDAP with system defaults (see evm.log for details)" if ldap.bind_with_default == false
+
       ldap_user = ldap.get_user_object(@object.email, 'mail') || ldap.get_user_object(@object.userid, 'userprincipalname')
       raise "No information returned for email=<#{@object.email}> userid=<#{@object.userid}>" if ldap_user.nil?
+
       ldap_user
     end
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
@@ -9,6 +9,7 @@ module MiqAeMethodService
 
     def add_to_service(service)
       raise ArgumentError, "service must be a MiqAeServiceService" unless service.kind_of?(MiqAeMethodService::MiqAeServiceService)
+
       ar_method { wrap_results(@object.add_to_service(Service.find_by(:id => service.id))) }
     end
 

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
@@ -25,7 +25,6 @@ module MiqAeMethodService
     expose :refresh, :method => :refresh_ems
     expose :evacuate
 
-
     METHODS_WITH_NO_ARGS = %w[start stop suspend unregister collect_running_processes shutdown_guest standby_guest reboot_guest].freeze
     METHODS_WITH_NO_ARGS.each do |m|
       define_method(m) do

--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_service_ansible_tower_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_service_ansible_tower_mixin.rb
@@ -11,7 +11,7 @@ module MiqAeServiceServiceAnsibleTowerMixin
     end
 
     ar_method do
-      @object.job_template = template ? ConfigurationScript.find_by(:id => template.id): nil
+      @object.job_template = template ? ConfigurationScript.find_by(:id => template.id) : nil
       @object.save
     end
   end

--- a/spec/data/evm1_domain/evm1/test/AUTOMATE.class/__methods__/evm1_missing_method.rb
+++ b/spec/data/evm1_domain/evm1/test/AUTOMATE.class/__methods__/evm1_missing_method.rb
@@ -1,1 +1,1 @@
-$evm.root['method_executed']  = "evm1_missing_method"
+$evm.root['method_executed'] = "evm1_missing_method"

--- a/spec/data/evm2_domain/evm2/test/AUTOMATE.class/__methods__/evm2_missing_method.rb
+++ b/spec/data/evm2_domain/evm2/test/AUTOMATE.class/__methods__/evm2_missing_method.rb
@@ -1,1 +1,1 @@
-$evm.root['method_executed']  = "evm2_missing_method"
+$evm.root['method_executed'] = "evm2_missing_method"

--- a/spec/data/inert_domain/inert/evm/AUTOMATE.class/__methods__/root_method.rb
+++ b/spec/data/inert_domain/inert/evm/AUTOMATE.class/__methods__/root_method.rb
@@ -1,1 +1,1 @@
-$evm.root['method_executed']  = "inert"
+$evm.root['method_executed'] = "inert"

--- a/spec/data/provision/SPEC_DOMAIN/EVMApplications/Provisioning/WHERE.class/__methods__/least_utilized.rb
+++ b/spec/data/provision/SPEC_DOMAIN/EVMApplications/Provisioning/WHERE.class/__methods__/least_utilized.rb
@@ -5,8 +5,9 @@ begin
   $evm.log("info", "Inline Method: least_utilized -- vm=[#{vm.name}]")
   raise "VM not specified" if vm.nil?
 
-  ems  = vm.ext_management_system
+  ems = vm.ext_management_system
   raise "EMS not found for VM [#{vm.name}" if vm.nil?
+
   host = storage = nil
   min_registered_vms = nil
   ems.hosts.each do |h|

--- a/spec/data/root_domain/root/evm/AUTOMATE.class/__methods__/root_method.rb
+++ b/spec/data/root_domain/root/evm/AUTOMATE.class/__methods__/root_method.rb
@@ -5,5 +5,5 @@ begin
           end
           $evm.log("info", "#{@method} - Root:<$evm.root> End Attributes")
           $evm.log("info", $evm.class.name)
-          $evm.root['method_executed']  = "root"
+          $evm.root['method_executed'] = "root"
         end

--- a/spec/data/state_machine/SPEC_DOMAIN/Automation/VMLifecycle.class/__methods__/provision_state_machine.rb
+++ b/spec/data/state_machine/SPEC_DOMAIN/Automation/VMLifecycle.class/__methods__/provision_state_machine.rb
@@ -35,25 +35,25 @@ def log_error(msg, state, final_state)
   $evm.log("warn", msg) unless state == final_state
 end
 
-current     = $evm.current
+current = $evm.current
 $evm.log("info", "Listing CURRENT Object Attributes:")
 current.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
 $evm.log("info", "===========================================")
-step        = current['step']
-step        = 'initial' if step.nil? || step.empty?
-step_index  = STEPS.index(step)
+step = current['step']
+step = 'initial' if step.blank?
+step_index = STEPS.index(step)
 $evm.log("info", "STEP=<#{step}> INDEX=<#{step_index}>")
 
-root        = $evm.root
+root = $evm.root
 $evm.log("info", "Listing ROOT Object Attributes:")
 root.attributes.sort.each { |k, v| $evm.log("info", "\t#{k}: #{v}") }
 $evm.log("info", "===========================================")
-state       = root["ae_state"]
-state       = 'initial' if state.nil? || state.empty?
+state = root["ae_state"]
+state = 'initial' if state.blank?
 state_index = STEPS.index(state)
 $evm.log("info", "STATE=<#{state}> INDEX=<#{state_index}>")
 
-result      = root["ae_result"]
+result = root["ae_result"]
 $evm.log("info", "AE_RESULT=<#{result}>")
 
 if step_index == (state_index - 1)
@@ -65,7 +65,7 @@ elsif step_index == state_index
     if result == 'error'
       message = 'error'
       final_state = STEPS.last
-      new_state_index = STEPS.index(final_state)   # Go To FINAL state on Error
+      new_state_index = STEPS.index(final_state) # Go To FINAL state on Error
       log_error("Error in State=<#{STEPS[state_index]}>", state, final_state)
     else
       message = 'create'

--- a/spec/data/user_domain/user/evm/AUTOMATE.class/__methods__/root_method.rb
+++ b/spec/data/user_domain/user/evm/AUTOMATE.class/__methods__/root_method.rb
@@ -5,5 +5,5 @@ begin
               end
               $evm.log("info", "#{@method} - Root:<$evm.root> End Attributes")
               $evm.log("info", $evm.class.name)
-              $evm.root['method_executed']  = "user"
+              $evm.root['method_executed'] = "user"
             end

--- a/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
@@ -2,7 +2,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
   before do
     @user = FactoryBot.create(:user_with_group)
     Spec::Support::MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM', 'AUTOMATE', 'test1', 'test')
-    @ae_method     = ::MiqAeMethod.first
+    @ae_method = ::MiqAeMethod.first
     @ae_result_key = 'foo'
   end
 
@@ -12,7 +12,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
 
   context "exposes ActiveSupport methods" do
     it "nil#blank?" do
-      method   = "$evm.root['#{@ae_result_key}'] = nil.blank?"
+      method = "$evm.root['#{@ae_result_key}'] = nil.blank?"
       @ae_method.update(:data => method)
       ae_object = invoke_ae.root(@ae_result_key)
       expect(ae_object).to be_truthy
@@ -64,7 +64,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
     to      = "wilma@bedrock.gov"
     from    = "fred@bedrock.gov"
     inputs  = {:to => to, :from => from}
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.execute(:snmp_trap_v1, #{inputs.inspect})"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:snmp_trap_v1, #{inputs.inspect})"
     @ae_method.update(:data => method)
 
     stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', true)
@@ -74,11 +74,12 @@ describe MiqAeMethodService::MiqAeServiceMethods do
 
     stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', false)
     expect(MiqQueue).to receive(:put).with(
-        :class_name  => "MiqSnmp",
-        :method_name => "trap_v1",
-        :args        => [inputs],
-        :role        => "notifier",
-        :zone        => nil).once
+      :class_name  => "MiqSnmp",
+      :method_name => "trap_v1",
+      :args        => [inputs],
+      :role        => "notifier",
+      :zone        => nil
+    ).once
     ae_object = invoke_ae.root(@ae_result_key)
     expect(ae_object).to be_truthy
   end
@@ -87,7 +88,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
     to      = "wilma@bedrock.gov"
     from    = "fred@bedrock.gov"
     inputs  = {:to => to, :from => from}
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.execute(:snmp_trap_v2, #{inputs.inspect})"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:snmp_trap_v2, #{inputs.inspect})"
     @ae_method.update(:data => method)
 
     stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', true)
@@ -97,17 +98,18 @@ describe MiqAeMethodService::MiqAeServiceMethods do
 
     stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', false)
     expect(MiqQueue).to receive(:put).with(
-        :class_name  => "MiqSnmp",
-        :method_name => "trap_v2",
-        :args        => [inputs],
-        :role        => "notifier",
-        :zone        => nil).once
+      :class_name  => "MiqSnmp",
+      :method_name => "trap_v2",
+      :args        => [inputs],
+      :role        => "notifier",
+      :zone        => nil
+    ).once
     ae_object = invoke_ae.root(@ae_result_key)
     expect(ae_object).to be_truthy
   end
 
   it "#vm_templates" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.execute(:vm_templates)"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:vm_templates)"
     @ae_method.update(:data => method)
 
     expect(invoke_ae.root(@ae_result_key)).to be_empty

--- a/spec/engine/miq_ae_method_spec.rb
+++ b/spec/engine/miq_ae_method_spec.rb
@@ -210,6 +210,7 @@ describe MiqAeEngine::MiqAeMethod do
           def verify_next_message(message)
             expected = expected_messages.shift
             return if message == expected
+
             puts "Expected: #{expected.inspect}, Got: #{message.inspect}"
             raise
           end

--- a/spec/engine/miq_ae_state_machine_multi_spec.rb
+++ b/spec/engine/miq_ae_state_machine_multi_spec.rb
@@ -17,19 +17,18 @@ describe "MultipleStateMachineSteps" do
     @state_class3        = 'SM3'
     @state_instance      = 'MY_STATE_INSTANCE'
     @fqname              = '/SPEC_DOMAIN/NS1/SM1/MY_STATE_INSTANCE'
-    @miq_server      = FactoryBot.create(:miq_server)
-    @user                = FactoryBot.create(:user_with_group)
-    @method_params       = {'ae_result'     => {:datatype => 'string', 'default_value' => 'ok'},
-                            'ae_next_state' => {:datatype => 'string'},
-                            'raise'         => {:datatype => 'string'}
-                           }
-    @automate_args   = {:namespace        => "#{@domain}/#{@namespace}",
-                        :class_name       => @state_class1,
-                        :instance_name    => @state_instance,
-                        :user_id          => @user.id,
-                        :miq_group_id     => @user.current_group_id,
-                        :tenant_id        => @user.current_tenant.id,
-                        :automate_message => 'create'}
+    @miq_server = FactoryBot.create(:miq_server)
+    @user = FactoryBot.create(:user_with_group)
+    @method_params = {'ae_result'     => {:datatype => 'string', 'default_value' => 'ok'},
+                      'ae_next_state' => {:datatype => 'string'},
+                      'raise'         => {:datatype => 'string'}}
+    @automate_args = {:namespace        => "#{@domain}/#{@namespace}",
+                      :class_name       => @state_class1,
+                      :instance_name    => @state_instance,
+                      :user_id          => @user.id,
+                      :miq_group_id     => @user.current_group_id,
+                      :tenant_id        => @user.current_tenant.id,
+                      :automate_message => 'create'}
     zone = FactoryBot.create(:zone)
     allow(MiqServer).to receive(:my_zone).and_return(zone.name)
     allow(MiqServer).to receive(:my_server).and_return(@miq_server)
@@ -98,15 +97,14 @@ describe "MultipleStateMachineSteps" do
                    'raise'         => {:value => ""}}
     ae_instances = {@instance1 => inst_values, @instance2 => inst_values,
                     @instance3 => inst_values}
-    ae_methods = {@common_method_name  => {:scope => 'instance', :location => 'inline',
+    ae_methods = {@common_method_name => {:scope => 'instance', :location => 'inline',
                                            :data => common_method_script,
-                                           :language => 'ruby', :params => @method_params}
-                 }
+                                           :language => 'ruby', :params => @method_params}}
 
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_instances' => ae_instances,
-                                   'ae_methods'   => ae_methods))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_instances' => ae_instances,
+                                  'ae_methods'   => ae_methods))
   end
 
   def create_state_class(attrs = {})
@@ -117,7 +115,7 @@ describe "MultipleStateMachineSteps" do
                  'on_error' => "common_state_method"}
     ae_fields = {"#{stem}_1" => {:aetype => 'state', :datatype => 'string', :priority => 1, :max_retries => 1},
                  "#{stem}_2" => {:aetype => 'state', :datatype => 'string', :priority => 2,
-                                 :max_retries => @max_retries, :message  => 'create'},
+                                 :max_retries => @max_retries, :message => 'create'},
                  "#{stem}_3" => {:aetype => 'state', :datatype => 'string', :priority => 3, :max_retries => 3},
                  "#{stem}_4" => {:aetype => 'state', :datatype => 'string', :priority => 4, :max_retries => 4}}
     state1_value = "/#{@domain}/#{@namespace}/#{@method_class}/#{@instance1}"
@@ -129,16 +127,15 @@ describe "MultipleStateMachineSteps" do
                                         "#{stem}_4" => {:value => state3_value}.merge(all_steps)}}
 
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_methods'   => state_methods,
-                                   'ae_instances' => ae_instances))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_methods'   => state_methods,
+                                  'ae_instances' => ae_instances))
   end
 
   def state_methods
     {@common_state_method => {:scope => 'instance', :location => 'inline',
                               :data => common_state_method_script,
-                              :language => 'ruby', 'params' => @method_params}
-    }
+                              :language => 'ruby', 'params' => @method_params}}
   end
 
   def tweak_instance(class_fqname, instance, field_name, attribute, value)

--- a/spec/engine/miq_ae_state_machine_retry_spec.rb
+++ b/spec/engine/miq_ae_state_machine_retry_spec.rb
@@ -107,9 +107,9 @@ describe "MiqAeStateMachineRetry" do
                                    :language => 'ruby', 'params' => {}}}
 
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_instances' => ae_instances,
-                                   'ae_methods'   => ae_methods))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_instances' => ae_instances,
+                                  'ae_methods'   => ae_methods))
   end
 
   def create_state_class(attrs = {}, max_time = nil)
@@ -120,9 +120,9 @@ describe "MiqAeStateMachineRetry" do
     ae_instances = {@state_instance => {'state1' => {:value => fqname}}}
 
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_methods'   => {},
-                                   'ae_instances' => ae_instances))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_methods'   => {},
+                                  'ae_instances' => ae_instances))
   end
 
   def create_root_class(attrs = {})
@@ -130,9 +130,9 @@ describe "MiqAeStateMachineRetry" do
     fqname = "/#{@domain}/#{@namespace}/#{@state_class}/#{@state_instance}"
     ae_instances = {@root_instance => {'rel1' => {:value => fqname}}}
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_methods'   => {},
-                                   'ae_instances' => ae_instances))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_methods'   => {},
+                                  'ae_instances' => ae_instances))
   end
 
   def create_method_class(attrs, script1, script2, script3)
@@ -151,9 +151,9 @@ describe "MiqAeStateMachineRetry" do
                               :language => 'ruby', 'params' => {}}}
 
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_instances' => ae_instances,
-                                   'ae_methods'   => ae_methods))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_instances' => ae_instances,
+                                  'ae_methods'   => ae_methods))
   end
 
   def create_multi_state_class(attrs = {})
@@ -167,9 +167,9 @@ describe "MiqAeStateMachineRetry" do
                                         'state2' => {:value => fq2},
                                         'state3' => {:value => fq3}}}
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_methods'   => {},
-                                   'ae_instances' => ae_instances))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_methods'   => {},
+                                  'ae_instances' => ae_instances))
   end
 
   def create_restart_model(script1, script2, script3)

--- a/spec/engine/miq_ae_state_machine_steps_spec.rb
+++ b/spec/engine/miq_ae_state_machine_steps_spec.rb
@@ -15,8 +15,7 @@ describe "MiqAeStateMachineSteps" do
     @method_params       = {'ae_result'     => {:datatype => 'string', :default_value => 'ok'},
                             'ae_next_state' => {:datatype => 'string'},
                             'raise'         => {:datatype => 'string'},
-                            'exit_code'     => {:datatype => 'integer'}
-                           }
+                            'exit_code'     => {:datatype => 'integer'}}
     clear_domain
     setup_model
   end
@@ -79,15 +78,14 @@ describe "MiqAeStateMachineSteps" do
                    'raise'         => {:value => ""}}
     ae_instances = {@instance1 => inst_values, @instance2 => inst_values,
                     @instance3 => inst_values}
-    ae_methods = {@common_method_name  => {:scope => 'instance', :location => 'inline',
+    ae_methods = {@common_method_name => {:scope => 'instance', :location => 'inline',
                                            :data => common_method_script,
-                                           :language => 'ruby', 'params' => @method_params}
-                 }
+                                           :language => 'ruby', 'params' => @method_params}}
 
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_instances' => ae_instances,
-                                   'ae_methods'   => ae_methods))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_instances' => ae_instances,
+                                  'ae_methods'   => ae_methods))
   end
 
   def create_state_class(attrs = {})
@@ -105,16 +103,15 @@ describe "MiqAeStateMachineSteps" do
                                         'state3' => {:value => state3_value}.merge(all_steps)}}
 
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_methods'   => state_methods,
-                                   'ae_instances' => ae_instances))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_methods'   => state_methods,
+                                  'ae_instances' => ae_instances))
   end
 
   def state_methods
     {@common_state_method => {:scope => 'instance', :location => 'inline',
                               :data => common_state_method_script,
-                              :language => 'ruby', 'params' => @method_params}
-    }
+                              :language => 'ruby', 'params' => @method_params}}
   end
 
   def tweak_instance(class_fqname, instance, field_name, attribute, value)

--- a/spec/engine/miq_ae_workspace_runtime_spec.rb
+++ b/spec/engine/miq_ae_workspace_runtime_spec.rb
@@ -7,7 +7,7 @@ describe MiqAeEngine::MiqAeWorkspaceRuntime do
 
   describe "#instantiate" do
     it "returns workspace" do
-      expect(MiqAeEngine::MiqAeWorkspaceRuntime.instantiate("/a/b/c", user)).to be_a_kind_of(MiqAeEngine::MiqAeWorkspaceRuntime) 
+      expect(MiqAeEngine::MiqAeWorkspaceRuntime.instantiate("/a/b/c", user)).to be_a_kind_of(MiqAeEngine::MiqAeWorkspaceRuntime)
     end
   end
 end

--- a/spec/miq_ae_ansible_template_method_spec.rb
+++ b/spec/miq_ae_ansible_template_method_spec.rb
@@ -3,7 +3,7 @@ describe MiqAeEngine::MiqAeAnsibleTemplateMethod do
     before { allow(MiqServer).to receive(:my_zone).and_return(FactoryGirl.create(:zone).name) }
     let(:user) { FactoryBot.create(:user_with_group) }
     let(:aw) { FactoryBot.create(:automate_workspace, :user => user, :tenant => user.current_tenant) }
-    let(:root_hash) { { 'name' => 'Flintstone' } }
+    let(:root_hash) { {'name' => 'Flintstone'} }
     let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
     let(:persist_hash) { MiqAeEngine::StateVarHash.new }
     let(:options) { {"test" => 13} }
@@ -27,12 +27,12 @@ describe MiqAeEngine::MiqAeAnsibleTemplateMethod do
 
     let(:user) do
       FactoryBot.create(:user_with_group, :userid   => "admin",
-                                           :settings => {:display => { :timezone => "UTC"}})
+                                          :settings => {:display => {:timezone => "UTC"}})
     end
 
     let(:aem)    { double("AEM", :options => options, :name => method_name) }
     let(:obj)    { double("OBJ", :workspace => workspace) }
-    let(:inputs) { { 'name' => 'Fred' } }
+    let(:inputs) { {'name' => 'Fred'} }
 
     let(:mpr) { FactoryBot.create(:miq_provision_request, :requester => user) }
 
@@ -90,8 +90,8 @@ describe MiqAeEngine::MiqAeAnsibleTemplateMethod do
       context "service_template_provision_task" do
         let(:task_href_slug) { "#{svc_stpr.href_slug}/#{svc_stpt.href_slug}" }
         let(:root_hash) do
-          { 'vmdb_object_type'                => 'service_template_provision_task',
-            'service_template_provision_task' => svc_stpt }
+          {'vmdb_object_type'                => 'service_template_provision_task',
+           'service_template_provision_task' => svc_stpt}
         end
         it_behaves_like "task_slug"
       end
@@ -99,8 +99,8 @@ describe MiqAeEngine::MiqAeAnsibleTemplateMethod do
       context "provision_task" do
         let(:task_href_slug) { "#{svc_mpr.href_slug}/#{svc_mpt.href_slug}" }
         let(:root_hash) do
-          { 'vmdb_object_type' => 'miq_provision',
-            'miq_provision'    => svc_mpt }
+          {'vmdb_object_type' => 'miq_provision',
+           'miq_provision'    => svc_mpt}
         end
         it_behaves_like "task_slug"
       end

--- a/spec/miq_ae_assertion_spec.rb
+++ b/spec/miq_ae_assertion_spec.rb
@@ -11,13 +11,13 @@ describe MiqAeEngine::MiqAeObject do
     let(:number_of_vms) { 999 }
     let(:vm_template) do
       FactoryBot.create(:template_vmware, :name                  => "template1",
-                                           :ext_management_system => ems)
+                                          :ext_management_system => ems)
     end
     let(:miq_provision_request) do
       FactoryBot.create(:miq_provision_request,
-                         :requester => user,
-                         :src_vm_id => vm_template.id,
-                         :options   => {:number_of_vms => number_of_vms})
+                        :requester => user,
+                        :src_vm_id => vm_template.id,
+                        :options   => {:number_of_vms => number_of_vms})
     end
 
     let(:ae_instances) do

--- a/spec/miq_ae_collect_spec.rb
+++ b/spec/miq_ae_collect_spec.rb
@@ -45,7 +45,7 @@ describe "MiqAeCollect" do
 
   it "collect on instance level overrides collect on class level" do
     c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/TEST", "COLLECT")
-    i1 = c1.ae_instances.detect { |i| i.name == "INFO"   }
+    i1 = c1.ae_instances.detect { |i| i.name == "INFO" }
     f1 = c1.ae_fields.detect    { |f| f.name == "weekdays" }
     i1.set_field_collect(f1, "weekdays = [description]")
 

--- a/spec/miq_ae_deserialize_workspace_spec.rb
+++ b/spec/miq_ae_deserialize_workspace_spec.rb
@@ -20,8 +20,8 @@ describe "MiqAeDeserializeWorkspace" do
 
   let(:user) do
     FactoryBot.create(:user_with_group,
-                       :userid   => "admin",
-                       :settings => {:display => { :timezone => "UTC"}})
+                      :userid   => "admin",
+                      :settings => {:display => {:timezone => "UTC"}})
   end
 
   let(:workspace) do
@@ -35,10 +35,10 @@ describe "MiqAeDeserializeWorkspace" do
 
   describe "#update_workspace" do
     context "caller adds a vm object as attribute" do
-      let(:root_hash) { { 'a' => 1, 'b' => '2'} }
+      let(:root_hash) { {'a' => 1, 'b' => '2'} }
       let(:updated_hash) do
         {
-          'state_vars' => { 'x' => 1 },
+          'state_vars' => {'x' => 1},
           'objects'    => {
             'root'                => {
               'a'     => 9,
@@ -53,7 +53,7 @@ describe "MiqAeDeserializeWorkspace" do
       end
 
       let(:invalid_obj_name_hash) do
-        {'objects' => { 'frooti' => {} }}
+        {'objects' => {'frooti' => {}}}
       end
 
       let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }

--- a/spec/miq_ae_discovery_spec.rb
+++ b/spec/miq_ae_discovery_spec.rb
@@ -26,8 +26,7 @@ describe "MiqAeDiscovery" do
                "ExtManagementSystem::ems" => @ems.id,
                :ems_id                    => @ems.id,
                "VmOrTemplate::vm"         => @vm.id,
-               :vm_id                     => @vm.id,
-      }
+               :vm_id                     => @vm.id}
 
       args = {:object_type      => "EmsEvent",
               :object_id        => @event.id,
@@ -39,7 +38,7 @@ describe "MiqAeDiscovery" do
               :automate_message => nil}
 
       expect(MiqAeEngine).to receive(:deliver_queue).with(args, anything)
-       MiqAeEvent.raise_ems_event(@event)
+      MiqAeEvent.raise_ems_event(@event)
     end
   end
 

--- a/spec/miq_ae_event_spec.rb
+++ b/spec/miq_ae_event_spec.rb
@@ -12,18 +12,16 @@ describe MiqAeEvent do
       let(:vm_owner) { nil }
       let(:vm) do
         FactoryBot.create(:vm_vmware,
-                           :ext_management_system => ems,
-                           :miq_group             => vm_group,
-                           :evm_owner             => vm_owner
-                          )
+                          :ext_management_system => ems,
+                          :miq_group             => vm_group,
+                          :evm_owner             => vm_owner)
       end
       let(:event) do
         FactoryBot.create(:ems_event,
-                           :event_type        => "CreateVM_Task_Complete",
-                           :source            => "VC",
-                           :ems_id            => ems.id,
-                           :vm_or_template_id => vm.id
-                          )
+                          :event_type        => "CreateVM_Task_Complete",
+                          :source            => "VC",
+                          :ems_id            => ems.id,
+                          :vm_or_template_id => vm.id)
       end
 
       context "with user owned VM" do
@@ -56,10 +54,9 @@ describe MiqAeEvent do
       let(:vm_owner) { nil }
       let(:vm) do
         FactoryBot.create(:vm_vmware,
-                           :ext_management_system => ems,
-                           :miq_group             => vm_group,
-                           :evm_owner             => vm_owner
-                          )
+                          :ext_management_system => ems,
+                          :miq_group             => vm_group,
+                          :evm_owner             => vm_owner)
       end
 
       shared_context "variables" do
@@ -169,8 +166,7 @@ describe MiqAeEvent do
         worker = FactoryBot.create(:miq_worker, :miq_server_id => miq_server.id)
         args   = {:user_id      => admin.id,
                   :miq_group_id => admin.current_group.id,
-                  :tenant_id    => admin.current_group.current_tenant.id
-        }
+                  :tenant_id    => admin.current_group.current_tenant.id}
         expect(MiqAeEngine).to receive(:deliver_queue).with(hash_including(args), anything)
 
         MiqAeEvent.raise_evm_event("evm_worker_start", worker.miq_server)
@@ -182,8 +178,7 @@ describe MiqAeEvent do
         storage = FactoryBot.create(:storage, :name => "test_storage_vmfs", :store_type => "VMFS", :ext_management_system => ems)
         args = {:user_id      => admin.id,
                 :miq_group_id => ems.tenant.default_miq_group.id,
-                :tenant_id    => ems.tenant.id
-        }
+                :tenant_id    => ems.tenant.id}
         expect(MiqAeEngine).to receive(:deliver_queue).with(hash_including(args), anything)
 
         MiqAeEvent.raise_evm_event("request_storage_scan", storage)
@@ -195,8 +190,7 @@ describe MiqAeEvent do
         request = FactoryBot.create(:vm_reconfigure_request, :requester => user)
         args    = {:user_id      => user.id,
                    :miq_group_id => user.current_group.id,
-                   :tenant_id    => user.current_tenant.id
-        }
+                   :tenant_id    => user.current_tenant.id}
         expect(MiqAeEngine).to receive(:deliver_queue).with(hash_including(args), anything)
 
         MiqAeEvent.raise_evm_event("request_approved", request)

--- a/spec/miq_ae_method_dispatch_spec.rb
+++ b/spec/miq_ae_method_dispatch_spec.rb
@@ -67,8 +67,7 @@ describe "MiqAeMethodDispatch" do
   def create_method_class(attrs = {})
     params = {'pidfile' => {'aetype'        => 'attribute',
                             'datatype'      => 'string',
-                            'default_value' => @pidfile}
-             }
+                            'default_value' => @pidfile}}
     method_script = attrs.delete(:method_script)
     ae_fields = {'execute' => {:aetype => 'method', :datatype => 'string'}}
     ae_instances = {@method_instance => {'execute' => {:value => @method_name}}}
@@ -77,9 +76,9 @@ describe "MiqAeMethodDispatch" do
                                    :language => 'ruby', 'params' => params}}
 
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_instances' => ae_instances,
-                                   'ae_methods'   => ae_methods))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_instances' => ae_instances,
+                                  'ae_methods'   => ae_methods))
   end
 
   def create_root_class(attrs = {})
@@ -87,9 +86,9 @@ describe "MiqAeMethodDispatch" do
     fqname = "/#{@domain}/#{@namespace}/#{@method_class}/#{@method_instance}"
     ae_instances = {@root_instance => {'rel1' => {:value => fqname}}}
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_methods'   => {},
-                                   'ae_instances' => ae_instances))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_methods'   => {},
+                                  'ae_instances' => ae_instances))
   end
 
   it "long running method", :skip => "Fails sporadically because 2 seconds is not long enough" do

--- a/spec/miq_ae_object_spec.rb
+++ b/spec/miq_ae_object_spec.rb
@@ -7,8 +7,8 @@ describe MiqAeEngine::MiqAeObject do
     @user = FactoryBot.create(:user_with_group)
     @model_data_dir = File.join(File.dirname(__FILE__), "data")
     EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_object_spec1"), @domain)
-    @vm      = FactoryBot.create(:vm_vmware)
-    @ws      = MiqAeEngine.instantiate("/SYSTEM/EVM/AUTOMATE/test1", @user)
+    @vm = FactoryBot.create(:vm_vmware)
+    @ws = MiqAeEngine.instantiate("/SYSTEM/EVM/AUTOMATE/test1", @user)
     @miq_obj = described_class.new(@ws, "#{@domain}/SYSTEM/EVM", "AUTOMATE", "test1")
   end
 
@@ -36,6 +36,7 @@ describe MiqAeEngine::MiqAeObject do
   def find_match(attrs, key, value)
     item = attrs.detect { |i| i['name'] == key }
     return false unless item
+
     item.delete('name')
     xml_class = item.keys.first
     type_match(value.class, xml_class) &&
@@ -53,6 +54,7 @@ describe MiqAeEngine::MiqAeObject do
   def value_match(value, xml_value)
     service_model = value.class.name.start_with?("MiqAeMethodService::")
     return value.id.inspect == xml_value['id'] if service_model
+
     value == xml_value || value.inspect == xml_value
   end
 
@@ -199,7 +201,6 @@ describe MiqAeEngine::MiqAeObject do
   include Spec::Support::AutomationHelper
 
   context "substitute_value" do
-
     let(:email_value) { '${/#miq_request.get_option(:email).upcase}' }
     let(:req_email_value) { '${/#user.email}' }
     let(:instance_name) { 'FRED' }
@@ -229,10 +230,10 @@ describe MiqAeEngine::MiqAeObject do
 
     let(:request) do
       FactoryBot.create(:miq_provision_request,
-                         :provision_type => 'template',
-                         :state => 'pending', :status => 'Ok',
-                         :src_vm_id => vm_template.id,
-                         :requester => user, :options => options)
+                        :provision_type => 'template',
+                        :state => 'pending', :status => 'Ok',
+                        :src_vm_id => vm_template.id,
+                        :requester => user, :options => options)
     end
 
     it "email address" do

--- a/spec/miq_ae_path_spec.rb
+++ b/spec/miq_ae_path_spec.rb
@@ -35,7 +35,7 @@ describe MiqAeEngine::MiqAePath do
     ae_namespace = "TEST_NAMESPACE"
     ae_class     = "TEST_CLASS"
     ae_instance  = "TEST_INSTANCE"
-    parts =  {
+    parts = {
       :ae_namespace => ae_namespace,
       :ae_class     => ae_class,
       :ae_instance  => ae_instance
@@ -52,7 +52,7 @@ describe MiqAeEngine::MiqAePath do
     ae_namespace = "TEST_NAMESPACE"
     ae_class     = "TEST_CLASS"
     ae_instance  = "TEST_INSTANCE"
-    parts =  {
+    parts = {
       :ae_namespace => ae_namespace,
       :ae_class     => ae_class,
       :ae_instance  => ae_instance
@@ -73,7 +73,7 @@ describe MiqAeEngine::MiqAePath do
       @ae_namespace = "TEST_NAMESPACE"
       @ae_class     = "TEST_CLASS"
       @ae_instance  = "TEST_INSTANCE"
-      @parts =  {
+      @parts = {
         :ae_namespace => @ae_namespace,
         :ae_class     => @ae_class,
         :ae_instance  => @ae_instance

--- a/spec/miq_ae_playbook_method_spec.rb
+++ b/spec/miq_ae_playbook_method_spec.rb
@@ -2,7 +2,7 @@ describe MiqAeEngine::MiqAePlaybookMethod do
   describe "run" do
     let(:user) { FactoryBot.create(:user_with_group) }
     let(:aw) { FactoryBot.create(:automate_workspace, :user => user, :tenant => user.current_tenant) }
-    let(:root_hash) { { 'name' => 'Flintstone' } }
+    let(:root_hash) { {'name' => 'Flintstone'} }
     let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
     let(:persist_hash) { MiqAeEngine::StateVarHash.new }
     let(:options) { {"test" => 13, :hosts => hosts, :log_output => 'error'} }
@@ -29,12 +29,12 @@ describe MiqAeEngine::MiqAePlaybookMethod do
 
     let(:user) do
       FactoryBot.create(:user_with_group, :userid   => "admin",
-                                           :settings => {:display => { :timezone => "UTC"}})
+                                          :settings => {:display => {:timezone => "UTC"}})
     end
 
     let(:aem)    { double("AEM", :options => options, :name => method_name) }
     let(:obj)    { double("OBJ", :workspace => workspace) }
-    let(:inputs) { { 'name' => 'Fred' } }
+    let(:inputs) { {'name' => 'Fred'} }
 
     let(:mpr) { FactoryBot.create(:miq_provision_request, :requester => user) }
 
@@ -100,8 +100,8 @@ describe MiqAeEngine::MiqAePlaybookMethod do
       context "service_template_provision_task" do
         let(:task_href_slug) { "#{svc_stpr.href_slug}/#{svc_stpt.href_slug}" }
         let(:root_hash) do
-          { 'vmdb_object_type'                => 'service_template_provision_task',
-            'service_template_provision_task' => svc_stpt }
+          {'vmdb_object_type'                => 'service_template_provision_task',
+           'service_template_provision_task' => svc_stpt}
         end
         it_behaves_like "task_slug"
       end
@@ -109,8 +109,8 @@ describe MiqAeEngine::MiqAePlaybookMethod do
       context "provision_task" do
         let(:task_href_slug) { "#{svc_mpr.href_slug}/#{svc_mpt.href_slug}" }
         let(:root_hash) do
-          { 'vmdb_object_type' => 'miq_provision',
-            'miq_provision'    => svc_mpt }
+          {'vmdb_object_type' => 'miq_provision',
+           'miq_provision'    => svc_mpt}
         end
         it_behaves_like "task_slug"
       end
@@ -177,9 +177,9 @@ describe MiqAeEngine::MiqAePlaybookMethod do
 
     context "state machine" do
       let(:root_hash) do
-        { 'vmdb_object_type' => 'miq_provision',
-          'service'          => svc_service,
-          'miq_provision'    => svc_mpt }
+        {'vmdb_object_type' => 'miq_provision',
+         'service'          => svc_service,
+         'miq_provision'    => svc_mpt}
       end
 
       before do

--- a/spec/miq_ae_provision_spec.rb
+++ b/spec/miq_ae_provision_spec.rb
@@ -52,7 +52,7 @@ describe "MiqAeProvision" do
     it "should instantiate lease_times" do
       ws = MiqAeEngine.instantiate("/EVMApplications/Provisioning/Information/Default#get_lease_times", @user)
       expect(ws).not_to be_nil
-      ttls  = ws.root("ttls")
+      ttls = ws.root("ttls")
       expect(ttls.class.name).to eq("Hash")
       expect(ttls.length).to eq(5)
     end

--- a/spec/miq_ae_reference_spec.rb
+++ b/spec/miq_ae_reference_spec.rb
@@ -2,7 +2,7 @@ describe MiqAeEngine::MiqAeReference do
   context "vmdb objects" do
     let(:user) do
       FactoryBot.create(:user_with_group, :userid   => "admin",
-                                           :settings => {:display => { :timezone => "UTC"}})
+                                          :settings => {:display => {:timezone => "UTC"}})
     end
     let(:host) { FactoryBot.create(:host) }
     let(:vm) { FactoryBot.create(:vm_vmware, :host => host) }
@@ -21,7 +21,7 @@ describe MiqAeEngine::MiqAeReference do
   context "passwords" do
     let(:user) do
       FactoryBot.create(:user_with_group, :userid   => "admin",
-                                           :settings => {:display => { :timezone => "UTC"}})
+                                          :settings => {:display => {:timezone => "UTC"}})
     end
     let(:password) { "ca$hc0w" }
     let(:miq_password) { MiqAePassword.new(password) }

--- a/spec/miq_ae_serialize_workspace_spec.rb
+++ b/spec/miq_ae_serialize_workspace_spec.rb
@@ -24,7 +24,7 @@ describe "MiqAeSerializeWorkspace" do
   let(:test_class_instance) { test_class.new(workspace) }
   let(:user) do
     FactoryBot.create(:user_with_group, :userid   => "admin",
-                                         :settings => {:display => { :timezone => "UTC"}})
+                                        :settings => {:display => {:timezone => "UTC"}})
   end
 
   let(:host) { FactoryBot.create(:host) }
@@ -33,8 +33,8 @@ describe "MiqAeSerializeWorkspace" do
 
   describe "#hash_workspace" do
     context "simple attributes" do
-      let(:root_hash) { { 'a' => 1, 'b' => '2'} }
-      let(:hashed_workspace) { { "root" => root_hash} }
+      let(:root_hash) { {'a' => 1, 'b' => '2'} }
+      let(:hashed_workspace) { {"root" => root_hash} }
       let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
 
       it "return a simple hash" do
@@ -43,9 +43,9 @@ describe "MiqAeSerializeWorkspace" do
     end
 
     context "vmdb_object" do
-      let(:root_hash) { { 'a' => 1, 'b' => '2', 'my_vm' => svc_vm} }
-      let(:ref_hash) { { 'a' => 1, 'b' => '2', 'my_vm' => "href_slug::#{vm.href_slug}"} }
-      let(:hashed_workspace) { { "root" => ref_hash} }
+      let(:root_hash) { {'a' => 1, 'b' => '2', 'my_vm' => svc_vm} }
+      let(:ref_hash) { {'a' => 1, 'b' => '2', 'my_vm' => "href_slug::#{vm.href_slug}"} }
+      let(:hashed_workspace) { {"root" => ref_hash} }
       let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
 
       it "return a simple hash with the vm reference" do
@@ -54,8 +54,8 @@ describe "MiqAeSerializeWorkspace" do
     end
 
     context "object graph" do
-      let(:root_hash) { { 'a' => 1, 'b' => '2' } }
-      let(:child_hash) { { 'age' => 55 } }
+      let(:root_hash) { {'a' => 1, 'b' => '2'} }
+      let(:child_hash) { {'age' => 55} }
       let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
       let(:child_object) { Spec::Support::MiqAeMockObject.new(child_hash) }
 
@@ -65,8 +65,8 @@ describe "MiqAeSerializeWorkspace" do
         child_object.instance  = "fred"
 
         child_object.link_parent_child(root_object, child_object)
-        result = { "root"                         => {"a" => 1, "b" => "2"},
-                   "/manageiq/bedrock/mogul/fred" => {"age" => 55, "::miq::parent" => "root"}}
+        result = {"root"                         => {"a" => 1, "b" => "2"},
+                  "/manageiq/bedrock/mogul/fred" => {"age" => 55, "::miq::parent" => "root"}}
         expect(test_class_instance.hash_workspace).to eq(result)
       end
     end

--- a/spec/miq_ae_service_spec.rb
+++ b/spec/miq_ae_service_spec.rb
@@ -8,14 +8,14 @@ describe MiqAeMethodService::MiqAeServiceObject do
   context "#attributes" do
     before do
       allow(@object).to receive(:attributes).and_return('true'     => true,
-                                           'false'    => false,
-                                           'time'     => Time.parse('Aug 30, 2013'),
-                                           'symbol'   => :symbol,
-                                           'int'      => 1,
-                                           'float'    => 1.1,
-                                           'string'   => 'hello',
-                                           'array'    => [1, 2, 3, 4],
-                                           'password' => MiqAePassword.new('test'))
+                                                        'false'    => false,
+                                                        'time'     => Time.zone.parse('Aug 30, 2013'),
+                                                        'symbol'   => :symbol,
+                                                        'int'      => 1,
+                                                        'float'    => 1.1,
+                                                        'string'   => 'hello',
+                                                        'array'    => [1, 2, 3, 4],
+                                                        'password' => MiqAePassword.new('test'))
     end
 
     it "obscures passwords" do
@@ -62,17 +62,21 @@ describe MiqAeMethodService::MiqAeService do
     it "loads name-spaced model by mapped name" do
       MiqAeMethodService::Deprecation.silence do
         expect(miq_ae_service.service_model(:ems_openstack)).to be(
-          MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager)
-        expect(miq_ae_service.service_model(:vm_openstack)).to  be(
-          MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_Vm)
+          MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager
+        )
+        expect(miq_ae_service.service_model(:vm_openstack)).to be(
+          MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_Vm
+        )
       end
     end
 
     it "loads name-spaced model by fully-qualified name" do
-      expect(miq_ae_service.service_model(:ManageIQ_Providers_Openstack_CloudManager)).to    be(
-        MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager)
+      expect(miq_ae_service.service_model(:ManageIQ_Providers_Openstack_CloudManager)).to be(
+        MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager
+      )
       expect(miq_ae_service.service_model(:ManageIQ_Providers_Openstack_CloudManager_Vm)).to be(
-        MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_Vm)
+        MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_Vm
+      )
     end
 
     it "raises error on invalid service_model name" do

--- a/spec/miq_ae_state_machine_spec.rb
+++ b/spec/miq_ae_state_machine_spec.rb
@@ -44,7 +44,7 @@ describe "MiqAeStateMachine" do
     EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
     c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/Factory", "VM")
     i1 = c1.ae_instances.detect { |i| i.name == "ProvisionCheck" }
-    f1 = c1.ae_fields.detect    { |f| f.name == "execute"   }
+    f1 = c1.ae_fields.detect    { |f| f.name == "execute" }
     i1.set_field_attribute(f1, "provision_check(result => 'error')", :value)
 
     ws = MiqAeEngine.instantiate("/SYSTEM/EVENT/VM_PROVISION_REQUESTED_NEW", @user)
@@ -60,7 +60,7 @@ describe "MiqAeStateMachine" do
 
     c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/Factory", "VM")
     i1 = c1.ae_instances.detect { |i| i.name == "ProvisionCheck" }
-    f1 = c1.ae_fields.detect    { |f| f.name == "execute"   }
+    f1 = c1.ae_fields.detect    { |f| f.name == "execute" }
     i1.set_field_attribute(f1, "provision_check(result => 'exception')", :value)
 
     ws = MiqAeEngine.instantiate("/SYSTEM/EVENT/VM_PROVISION_REQUESTED_NEW", @user)
@@ -93,7 +93,7 @@ describe "MiqAeStateMachine" do
 
     c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
     i1 = c1.ae_instances.detect { |i| i.name == "Provisioning" }
-    f1 = c1.ae_fields.detect    { |f| f.name == "AcquireIPAddress"   }
+    f1 = c1.ae_fields.detect    { |f| f.name == "AcquireIPAddress" }
     method_string = "update_provision_status(status => 'Testing on entry method',status_state => 'on_entry')"
     i1.set_field_attribute(f1, method_string, :on_entry)
 
@@ -113,7 +113,7 @@ describe "MiqAeStateMachine" do
 
     c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
     i1 = c1.ae_instances.detect { |i| i.name == "Provisioning" }
-    f1 = c1.ae_fields.detect    { |f| f.name == "AcquireIPAddress"   }
+    f1 = c1.ae_fields.detect    { |f| f.name == "AcquireIPAddress" }
     method_string = "SPEC_DOMAIN/factory/method.test_class_method(status => 'Testing class on entry method',status_state => 'on_entry')"
     i1.set_field_attribute(f1, method_string, :on_entry)
     ws = MiqAeEngine.instantiate("#{@domain}/Factory/statemachine/Provisioning", @user)

--- a/spec/miq_ae_state_missing_relation_spec.rb
+++ b/spec/miq_ae_state_missing_relation_spec.rb
@@ -28,9 +28,9 @@ describe "MiqAeStateMachine" do
     ae_instances = {@other1 => {'var1' => {:value => "1"}},
                     @other3 => {'var1' => {:value => "3"}}}
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_instances' => ae_instances,
-                                   'ae_methods'   => {}))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_instances' => ae_instances,
+                                  'ae_methods'   => {}))
   end
 
   def create_state_class(attrs = {})
@@ -40,7 +40,7 @@ describe "MiqAeStateMachine" do
                               :message => 'create', :priority => 2, :collect => 'var1'},
                  'state3' => {:aetype => 'state', :datatype => 'string', :max_retries => 10,
                               :message => 'create', :priority => 3, :collect => 'var1'}}
-    fqname1    = "/#{@domain}/#{@namespace}/#{@other_class}/#{@other1}"
+    fqname1 = "/#{@domain}/#{@namespace}/#{@other_class}/#{@other1}"
     missing_fq = "/#{@domain}/#{@namespace}/#{@other_class}/#{@other2}"
     fqname3    = "/#{@domain}/#{@namespace}/#{@other_class}/#{@other3}"
     ae_instances = {@state_instance1 => {'state1' => {:value => missing_fq},
@@ -51,13 +51,12 @@ describe "MiqAeStateMachine" do
                                          'state3' => {:value => fqname3}},
                     @state_instance3 => {'state1' => {:value => fqname1},
                                          'state2' => {:value => fqname3},
-                                         'state3' => {:value => missing_fq}}
-                   }
+                                         'state3' => {:value => missing_fq}}}
 
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       attrs.merge('ae_fields'    => ae_fields,
-                                   'ae_methods'   => {},
-                                   'ae_instances' => ae_instances))
+                      attrs.merge('ae_fields'    => ae_fields,
+                                  'ae_methods'   => {},
+                                  'ae_instances' => ae_instances))
   end
 
   it "missing instance in first slot" do

--- a/spec/models/miq_ae_browser_spec.rb
+++ b/spec/models/miq_ae_browser_spec.rb
@@ -33,8 +33,8 @@ describe MiqAeBrowser do
                                              "perform" => { :value => "" } } }
 
     FactoryBot.create(:miq_ae_class, :with_instances_and_methods,
-                       :name => "Learning", :namespace => "/Liszt/SelectedWorks",
-                       :ae_fields => learning_fields, :ae_methods => {}, :ae_instances => learning_instances)
+                      :name => "Learning", :namespace => "/Liszt/SelectedWorks",
+                      :ae_fields => learning_fields, :ae_methods => {}, :ae_instances => learning_instances)
 
     @user = FactoryBot.create(:user_with_group)
     @browser = described_class.new(@user)

--- a/spec/models/miq_ae_class_compare_fields_spec.rb
+++ b/spec/models/miq_ae_class_compare_fields_spec.rb
@@ -1,7 +1,7 @@
 describe MiqAeClassCompareFields do
   before do
     @domain = 'SPEC_DOMAIN'
-    @namespace   = 'NS1'
+    @namespace = 'NS1'
     @yaml_folder = File.join(File.dirname(__FILE__), 'miq_ae_copy_data')
     MiqAeDatastore.reset
     @export_dir = Dir.mktmpdir
@@ -13,7 +13,7 @@ describe MiqAeClassCompareFields do
 
   context "same fields" do
     before do
-      @yaml_file   = File.join(@yaml_folder, 'class_copy1.yaml')
+      @yaml_file = File.join(@yaml_folder, 'class_copy1.yaml')
       EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
       prep_class_file_names("CLASS1")
     end
@@ -33,7 +33,7 @@ describe MiqAeClassCompareFields do
 
   context "same fields mixed case" do
     before do
-      @yaml_file   = File.join(@yaml_folder, 'class_copy2.yaml')
+      @yaml_file = File.join(@yaml_folder, 'class_copy2.yaml')
       EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
       prep_class_file_names("CLASS1", "MIXED_CASE_NAMES")
     end
@@ -54,7 +54,7 @@ describe MiqAeClassCompareFields do
 
   context "same field but aetype changes" do
     before do
-      @yaml_file   = File.join(@yaml_folder, 'class_copy3.yaml')
+      @yaml_file = File.join(@yaml_folder, 'class_copy3.yaml')
       EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
       prep_class_file_names("CLASS1", "CLASS_AETYPE_OFF")
     end
@@ -75,7 +75,7 @@ describe MiqAeClassCompareFields do
 
   context "same field but datatype changes" do
     before do
-      @yaml_file   = File.join(@yaml_folder, 'class_copy4.yaml')
+      @yaml_file = File.join(@yaml_folder, 'class_copy4.yaml')
       EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
       prep_class_file_names("CLASS1", "CLASS_DATATYPE_OFF")
     end
@@ -97,7 +97,7 @@ describe MiqAeClassCompareFields do
 
   context "same fields but priority changes" do
     before do
-      @yaml_file   = File.join(@yaml_folder, 'class_copy5.yaml')
+      @yaml_file = File.join(@yaml_folder, 'class_copy5.yaml')
       EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
       prep_class_file_names("CLASS1", "CLASS_PRIORITY_OFF")
     end
@@ -118,7 +118,7 @@ describe MiqAeClassCompareFields do
 
   context "mostly same fields except a new additon" do
     before do
-      @yaml_file   = File.join(@yaml_folder, 'class_copy6.yaml')
+      @yaml_file = File.join(@yaml_folder, 'class_copy6.yaml')
       EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
       prep_class_file_names("CLASS_ADD_A_FIELD", "CLASS1")
     end
@@ -139,7 +139,7 @@ describe MiqAeClassCompareFields do
 
   context "mostly same fields except a deletion of a in use field" do
     before do
-      @yaml_file   = File.join(@yaml_folder, 'class_copy7.yaml')
+      @yaml_file = File.join(@yaml_folder, 'class_copy7.yaml')
       EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
       prep_class_file_names("CLASS_IN_USE_FIELD_DELETED", "CLASS1")
     end
@@ -160,7 +160,7 @@ describe MiqAeClassCompareFields do
 
   context "mostly same fields except a deletion of a field not in use" do
     before do
-      @yaml_file   = File.join(@yaml_folder, 'class_copy8.yaml')
+      @yaml_file = File.join(@yaml_folder, 'class_copy8.yaml')
       EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
       prep_class_file_names("CLASS_FIELD_DELETED", "CLASS1")
     end

--- a/spec/models/miq_ae_class_copy_spec.rb
+++ b/spec/models/miq_ae_class_copy_spec.rb
@@ -34,7 +34,7 @@ describe MiqAeClassCopy do
 
     it "after copy both classes in DB should be congruent" do
       class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @src_class)
-      new_ns   = "NS3/NS4"
+      new_ns = "NS3/NS4"
       class2 = MiqAeClassCopy.new(@src_fqname).to_domain(@dest_domain, new_ns)
       class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
       @ns2 = MiqAeNamespace.lookup_by_fqname("#{@dest_domain}/#{new_ns}", false)

--- a/spec/models/miq_ae_datastore/xml_export_spec.rb
+++ b/spec/models/miq_ae_datastore/xml_export_spec.rb
@@ -28,9 +28,9 @@ describe MiqAeDatastore::XmlExport do
 
     it "sorts the miq ae classes and returns the correct xml" do
       expect(miq_ae_class2).to receive(:to_export_xml) do |options|
-        expect(options[:builder].target!).to eq <<-XML
-<?xml version="1.0" encoding="UTF-8"?>
-<MiqAeDatastore version="1.0">
+        expect(options[:builder].target!).to eq <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <MiqAeDatastore version="1.0">
         XML
         expect(options[:skip_instruct]).to be_truthy
         expect(options[:indent]).to eq(2)
@@ -38,10 +38,10 @@ describe MiqAeDatastore::XmlExport do
       end
 
       expect(miq_ae_class1).to receive(:to_export_xml) do |options|
-        expect(options[:builder].target!).to eq <<-XML
-<?xml version="1.0" encoding="UTF-8"?>
-<MiqAeDatastore version="1.0">
-  <class2/>
+        expect(options[:builder].target!).to eq <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <MiqAeDatastore version="1.0">
+            <class2/>
         XML
         expect(options[:skip_instruct]).to be_truthy
         expect(options[:indent]).to eq(2)
@@ -49,11 +49,11 @@ describe MiqAeDatastore::XmlExport do
       end
 
       expect(custom_button).to receive(:to_export_xml) do |options|
-        expect(options[:builder].target!).to eq <<-XML
-<?xml version="1.0" encoding="UTF-8"?>
-<MiqAeDatastore version="1.0">
-  <class2/>
-  <class1/>
+        expect(options[:builder].target!).to eq <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <MiqAeDatastore version="1.0">
+            <class2/>
+            <class1/>
         XML
         expect(options[:skip_instruct]).to be_truthy
         expect(options[:indent]).to eq(2)

--- a/spec/models/miq_ae_datastore_spec.rb
+++ b/spec/models/miq_ae_datastore_spec.rb
@@ -75,7 +75,7 @@ describe MiqAeDatastore do
 
   it ".backup" do
     expect_any_instance_of(MiqAeYamlExportZipfs).to receive(:export).once
-    MiqAeDatastore.backup('zip_file'  => 'dummy', 'overwrite' => true)
+    MiqAeDatastore.backup('zip_file' => 'dummy', 'overwrite' => true)
   end
 
   it ".upload" do
@@ -131,7 +131,7 @@ describe MiqAeDatastore do
   end
 
   describe "restore" do
-    let(:miq_ae_yaml_import_zipfs)  { double("MiqAeYamlImportZipfs") }
+    let(:miq_ae_yaml_import_zipfs) { double("MiqAeYamlImportZipfs") }
     let(:dummy_zipfile) { File.expand_path(File.join(File.dirname(__FILE__), "/miq_ae_datastore/data/dummy.zip")) }
 
     before do

--- a/spec/models/miq_ae_domain_spec.rb
+++ b/spec/models/miq_ae_domain_spec.rb
@@ -295,8 +295,8 @@ describe MiqAeDomain do
     let(:url) { "http://www.example.com/x/y" }
     let(:dom1) do
       FactoryBot.create(:miq_ae_git_domain,
-                         :tenant => @user.current_tenant,
-                         :name   => domain_name)
+                        :tenant => @user.current_tenant,
+                        :name   => domain_name)
     end
     let(:dom2) { FactoryBot.create(:miq_ae_domain) }
     let(:repo) { FactoryBot.create(:git_repository, :url => url) }
@@ -360,7 +360,7 @@ describe MiqAeDomain do
     ae_instances = {'instance1' => {'field1' => {:value => 'hello world'}}}
 
     FactoryBot.create(:miq_ae_domain, :with_small_model, :with_instances,
-                       attrs.merge('ae_fields' => ae_fields, 'ae_instances' => ae_instances))
+                      attrs.merge('ae_fields' => ae_fields, 'ae_instances' => ae_instances))
   end
 
   def create_model_with_methods(attrs = {})
@@ -369,7 +369,7 @@ describe MiqAeDomain do
                                 :data => 'puts "Hello World"',
                                 :language => 'ruby', 'params' => {}}}
     FactoryBot.create(:miq_ae_domain, :with_small_model, :with_methods,
-                       attrs.merge('ae_methods' => ae_methods))
+                      attrs.merge('ae_methods' => ae_methods))
   end
 
   def create_multiple_domains

--- a/spec/models/miq_ae_git_import_spec.rb
+++ b/spec/models/miq_ae_git_import_spec.rb
@@ -8,8 +8,8 @@ describe MiqAeGitImport do
     let(:verify_ssl_disabled) { 0 }
     let(:domain) do
       FactoryBot.create(:miq_ae_git_domain,
-                         :tenant => user.current_tenant,
-                         :name   => domain_name)
+                        :tenant => user.current_tenant,
+                        :name   => domain_name)
     end
     let(:repo) { FactoryBot.create(:git_repository, :url => url, :verify_ssl => verify_ssl_disabled) }
     let(:user) { FactoryBot.create(:user_with_group) }
@@ -70,7 +70,7 @@ describe MiqAeGitImport do
         shared_examples_for "#import that has a valid branch" do
           it "runs successfully" do
             expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options)
-              .and_return(miq_ae_yaml_import_gitfs)
+                                                         .and_return(miq_ae_yaml_import_gitfs)
             allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
             dom = miq_ae_git_import.import
             expect(dom).to have_attributes(branch_hash)
@@ -96,14 +96,14 @@ describe MiqAeGitImport do
 
         it "import fails with domain not found" do
           expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options)
-            .and_return(miq_ae_yaml_import_gitfs)
+                                                       .and_return(miq_ae_yaml_import_gitfs)
           allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(nil)
           expect { miq_ae_git_import.import }.to raise_error(MiqAeException::DomainNotFound)
         end
 
         it "raises an exception with a message about multiple domains" do
           expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options)
-            .and_return(miq_ae_yaml_import_gitfs)
+                                                       .and_return(miq_ae_yaml_import_gitfs)
           allow(miq_ae_yaml_import_gitfs).to receive(:domain_files) { ['BB8/__domain__.yaml', 'BB8/__domain__.yaml'] }
           expect { miq_ae_git_import.import }.to raise_exception(
             MiqAeException::InvalidDomain, 'Multiple Domain import is not supported.'
@@ -129,7 +129,7 @@ describe MiqAeGitImport do
         shared_examples_for "#import that has a valid tag" do
           it "imports correctly" do
             expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options)
-              .and_return(miq_ae_yaml_import_gitfs)
+                                                         .and_return(miq_ae_yaml_import_gitfs)
             allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
             dom = miq_ae_git_import.import
             expect(dom).to have_attributes(tag_hash)
@@ -172,7 +172,7 @@ describe MiqAeGitImport do
 
         it "imports correctly" do
           expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options)
-            .and_return(miq_ae_yaml_import_gitfs)
+                                                       .and_return(miq_ae_yaml_import_gitfs)
           allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
           dom = miq_ae_git_import.import
           expect(dom).to have_attributes(branch_hash)
@@ -182,7 +182,7 @@ describe MiqAeGitImport do
 
         it "doesn't overwrite verify_ssl" do
           expect(MiqAeYamlImportGitfs).to receive(:new).with(domain_name, import_options)
-            .and_return(miq_ae_yaml_import_gitfs)
+                                                       .and_return(miq_ae_yaml_import_gitfs)
           allow(miq_ae_yaml_import_gitfs).to receive(:import).and_return(domain)
           miq_ae_git_import.import
           expect(repo.verify_ssl).to eq(verify_ssl_disabled)

--- a/spec/models/miq_ae_instance_copy_spec.rb
+++ b/spec/models/miq_ae_instance_copy_spec.rb
@@ -10,7 +10,7 @@ describe MiqAeInstanceCopy do
     @dest_instance = 'default2'
     @dest_ns       = 'NSX/NSY'
     @src_fqname    = "#{@src_domain}/#{@src_ns}/#{@src_class}/#{@src_instance}"
-    @yaml_file   = File.join(File.dirname(__FILE__), 'miq_ae_copy_data', 'miq_ae_instance_copy.yaml')
+    @yaml_file = File.join(File.dirname(__FILE__), 'miq_ae_copy_data', 'miq_ae_instance_copy.yaml')
     MiqAeDatastore.reset
     EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @src_domain)
   end

--- a/spec/models/miq_ae_method_compare_spec.rb
+++ b/spec/models/miq_ae_method_compare_spec.rb
@@ -1,9 +1,9 @@
 describe MiqAeMethodCompare do
   before do
     @domain = 'SPEC_DOMAIN'
-    @namespace   = 'NS1'
-    @classname   = 'CLASS1'
-    @yaml_file   = File.join(File.dirname(__FILE__), 'miq_ae_copy_data', 'miq_ae_method_copy.yaml')
+    @namespace = 'NS1'
+    @classname = 'CLASS1'
+    @yaml_file = File.join(File.dirname(__FILE__), 'miq_ae_copy_data', 'miq_ae_method_copy.yaml')
     MiqAeDatastore.reset
     EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
     @export_dir = Dir.mktmpdir

--- a/spec/models/miq_ae_method_copy_spec.rb
+++ b/spec/models/miq_ae_method_copy_spec.rb
@@ -80,7 +80,7 @@ describe MiqAeMethodCopy do
         :language         => 'ruby',
         :location         => 'inline'
       )
-      src_fqname  = "#{@src_domain}/#{@src_ns}/#{@src_class}/#{method.name}"
+      src_fqname = "#{@src_domain}/#{@src_ns}/#{@src_class}/#{method.name}"
       method_copy = MiqAeMethodCopy.new(src_fqname).to_domain(@dest_domain, @dest_ns, true)
       expect(method_copy.embedded_methods).to(eq(method.embedded_methods))
     end
@@ -106,7 +106,7 @@ describe MiqAeMethodCopy do
           :become_enabled      => true
         }
       )
-      src_fqname  = "#{@src_domain}/#{@src_ns}/#{@src_class}/#{method.name}"
+      src_fqname = "#{@src_domain}/#{@src_ns}/#{@src_class}/#{method.name}"
       method_copy = MiqAeMethodCopy.new(src_fqname).to_domain(@dest_domain, @dest_ns, true)
       expect(method_copy.options).to(eq(method.options))
     end

--- a/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -231,7 +231,7 @@ describe MiqAeDatastore do
       def assert_all_domains_imported(export_options, import_options)
         export_model(MiqAeYamlImportExportMixin::ALL_DOMAINS, export_options)
         reset_and_import(@export_dir, MiqAeYamlImportExportMixin::ALL_DOMAINS, import_options)
-        check_counts('dom'  => 2, 'ns'    => 6,  'class' => 8, 'inst'  => 20,
+        check_counts('dom'  => 2, 'ns'    => 6,  'class' => 8, 'inst' => 20,
                      'meth' => 8, 'field' => 24, 'value' => 16)
       end
 
@@ -273,7 +273,7 @@ describe MiqAeDatastore do
 
       def add_extra_items_to_customer_domain
         @customer_domain = MiqAeDomain.find_by_name("customer")
-        n    = FactoryBot.create(:miq_ae_namespace, :name => "bonus_namespace_2", :parent_id => @customer_domain.id)
+        n = FactoryBot.create(:miq_ae_namespace, :name => "bonus_namespace_2", :parent_id => @customer_domain.id)
         n_c1 = FactoryBot.create(:miq_ae_class, :name => "bonus_test_class_3", :namespace_id => n.id)
         FactoryBot.create(:miq_ae_instance, :name => "bonus_test_instance1", :class_id => n_c1.id)
       end
@@ -376,7 +376,7 @@ describe MiqAeDatastore do
     def assert_import_as(export_options, import_options)
       export_model(@manageiq_domain.name, export_options)
       reset_and_import(@export_dir, @manageiq_domain.name, import_options)
-      check_counts('dom'  => 2, 'ns'    => 6,  'class' => 8,  'inst'  => 20,
+      check_counts('dom'  => 2, 'ns'    => 6,  'class' => 8, 'inst' => 20,
                    'meth' => 8, 'field' => 24, 'value' => 16)
       expect(MiqAeDomain.lookup_by_fqname(import_options['import_as'])).not_to be_nil
     end
@@ -425,7 +425,7 @@ describe MiqAeDatastore do
     def assert_import_namespace_only(export_options, import_options)
       export_model(@manageiq_domain.name, export_options)
       reset_and_import(@export_dir, @manageiq_domain.name, import_options)
-      check_counts('dom'  => 1, 'ns'    => 2, 'class' => 3, 'inst'  => 6,
+      check_counts('dom'  => 1, 'ns'    => 2, 'class' => 3, 'inst' => 6,
                    'meth' => 3, 'field' => 6, 'value' => 4)
     end
 
@@ -449,7 +449,7 @@ describe MiqAeDatastore do
     def assert_import_multipart_namespace_only(export_options, import_options)
       export_model(@manageiq_domain.name, export_options)
       reset_and_import(@export_dir, @manageiq_domain.name, import_options)
-      check_counts('dom'  => 1, 'ns'    => 2, 'class' => 1, 'inst'  => 1,
+      check_counts('dom'  => 1, 'ns'    => 2, 'class' => 1, 'inst' => 1,
                    'meth' => 0, 'field' => 0, 'value' => 0)
     end
 
@@ -476,7 +476,7 @@ describe MiqAeDatastore do
     def assert_import_class_only(export_options, import_options)
       export_model(@manageiq_domain.name, export_options)
       reset_and_import(@export_dir, @manageiq_domain.name, import_options)
-      check_counts('dom'  => 1,  'ns'    => 1, 'class' => 1, 'inst'  => 2,
+      check_counts('dom'  => 1, 'ns' => 1, 'class' => 1, 'inst' => 2,
                    'meth' => 3, 'field' => 6, 'value' => 4)
     end
 
@@ -501,7 +501,7 @@ describe MiqAeDatastore do
     def assert_single_namespace_export(export_options, import_options)
       export_model(@manageiq_domain.name, export_options)
       reset_and_import(@export_dir, @manageiq_domain.name, import_options)
-      check_counts('dom'  => 1, 'ns'    => 2, 'class' => 3, 'inst'  => 6,
+      check_counts('dom'  => 1, 'ns'    => 2, 'class' => 3, 'inst' => 6,
                    'meth' => 3, 'field' => 6, 'value' => 4)
     end
 
@@ -525,7 +525,7 @@ describe MiqAeDatastore do
     def assert_multi_namespace_export(export_options, import_options)
       export_model(@manageiq_domain.name, export_options)
       reset_and_import(@export_dir, @manageiq_domain.name, import_options)
-      check_counts('dom'  => 1, 'ns'    => 2, 'class' => 1, 'inst'  => 1,
+      check_counts('dom'  => 1, 'ns'    => 2, 'class' => 1, 'inst' => 1,
                    'meth' => 0, 'field' => 0, 'value' => 0)
     end
 
@@ -534,17 +534,17 @@ describe MiqAeDatastore do
       options['export_dir'] = @export_dir
       export_model(@manageiq_domain.name, options)
       reset_and_import(@export_dir, @manageiq_domain.name)
-      check_counts('dom'  => 1, 'ns'    => 1, 'class' => 1, 'inst'  => 2,
+      check_counts('dom'  => 1, 'ns'    => 1, 'class' => 1, 'inst' => 2,
                    'meth' => 3, 'field' => 6, 'value' => 4)
       @manageiq_domain = MiqAeNamespace.lookup_by_fqname('manageiq', false)
       @aen1_aec1       = MiqAeClass.lookup_by_name('manageiq_test_class_1')
       @aen1_aec1_aei2  = FactoryBot.create(:miq_ae_instance,
-                                            :name     => 'test_instance3',
-                                            :class_id => @aen1_aec1.id)
+                                           :name     => 'test_instance3',
+                                           :class_id => @aen1_aec1.id)
       setup_export_dir
       export_model(@manageiq_domain.name, options)
       MiqAeImport.new(@manageiq_domain.name, 'preview' => false, 'import_dir' => @export_dir).import
-      check_counts('dom'  => 1, 'ns'    => 1, 'class' => 1, 'inst'  => 3,
+      check_counts('dom'  => 1, 'ns'    => 1, 'class' => 1, 'inst' => 3,
                    'meth' => 3, 'field' => 6, 'value' => 4)
     end
 
@@ -571,7 +571,7 @@ describe MiqAeDatastore do
     def assert_class_with_methods_export(export_options, import_options)
       export_model(@manageiq_domain.name, export_options)
       reset_and_import(@export_dir, @manageiq_domain.name, import_options)
-      check_counts('dom'  => 1, 'ns'    => 1, 'class' => 1, 'inst'  => 2,
+      check_counts('dom'  => 1, 'ns'    => 1, 'class' => 1, 'inst' => 2,
                    'meth' => 3, 'field' => 6, 'value' => 4)
     end
 
@@ -649,7 +649,7 @@ describe MiqAeDatastore do
     def assert_class_without_methods(export_options, import_options)
       export_model(@manageiq_domain.name, export_options)
       reset_and_import(@export_dir, @manageiq_domain.name, import_options)
-      check_counts('dom'  => 1, 'ns'    => 1, 'class' => 1, 'inst'  => 3,
+      check_counts('dom'  => 1, 'ns'    => 1, 'class' => 1, 'inst' => 3,
                    'meth' => 0, 'field' => 0, 'value' => 0)
     end
   end
@@ -789,23 +789,23 @@ describe MiqAeDatastore do
   def create_field(class_obj, instance_obj, method_obj, options)
     if method_obj.nil?
       field = FactoryBot.create(:miq_ae_field,
-                                 :class_id      => class_obj.id,
-                                 :name          => options['name'],
-                                 :aetype        => options['type'],
-                                 :datatype      => options['datatype'],
-                                 :priority      => 1,
-                                 :substitute    => true,
-                                 :default_value => options['default_value'])
+                                :class_id      => class_obj.id,
+                                :name          => options['name'],
+                                :aetype        => options['type'],
+                                :datatype      => options['datatype'],
+                                :priority      => 1,
+                                :substitute    => true,
+                                :default_value => options['default_value'])
       create_field_value(instance_obj, field, options) unless options['value'].nil?
     else
       FactoryBot.create(:miq_ae_field,
-                         :method_id     => method_obj.id,
-                         :name          => options['name'],
-                         :aetype        => options['type'],
-                         :datatype      => options['datatype'],
-                         :priority      => 1,
-                         :substitute    => true,
-                         :default_value => options['value'])
+                        :method_id     => method_obj.id,
+                        :name          => options['name'],
+                        :aetype        => options['type'],
+                        :datatype      => options['datatype'],
+                        :priority      => 1,
+                        :substitute    => true,
+                        :default_value => options['value'])
     end
   end
 
@@ -865,42 +865,42 @@ describe MiqAeDatastore do
     n1_1_c1  = FactoryBot.create(:miq_ae_class,     :name => "#{domain_name}_test_class_4",   :namespace_id => n1_1.id)
     n1_c1_i1 = FactoryBot.create(:miq_ae_instance,  :name => "#{domain_name}_test_instance1", :class_id => n1_c1.id)
     n1_c1_m1 = FactoryBot.create(:miq_ae_method,
-                                  :class_id => n1_c1.id,
-                                  :name     => 'test1',
-                                  :scope    => "instance",
-                                  :language => "ruby",
-                                  # Method with no data
-                                  :location => "inline")
-    FactoryBot.create(:miq_ae_instance,  :name => "#{domain_name}_test_instance1", :class_id => n1_1_c1.id)
+                                 :class_id => n1_c1.id,
+                                 :name     => 'test1',
+                                 :scope    => "instance",
+                                 :language => "ruby",
+                                 # Method with no data
+                                 :location => "inline")
+    FactoryBot.create(:miq_ae_instance, :name => "#{domain_name}_test_instance1", :class_id => n1_1_c1.id)
     FactoryBot.create(:miq_ae_method,
-                       :class_id => n1_c1.id,
-                       :name     => 'test2',
-                       :scope    => "instance",
-                       :language => "ruby",
-                       :location => "builtin")
+                      :class_id => n1_c1.id,
+                      :name     => 'test2',
+                      :scope    => "instance",
+                      :language => "ruby",
+                      :location => "builtin")
     FactoryBot.create(:miq_ae_method,
-                       :class_id => n1_c1.id,
-                       :name     => 'test3',
-                       :scope    => "instance",
-                       :language => "ruby",
-                       :data     => @expression_data,
-                       :location => "expression")
-    FactoryBot.create(:miq_ae_instance,  :name => 'test_instance2', :class_id => n1_c1.id)
+                      :class_id => n1_c1.id,
+                      :name     => 'test3',
+                      :scope    => "instance",
+                      :language => "ruby",
+                      :data     => @expression_data,
+                      :location => "expression")
+    FactoryBot.create(:miq_ae_instance, :name => 'test_instance2', :class_id => n1_c1.id)
     create_fields(n1_c1, n1_c1_i1, n1_c1_m1)
 
-    n1_c2     = FactoryBot.create(:miq_ae_class,     :name => "#{domain_name}_test_class_2",   :namespace_id => n1.id)
-    3.times {   FactoryBot.create(:miq_ae_instance,  :class_id => n1_c2.id) }
-    n2        = FactoryBot.create(:miq_ae_namespace, :name => "#{domain_name}_namespace_2",    :parent_id => domain.id)
-    n2_c1     = FactoryBot.create(:miq_ae_class,     :name => "#{domain_name}_test_class_3",   :namespace_id => n2.id)
-    n2_c1_i1  = FactoryBot.create(:miq_ae_instance,  :name => "#{domain_name}_test_instance1", :class_id => n2_c1.id)
-    3.times {   FactoryBot.create(:miq_ae_instance,  :class_id => n2_c1.id) }
+    n1_c2 = FactoryBot.create(:miq_ae_class, :name => "#{domain_name}_test_class_2", :namespace_id => n1.id)
+    3.times { FactoryBot.create(:miq_ae_instance, :class_id => n1_c2.id) }
+    n2 = FactoryBot.create(:miq_ae_namespace, :name => "#{domain_name}_namespace_2", :parent_id => domain.id)
+    n2_c1 = FactoryBot.create(:miq_ae_class, :name => "#{domain_name}_test_class_3", :namespace_id => n2.id)
+    n2_c1_i1 = FactoryBot.create(:miq_ae_instance, :name => "#{domain_name}_test_instance1", :class_id => n2_c1.id)
+    3.times {   FactoryBot.create(:miq_ae_instance, :class_id => n2_c1.id) }
     n2_c1_m1 =  FactoryBot.create(:miq_ae_method,
-                                   :class_id => n2_c1.id,
-                                   :name     => 'namespace2_method_test1',
-                                   :scope    => "instance",
-                                   :language => "ruby",
-                                   :data     => "puts 1",
-                                   :location => "inline")
+                                  :class_id => n2_c1.id,
+                                  :name     => 'namespace2_method_test1',
+                                  :scope    => "instance",
+                                  :language => "ruby",
+                                  :data     => "puts 1",
+                                  :location => "inline")
     create_fields(n2_c1, n2_c1_i1, n2_c1_m1)
   end
 
@@ -941,7 +941,7 @@ describe MiqAeDatastore do
     MiqAeDomain.all.each do |d|
       d.ae_namespaces.each { |ns| ns_count += child_namespace_count(ns) }
     end
-    expect(ns_count).to eql(counts['ns'])    if counts.key?('ns')
+    expect(ns_count).to eql(counts['ns']) if counts.key?('ns')
     expect(MiqAeClass.count).to eql(counts['class']) if counts.key?('class')
     check_class_component_counts counts
     validate_additional_columns
@@ -956,6 +956,7 @@ describe MiqAeDatastore do
   def validate_additional_columns
     klass = MiqAeClass.lookup_by_name(@class_name)
     return unless klass
+
     klass.ae_instances.each do |inst|
       inst.ae_values.select { |v| v.value == @relations_value }.each do |rel|
         validate_relation(rel.attributes)
@@ -968,8 +969,8 @@ describe MiqAeDatastore do
   end
 
   def check_class_component_counts(counts)
-    expect(MiqAeInstance.count).to eql(counts['inst'])  if counts.key?('inst')
-    expect(MiqAeMethod.count).to eql(counts['meth'])  if counts.key?('meth')
+    expect(MiqAeInstance.count).to eql(counts['inst']) if counts.key?('inst')
+    expect(MiqAeMethod.count).to eql(counts['meth']) if counts.key?('meth')
     expect(MiqAeField.count).to eql(counts['field']) if counts.key?('field')
     expect(MiqAeValue.count).to eql(counts['value']) if counts.key?('value')
   end

--- a/spec/service_models/miq_ae_service_generic_object_spec.rb
+++ b/spec/service_models/miq_ae_service_generic_object_spec.rb
@@ -115,7 +115,7 @@ describe MiqAeMethodService::MiqAeServiceGenericObject do
   end
 
   describe '#convert_params_to_ar_model' do
-    subject    { service_go.send(:convert_params_to_ar_model, @args) }
+    subject { service_go.send(:convert_params_to_ar_model, @args) }
 
     before do
       allow(DRb).to receive_message_chain('front.workspace.ae_user').and_return(user)

--- a/spec/service_models/miq_ae_service_host_spec.rb
+++ b/spec/service_models/miq_ae_service_host_spec.rb
@@ -2,7 +2,7 @@ describe MiqAeMethodService::MiqAeServiceHost do
   before do
     @user = FactoryBot.create(:user_with_group)
     Spec::Support::MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM', 'AUTOMATE', 'test1', 'test')
-    @ae_method     = ::MiqAeMethod.first
+    @ae_method = ::MiqAeMethod.first
     @ae_result_key = 'foo'
     @host = FactoryBot.create(:host)
   end

--- a/spec/service_models/miq_ae_service_manageiq-providers-amazon-cloud_manager_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-amazon-cloud_manager_spec.rb
@@ -5,7 +5,7 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Amazon_CloudManager 
     @availability_zone      = FactoryBot.create(:availability_zone)
     @ems.availability_zones << @availability_zone
     @ems.flavors << @flavor
-    @ems_amazon             = MiqAeMethodService::MiqAeServiceManageIQ_Providers_Amazon_CloudManager.find(@ems.id)
+    @ems_amazon = MiqAeMethodService::MiqAeServiceManageIQ_Providers_Amazon_CloudManager.find(@ems.id)
   end
 
   it "#flavors" do

--- a/spec/service_models/miq_ae_service_manageiq-providers-cloud_manager-provision_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-cloud_manager-provision_spec.rb
@@ -6,13 +6,13 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
         @cloud_image   = FactoryBot.create("template_#{t}".to_sym, :ext_management_system => @provider)
         @options       = {:src_vm_id => [@cloud_image.id, @cloud_image.name],
                           :pass      => 1}
-        @user          = FactoryBot.create(:user, :name => 'Fred Flintstone',  :userid => 'fred')
+        @user          = FactoryBot.create(:user, :name => 'Fred Flintstone', :userid => 'fred')
         @miq_provision = FactoryBot.create("miq_provision_#{t}".to_sym,
-                                            :provision_type => 'template',
-                                            :state          => 'pending',
-                                            :status         => 'Ok',
-                                            :options        => @options,
-                                            :userid         => @user.userid)
+                                           :provision_type => 'template',
+                                           :state          => 'pending',
+                                           :status         => 'Ok',
+                                           :options        => @options,
+                                           :userid         => @user.userid)
       end
 
       let(:workflow_klass) { MiqProvisionWorkflow.class_for_platform(t) }

--- a/spec/service_models/miq_ae_service_manageiq-providers-cloud_manager-vm_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-cloud_manager-vm_spec.rb
@@ -20,14 +20,14 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManag
         network = FactoryBot.create("cloud_network_#{t}".to_sym)
         subnet  = FactoryBot.create("cloud_subnet_#{t}".to_sym, :cloud_network => network)
         vm.network_ports << network_port = FactoryBot.create("network_port_#{t}".to_sym,
-                                                              :device       => vm)
+                                                             :device => vm)
         FactoryBot.create(:cloud_subnet_network_port, :cloud_subnet => subnet, :network_port => network_port)
 
         network_port.security_groups << FactoryBot.create("security_group_#{t}".to_sym)
         network_port.floating_ip = FactoryBot.create("floating_ip_#{t}".to_sym, :vm => vm)
 
         vm.save!
-        @vm                  = service_class_for(:vm).find(vm.id)
+        @vm = service_class_for(:vm).find(vm.id)
       end
 
       it "#flavor" do

--- a/spec/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-cloud_volume_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-cloud_volume_spec.rb
@@ -23,7 +23,8 @@ describe MiqAeMethodService::MiqAeServiceUser do
     expect(MiqQueue.last).to have_attributes(
       @base_queue_options.merge(
         :method_name => 'backup_create',
-        :args        => [{:name => "test backup", :incremental => false}])
+        :args        => [{:name => "test backup", :incremental => false}]
+      )
     )
   end
 
@@ -33,7 +34,8 @@ describe MiqAeMethodService::MiqAeServiceUser do
     expect(MiqQueue.last).to have_attributes(
       @base_queue_options.merge(
         :method_name => 'backup_restore',
-        :args        => ["1234"])
+        :args        => ["1234"]
+      )
     )
   end
 end

--- a/spec/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm_spec.rb
@@ -19,7 +19,8 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManag
     expect(MiqQueue.last).to have_attributes(
       @base_queue_options.merge(
         :method_name => 'attach_volume',
-        :args        => ['volume1', '/device/path'])
+        :args        => ['volume1', '/device/path']
+      )
     )
   end
 
@@ -29,7 +30,8 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManag
     expect(MiqQueue.last).to have_attributes(
       @base_queue_options.merge(
         :method_name => 'detach_volume',
-        :args        => ['volume1'])
+        :args        => ['volume1']
+      )
     )
   end
 end

--- a/spec/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager_spec.rb
@@ -5,7 +5,7 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManag
     @availability_zone      = FactoryBot.create(:availability_zone_openstack)
     @ems.availability_zones << @availability_zone
     @ems.flavors << @flavor
-    @ems_openstack          = MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager.find(@ems.id)
+    @ems_openstack = MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager.find(@ems.id)
   end
 
   it "#flavors" do

--- a/spec/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager-vm_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager-vm_spec.rb
@@ -41,7 +41,8 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Redhat_InfraManager_
     expect(MiqQueue.first).to have_attributes(
       @base_queue_options.merge(
         :method_name => 'add_disk',
-        :args        => ['disk_1', 100, {:interface => "IDE", :bootable => true}])
+        :args        => ['disk_1', 100, {:interface => "IDE", :bootable => true}]
+      )
     )
   end
 end

--- a/spec/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-provision_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-provision_spec.rb
@@ -11,10 +11,10 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_
     @options[:pass]      = 1
     @user = FactoryBot.create(:user_with_group, :name => 'Fred Flintstone', :userid => 'fred')
     @miq_provision = FactoryBot.create(:miq_provision_vmware,
-                                        :provision_type => 'template',
-                                        :state => 'pending', :status => 'Ok',
-                                        :options => @options,
-                                        :userid => @user.userid)
+                                       :provision_type => 'template',
+                                       :state => 'pending', :status => 'Ok',
+                                       :options => @options,
+                                       :userid => @user.userid)
   end
 
   let(:ae_svc_prov) { MiqAeMethodService::MiqAeServiceMiqProvision.find(@miq_provision.id) }
@@ -28,10 +28,10 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_
   context "check requests" do
     before do
       @miq_provision_request = FactoryBot.create(:miq_provision_request,
-                                                  :provision_type => 'template',
-                                                  :state => 'pending', :status => 'Ok',
-                                                  :src_vm_id => @vm_template.id,
-                                                  :requester => @user)
+                                                 :provision_type => 'template',
+                                                 :state => 'pending', :status => 'Ok',
+                                                 :src_vm_id => @vm_template.id,
+                                                 :requester => @user)
       @miq_provision.miq_provision_request = @miq_provision_request
       @miq_provision.save!
       @miq_provision_request.save!
@@ -146,8 +146,8 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_
       iso_image_struct = [MiqHashStruct.new(
         :id               => "IsoImage::#{@iso_image.id}",
         :name             => @iso_image.name,
-        :evm_object_class => @iso_image.class.base_class.name.to_sym)
-                         ]
+        :evm_object_class => @iso_image.class.base_class.name.to_sym
+      )]
       allow_any_instance_of(MiqProvisionWorkflow).to receive(:allowed_iso_images).and_return(iso_image_struct)
     end
 

--- a/spec/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
@@ -21,7 +21,8 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_
     expect(MiqQueue.first).to have_attributes(
       @base_queue_options.merge(
         :method_name => 'set_number_of_cpus',
-        :args        => [1])
+        :args        => [1]
+      )
     )
   end
 
@@ -31,7 +32,8 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_
     expect(MiqQueue.first).to have_attributes(
       @base_queue_options.merge(
         :method_name => 'set_memory',
-        :args        => [100])
+        :args        => [100]
+      )
     )
   end
 
@@ -51,17 +53,19 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_
     expect(MiqQueue.first).to have_attributes(
       @base_queue_options.merge(
         :method_name => 'add_disk',
-        :args        => ['disk_1', 100, :thin_provisioned => true])
+        :args        => ['disk_1', 100, :thin_provisioned => true]
+      )
     )
   end
 
-  it "#remove_from_disk async"do
+  it "#remove_from_disk async" do
     service_vm.remove_from_disk(false)
 
     expect(MiqQueue.first).to have_attributes(
       @base_queue_options.merge(
         :method_name => 'vm_destroy',
-        :args        => [])
+        :args        => []
+      )
     )
   end
 

--- a/spec/service_models/miq_ae_service_miq_provision_request_spec.rb
+++ b/spec/service_models/miq_ae_service_miq_provision_request_spec.rb
@@ -22,7 +22,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvisionRequest do
   it "#miq_request" do
     @miq_provision_request.save!
 
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].miq_request"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].miq_request"
     @ae_method.update(:data => method)
     ae_object = invoke_ae.root(@ae_result_key)
     expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
@@ -30,12 +30,12 @@ describe MiqAeMethodService::MiqAeServiceMiqProvisionRequest do
   end
 
   it "#miq_provisions" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].miq_provisions"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].miq_provisions"
     @ae_method.update(:data => method)
     ae_object = invoke_ae.root(@ae_result_key)
     expect(ae_object).to eq([])
 
-    options       = {}
+    options = {}
     options[:src_vm_id] = [@vm_template.id, @vm_template.name]
     options[:pass]      = 1
     miq_provision1 = FactoryBot.create(:miq_provision, :provision_type => 'template', :state => 'pending', :status => 'Ok', :options => options)
@@ -65,7 +65,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvisionRequest do
   end
 
   it "#vm_template" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].vm_template"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].vm_template"
     @ae_method.update(:data => method)
     ae_object = invoke_ae.root(@ae_result_key)
     expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqTemplate)
@@ -73,7 +73,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvisionRequest do
   end
 
   it "#request_type" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].request_type"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].request_type"
     @ae_method.update(:data => method)
 
     %w[template clone_to_vm clone_to_template].each do |provision_type|
@@ -83,7 +83,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvisionRequest do
   end
 
   it "#target_type" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].target_type"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].target_type"
     @ae_method.update(:data => method)
 
     %w[clone_to_template].each do |provision_type|
@@ -98,7 +98,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvisionRequest do
   end
 
   it "#register_automate_callback - no previous callbacks" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].register_automate_callback(:first_time_out, 'do_something_great')"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].register_automate_callback(:first_time_out, 'do_something_great')"
     @ae_method.update(:data => method)
     expect(invoke_ae.root(@ae_result_key)).to be_truthy
     expect(@miq_provision_request.options[:callbacks]).to be_nil
@@ -109,7 +109,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvisionRequest do
   end
 
   it "#register_automate_callback - with previous callbacks" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].register_automate_callback(:first_time_out, 'do_something_great')"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].register_automate_callback(:first_time_out, 'do_something_great')"
     @ae_method.update(:data => method)
     expect(@miq_provision_request.options[:callbacks]).to be_nil
     opts = @miq_provision_request.options.dup
@@ -124,7 +124,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvisionRequest do
   end
 
   it "#source_type" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].source_type"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].source_type"
     @ae_method.update(:data => method)
 
     vm = VmOrTemplate.find(@vm_template.id)
@@ -139,7 +139,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvisionRequest do
   end
 
   it "#ci_type" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].ci_type"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision_request'].ci_type"
     @ae_method.update(:data => method)
     expect(invoke_ae.root(@ae_result_key)).to eq('vm')
   end

--- a/spec/service_models/miq_ae_service_miq_provision_spec.rb
+++ b/spec/service_models/miq_ae_service_miq_provision_spec.rb
@@ -9,7 +9,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
     @options       = {}
     @options[:src_vm_id] = [@vm_template.id, @vm_template.name]
     @options[:pass]      = 1
-    @user        = FactoryBot.create(:user_with_group, :name => 'Fred Flintstone',  :userid => 'fred')
+    @user = FactoryBot.create(:user_with_group, :name => 'Fred Flintstone', :userid => 'fred')
     @miq_provision = FactoryBot.create(:miq_provision, :provision_type => 'template', :state => 'pending', :status => 'Ok', :options => @options, :userid => @user.userid)
   end
 
@@ -23,7 +23,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
     @miq_provision.miq_provision_request = miq_provision_request
     @miq_provision.save!
 
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].miq_request"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].miq_request"
     @ae_method.update(:data => method)
     ae_object = invoke_ae.root(@ae_result_key)
     expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqRequest)
@@ -35,7 +35,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
     @miq_provision.miq_provision_request = miq_provision_request
     @miq_provision.save!
 
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].miq_provision_request"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].miq_provision_request"
     @ae_method.update(:data => method)
     ae_object = invoke_ae.root(@ae_result_key)
     expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqProvisionRequest)
@@ -43,7 +43,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
   end
 
   it "#vm" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].vm"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].vm"
     @ae_method.update(:data => method)
     ae_object = invoke_ae.root(@ae_result_key)
     expect(ae_object).to be_nil
@@ -58,7 +58,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
   end
 
   it "#vm_template" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].vm_template"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].vm_template"
     @ae_method.update(:data => method)
     ae_object = invoke_ae.root(@ae_result_key)
     expect(ae_object).to be_kind_of(MiqAeMethodService::MiqAeServiceMiqTemplate)
@@ -66,7 +66,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
   end
 
   it "#execute" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].execute"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].execute"
     @ae_method.update(:data => method)
 
     expect_any_instance_of(MiqProvision).to receive(:execute_queue).once
@@ -74,7 +74,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
   end
 
   it "#request_type" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].request_type"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].request_type"
     @ae_method.update(:data => method)
 
     %w[template clone_to_vm clone_to_template].each do |provision_type|
@@ -84,7 +84,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
   end
 
   it "#register_automate_callback - no previous callbacks" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].register_automate_callback(:first_time_out, 'do_something_great')"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].register_automate_callback(:first_time_out, 'do_something_great')"
     @ae_method.update(:data => method)
     expect(invoke_ae.root(@ae_result_key)).to be_truthy
     expect(@miq_provision.options[:callbacks]).to be_nil
@@ -95,7 +95,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
   end
 
   it "#register_automate_callback - with previous callbacks" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].register_automate_callback(:first_time_out, 'do_something_great')"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].register_automate_callback(:first_time_out, 'do_something_great')"
     @ae_method.update(:data => method)
     expect(@miq_provision.options[:callbacks]).to be_nil
     opts = @miq_provision.options.dup
@@ -119,7 +119,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
   end
 
   it "#target_type" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].target_type"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].target_type"
     @ae_method.update(:data => method)
 
     %w[clone_to_template].each do |provision_type|
@@ -141,7 +141,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
     end
 
     it "eligible_iso_images" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_iso_images"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_iso_images"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to be_kind_of(Array)
@@ -161,7 +161,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
 
   context "#source_type" do
     before do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].source_type"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].source_type"
       @ae_method.update(:data => method)
     end
 
@@ -186,7 +186,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
     end
 
     it "#eligible_customization_templates" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_customization_templates"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_customization_templates"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to be_kind_of(Array)
@@ -213,7 +213,7 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
     end
 
     it "#eligible_resource_pools" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_resource_pools"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].eligible_resource_pools"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to be_kind_of(Array)

--- a/spec/service_models/miq_ae_service_miq_request_spec.rb
+++ b/spec/service_models/miq_ae_service_miq_request_spec.rb
@@ -31,7 +31,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequest do
     @ae_method.update(:data => method)
     expect(MiqRequest).to receive(:find).with(@miq_request.id.to_s).and_return(@miq_request)
     expect(@miq_request).to receive(:approve).with(approver, reason).once
-    expect(invoke_ae.root(@ae_result_key)).to  be_truthy
+    expect(invoke_ae.root(@ae_result_key)).to be_truthy
   end
 
   it "#deny" do
@@ -45,14 +45,14 @@ describe MiqAeMethodService::MiqAeServiceMiqRequest do
   end
 
   it "#pending" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].pending"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].pending"
     @ae_method.update(:data => method)
     expect_any_instance_of(MiqRequest).to receive(:pending).once
     expect(invoke_ae.root(@ae_result_key)).to  be_truthy
   end
 
   it "#approvers" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].approvers"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].approvers"
     @ae_method.update(:data => method)
     expect(invoke_ae.root(@ae_result_key)).to eq([])
 
@@ -80,14 +80,14 @@ describe MiqAeMethodService::MiqAeServiceMiqRequest do
   end
 
   it "#requester" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].requester"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].requester"
     @ae_method.update(:data => method)
     fred = invoke_ae.root(@ae_result_key)
     assert_ae_user_matches_ar_user(fred, @fred)
   end
 
   it "#authorized?" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].authorized?"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].authorized?"
     @ae_method.update(:data => method)
     [true, false].each do |expected_authorized|
       allow_any_instance_of(MiqRequest).to receive(:authorized?).and_return(expected_authorized)
@@ -97,7 +97,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequest do
   end
 
   it "#resource" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].resource"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].resource"
     @ae_method.update(:data => method)
 
     vm_template = FactoryBot.create(:template_vmware, :name => "template1")
@@ -111,7 +111,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequest do
   end
 
   it "#reason" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].reason"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].reason"
     @ae_method.update(:data => method)
     reason = invoke_ae.root(@ae_result_key)
     expect(reason).to be_nil
@@ -180,7 +180,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequest do
   end
 
   it "#get_tags" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].get_tags"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].get_tags"
     @ae_method.update(:data => method)
     tags = ['tag1', 'tag2']
     expect_any_instance_of(MiqRequest).to receive(:get_tags).once.and_return(tags)
@@ -189,7 +189,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequest do
 
   context "#clear_tag" do
     it "should work with no parms" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].clear_tag"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].clear_tag"
       @ae_method.update(:data => method)
       expect_any_instance_of(MiqRequest).to receive(:clear_tag).with(nil, nil).once
       invoke_ae
@@ -223,7 +223,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequest do
   end
 
   it "#get_classifications" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].get_classifications"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request'].get_classifications"
     @ae_method.update(:data => method)
     classifications = ['classification1', 'classification2']
     expect_any_instance_of(MiqRequest).to receive(:get_classifications).once.and_return(classifications)
@@ -240,7 +240,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequest do
 
   it "#description=" do
     description = 'test description'
-    method  = "$evm.root['miq_request'].description=('#{description}')"
+    method = "$evm.root['miq_request'].description=('#{description}')"
     @ae_method.update(:data => method)
     invoke_ae
     expect(@miq_request.reload.description).to eq(description)

--- a/spec/service_models/miq_ae_service_miq_request_task_spec.rb
+++ b/spec/service_models/miq_ae_service_miq_request_task_spec.rb
@@ -2,7 +2,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequestTask do
   before do
     @user = FactoryBot.create(:user_with_group)
     Spec::Support::MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM', 'AUTOMATE', 'test1', 'test')
-    @ae_method     = ::MiqAeMethod.first
+    @ae_method = ::MiqAeMethod.first
     @ae_result_key = 'foo'
 
     @miq_request_task = FactoryBot.create(:miq_request_task, :status => 'Ok')
@@ -13,14 +13,14 @@ describe MiqAeMethodService::MiqAeServiceMiqRequestTask do
   end
 
   it "#execute" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].execute"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].execute"
     @ae_method.update(:data => method)
     expect_any_instance_of(MiqRequestTask).to receive(:execute_queue).once
     expect(invoke_ae.root(@ae_result_key)).to be_truthy
   end
 
   it "#miq_request" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].miq_request"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].miq_request"
     @ae_method.update(:data => method)
 
     user        = FactoryBot.create(:user)
@@ -33,7 +33,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequestTask do
   end
 
   it "#options" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].options"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].options"
     @ae_method.update(:data => method)
     options = {:a => 1, :b => 'two'}
     expect_any_instance_of(MiqRequestTask).to receive(:options).once.and_return(options)
@@ -42,7 +42,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequestTask do
 
   it "#get_option" do
     key = 'key1'
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_option('#{key}')"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_option('#{key}')"
     @ae_method.update(:data => method)
     value = 'three hundred'
     expect_any_instance_of(MiqRequestTask).to receive(:get_option).with(key).once.and_return(value)
@@ -51,7 +51,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequestTask do
 
   it "#get_option_last" do
     key = 'key1'
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_option_last('#{key}')"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_option_last('#{key}')"
     @ae_method.update(:data => method)
     value = 'three hundred'
     expect_any_instance_of(MiqRequestTask).to receive(:get_option_last).with(key).once.and_return(value)
@@ -63,7 +63,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequestTask do
     @miq_request_task.update(:options => options)
     key     = 'foo'
     value   = 'bar'
-    method   = "$evm.root['miq_request_task'].set_option('#{key}', '#{value}')"
+    method = "$evm.root['miq_request_task'].set_option('#{key}', '#{value}')"
     @ae_method.update(:data => method)
     invoke_ae
     new_options = options.dup
@@ -81,7 +81,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequestTask do
   end
 
   it "#get_tags" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_tags"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_tags"
     @ae_method.update(:data => method)
     tags = ['tag1', 'tag2']
     expect_any_instance_of(MiqRequestTask).to receive(:get_tags).once.and_return(tags)
@@ -98,7 +98,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequestTask do
   end
 
   it "#get_classifications" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_classifications"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_request_task'].get_classifications"
     @ae_method.update(:data => method)
     classifications = ['classification1', 'classification2']
     expect_any_instance_of(MiqRequestTask).to receive(:get_classifications).once.and_return(classifications)
@@ -127,7 +127,7 @@ describe MiqAeMethodService::MiqAeServiceMiqRequestTask do
 
   it "#finished" do
     message = 'message1'
-    method   = "$evm.root['miq_request_task'].finished('#{message}')"
+    method = "$evm.root['miq_request_task'].finished('#{message}')"
     @ae_method.update(:data => method)
     expect_any_instance_of(MiqRequestTask).to receive(:update_and_notify_parent).with(:state => 'finished', :message => message).once
     invoke_ae

--- a/spec/service_models/miq_ae_service_service_reconfigure_request_spec.rb
+++ b/spec/service_models/miq_ae_service_service_reconfigure_request_spec.rb
@@ -2,7 +2,7 @@ describe MiqAeMethodService::MiqAeServiceServiceReconfigureRequest do
   include Spec::Support::AutomationHelper
 
   before do
-    method_script   = "$evm.root['ci_type'] = $evm.root['request'].ci_type"
+    method_script = "$evm.root['ci_type'] = $evm.root['request'].ci_type"
     create_ae_model_with_method(:method_script => method_script, :ae_class => 'AUTOMATE',
                                 :ae_namespace  => 'EVM', :instance_name => 'test1',
                                 :method_name   => 'test', :name => 'TEST_DOMAIN')

--- a/spec/service_models/miq_ae_service_service_reconfigure_task_spec.rb
+++ b/spec/service_models/miq_ae_service_service_reconfigure_task_spec.rb
@@ -2,7 +2,7 @@ describe MiqAeMethodService::MiqAeServiceServiceReconfigureTask do
   include Spec::Support::AutomationHelper
 
   before do
-    method_script   = "$evm.root['result'] = $evm.root['service_reconfigure_task'].status"
+    method_script = "$evm.root['result'] = $evm.root['service_reconfigure_task'].status"
     create_ae_model_with_method(:method_script => method_script, :ae_class => 'AUTOMATE',
                                 :ae_namespace  => 'EVM', :instance_name => 'test1',
                                 :method_name   => 'test', :name => 'TEST_DOMAIN')
@@ -13,10 +13,10 @@ describe MiqAeMethodService::MiqAeServiceServiceReconfigureTask do
   let(:user)      { FactoryBot.create(:user_with_group) }
   let(:task)      do
     FactoryBot.create(:service_reconfigure_task,
-                       :state        => 'pending',
-                       :status       => 'Ok',
-                       :request_type => 'service_reconfigure',
-                       :options      => options)
+                      :state        => 'pending',
+                      :status       => 'Ok',
+                      :request_type => 'service_reconfigure',
+                      :options      => options)
   end
 
   def invoke_ae

--- a/spec/service_models/miq_ae_service_service_spec.rb
+++ b/spec/service_models/miq_ae_service_service_spec.rb
@@ -8,7 +8,7 @@ describe MiqAeMethodService::MiqAeServiceService do
     @ae_method     = ::MiqAeMethod.first
     @ae_result_key = 'foo'
 
-    @service   = FactoryBot.create(:service, :name => "test_service", :description => "test_description")
+    @service = FactoryBot.create(:service, :name => "test_service", :description => "test_description")
   end
 
   def invoke_ae
@@ -112,12 +112,12 @@ describe MiqAeMethodService::MiqAeServiceService do
       service_template = FactoryBot.create(:service_template, :name => 'Dummy')
       service_name = 'service name'
       description = 'description'
-      method = <<-SCP
+      method = <<~CREATE_SERVICE_SCRIPT
         service_template = $evm.vmdb('service_template').find(#{service_template.id})
         $evm.vmdb('service').create(:name             => '#{service_name}',
-                            :description      => '#{description}',
-                            :service_template => service_template)
-      SCP
+                                    :description      => '#{description}',
+                                    :service_template => service_template)
+      CREATE_SERVICE_SCRIPT
       @ae_method.update(:data => method)
       invoke_ae
 

--- a/spec/service_models/miq_ae_service_service_template_provision_request_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_provision_request_spec.rb
@@ -7,7 +7,7 @@ describe MiqAeMethodService::MiqAeServiceServiceTemplateProvisionRequest do
     Spec::Support::MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM', 'AUTOMATE', 'test1', 'test')
     @ae_method     = ::MiqAeMethod.first
     @ae_result_key = 'foo'
-    @user          = FactoryBot.create(:user_with_group, :name => 'Fred Flintstone',  :userid => 'fred')
+    @user          = FactoryBot.create(:user_with_group, :name => 'Fred Flintstone', :userid => 'fred')
     @service_template_provision_request = FactoryBot.create(:service_template_provision_request, :requester => @user)
   end
 

--- a/spec/service_models/miq_ae_service_service_template_provision_task_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_provision_task_spec.rb
@@ -17,7 +17,7 @@ describe MiqAeMethodService::MiqAeServiceServiceTemplateProvisionTask do
   end
 
   it "#execute" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_task'].execute"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_task'].execute"
     @ae_method.update(:data => method)
     expect_any_instance_of(ServiceTemplateProvisionTask).to receive(:execute_queue).once
     expect(invoke_ae.root(@ae_result_key)).to be_truthy
@@ -43,7 +43,7 @@ describe MiqAeMethodService::MiqAeServiceServiceTemplateProvisionTask do
   context "#status" do
     it "when state is provisioned" do
       @service_template_provision_task.update(:state => "provisioned")
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_task'].status"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_task'].status"
       @ae_method.update!(:data => method)
 
       expect(invoke_ae.root(@ae_result_key)).to eq('ok')
@@ -51,7 +51,7 @@ describe MiqAeMethodService::MiqAeServiceServiceTemplateProvisionTask do
 
     it "when state is finished" do
       @service_template_provision_task.update(:state => "finished")
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_task'].status"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_task'].status"
       @ae_method.update!(:data => method)
 
       expect(invoke_ae.root(@ae_result_key)).to eq('ok')
@@ -59,7 +59,7 @@ describe MiqAeMethodService::MiqAeServiceServiceTemplateProvisionTask do
 
     it "when state is pending" do
       @service_template_provision_task.update(:state => "pending")
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_task'].status"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.root['service_template_provision_task'].status"
       @ae_method.update!(:data => method)
 
       expect(invoke_ae.root(@ae_result_key)).to eq('retry')

--- a/spec/service_models/miq_ae_service_service_template_spec.rb
+++ b/spec/service_models/miq_ae_service_service_template_spec.rb
@@ -4,7 +4,7 @@ describe MiqAeMethodService::MiqAeServiceServiceTemplate do
       Spec::Support::MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM', 'AUTOMATE', 'test1', 'test')
       @ae_method     = ::MiqAeMethod.first
       @ae_result_key = 'foo'
-      @service_template   = FactoryBot.create(:service_template)
+      @service_template = FactoryBot.create(:service_template)
       @user = FactoryBot.create(:user_with_group)
     end
 
@@ -33,8 +33,8 @@ describe MiqAeMethodService::MiqAeServiceServiceTemplate do
 
   context "associations" do
     before do
-      service_template          = FactoryBot.create(:service_template)
-      @service_service_template  = MiqAeMethodService::MiqAeServiceServiceTemplate.find(service_template.id)
+      service_template = FactoryBot.create(:service_template)
+      @service_service_template = MiqAeMethodService::MiqAeServiceServiceTemplate.find(service_template.id)
     end
 
     it "#services" do
@@ -48,7 +48,7 @@ describe MiqAeMethodService::MiqAeServiceServiceTemplate do
     context "with a service resource" do
       before do
         @service_resource = FactoryBot.create(:service_resource,
-                                               :service_template_id => @service_service_template.id)
+                                              :service_template_id => @service_service_template.id)
       end
 
       it "#service_resources" do

--- a/spec/service_models/miq_ae_service_spec.rb
+++ b/spec/service_models/miq_ae_service_spec.rb
@@ -7,7 +7,7 @@ describe MiqAeMethodService::MiqAeService do
     @tenant = FactoryBot.build(:tenant, :parent => @root_tenant)
     @owner = FactoryBot.create(:user_with_group, :name => "fred", :tenant => @tenant)
     create_method(@domain, @tenant)
-    @ae_method     = ::MiqAeMethod.first
+    @ae_method = ::MiqAeMethod.first
     @ae_result_key = 'foo'
   end
 
@@ -20,8 +20,7 @@ describe MiqAeMethodService::MiqAeService do
                    {:name => 'var1', :type => 'attribute',
                              :priority => 2, :value => 'testvalueforvar1'},
                    {:name => 'var2', :type => 'attribute',
-                             :priority => 3}
-                  ]
+                             :priority => 3}]
     Spec::Support::MiqAutomateHelper.create_dummy_method(identifiers, fields)
   end
 
@@ -47,14 +46,14 @@ describe MiqAeMethodService::MiqAeService do
 
   context "$evm.instance_exists?" do
     it "nonexistant instance " do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('/bogus/evenworse/fred')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('/bogus/evenworse/fred')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(false)
     end
 
     it "existing instance " do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/test1')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/test1')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(true)
@@ -63,31 +62,31 @@ describe MiqAeMethodService::MiqAeService do
 
   context "$evm.instance_create" do
     it "instance already exists" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/test1', 'method1' => 'testattributevalue', 'var1' => 'variablevalue1')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/test1', 'method1' => 'testattributevalue', 'var1' => 'variablevalue1')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(false)
     end
 
     it "readonly domain" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/freddy', 'method1' => 'a', 'var1' => 'b')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/freddy', 'method1' => 'a', 'var1' => 'b')"
       assert_readonly_instance(method)
     end
 
     it "instance does not exist, create it, check that it exists, then get the instance values" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/testadd', 'method1' => 'testattributevalue', 'var1' => 'variablevalue1' )"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/testadd', 'method1' => 'testattributevalue', 'var1' => 'variablevalue1' )"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(true)
 
       # Now the instance should exist
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/testadd')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/testadd')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(true)
 
       # Make sure we can get instance values
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_get('#{@domain}/EVM/AUTOMATE/testadd')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_get('#{@domain}/EVM/AUTOMATE/testadd')"
       @ae_method.update(:data => method)
       result_hash = invoke_ae.root(@ae_result_key)
       expect(result_hash).to be_kind_of(Hash)
@@ -98,7 +97,7 @@ describe MiqAeMethodService::MiqAeService do
   context "$evm.instance_find" do
     context "single instance in datastore" do
       it "instance not found" do
-        method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/testadd')"
+        method = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/testadd')"
         @ae_method.update(:data => method)
         result_hash = invoke_ae.root(@ae_result_key)
         expect(result_hash).to eq({})
@@ -106,7 +105,7 @@ describe MiqAeMethodService::MiqAeService do
 
       context "instance found" do
         it "with no options specified" do
-          method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/te*')"
+          method = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/te*')"
           @ae_method.update(:data => method)
           result_hash = invoke_ae.root(@ae_result_key)
           expect(result_hash).to be_kind_of(Hash)
@@ -118,7 +117,7 @@ describe MiqAeMethodService::MiqAeService do
         end
 
         it "with path option specified" do
-          method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/te*', :path => true)"
+          method = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/te*', :path => true)"
           @ae_method.update(:data => method)
           result_hash = invoke_ae.root(@ae_result_key)
           expect(result_hash).to be_kind_of(Hash)
@@ -142,7 +141,7 @@ describe MiqAeMethodService::MiqAeService do
       end
 
       it "should find 3 instances when searching for te?t1*" do
-        method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/te?t1*')"
+        method = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/te?t1*')"
         @ae_method.update(:data => method)
         result_hash = invoke_ae.root(@ae_result_key)
         expect(result_hash).to be_kind_of(Hash)
@@ -155,7 +154,7 @@ describe MiqAeMethodService::MiqAeService do
       end
 
       it "should find 3 instances when searching for test*" do
-        method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/test*')"
+        method = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/test*')"
         @ae_method.update(:data => method)
         result_hash = invoke_ae.root(@ae_result_key)
         expect(result_hash).to be_kind_of(Hash)
@@ -168,7 +167,7 @@ describe MiqAeMethodService::MiqAeService do
       end
 
       it "should find 2 instances when searching for test1*" do
-        method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/test1*')"
+        method = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/test1*')"
         @ae_method.update(:data => method)
         result_hash = invoke_ae.root(@ae_result_key)
         expect(result_hash).to be_kind_of(Hash)
@@ -181,7 +180,7 @@ describe MiqAeMethodService::MiqAeService do
       end
 
       it "should find 1 instances when searching for test1?" do
-        method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/test1?')"
+        method = "$evm.root['#{@ae_result_key}'] = $evm.instance_find('#{@domain}/EVM/AUTOMATE/test1?')"
         @ae_method.update(:data => method)
         result_hash = invoke_ae.root(@ae_result_key)
         expect(result_hash).to be_kind_of(Hash)
@@ -197,14 +196,14 @@ describe MiqAeMethodService::MiqAeService do
 
   context "$evm.instance_get" do
     it "instance does not exist" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_get('#{@domain}/EVM/AUTOMATE/testadd')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_get('#{@domain}/EVM/AUTOMATE/testadd')"
       @ae_method.update(:data => method)
       result_hash = invoke_ae.root(@ae_result_key)
       expect(result_hash).to be_nil
     end
 
     it "instance exists" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_get('#{@domain}/EVM/AUTOMATE/test1')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_get('#{@domain}/EVM/AUTOMATE/test1')"
       @ae_method.update(:data => method)
       result_hash = invoke_ae.root(@ae_result_key)
       expect(result_hash).to be_kind_of(Hash)
@@ -214,14 +213,14 @@ describe MiqAeMethodService::MiqAeService do
 
   context "$evm.instance_get_display_name" do
     it "instance does not exist" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_get_display_name('#{@domain}/EVM/AUTOMATE/testadd')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_get_display_name('#{@domain}/EVM/AUTOMATE/testadd')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to be_nil
     end
 
     it "instance does exist" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_get_display_name('#{@domain}/EVM/AUTOMATE/test1')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_get_display_name('#{@domain}/EVM/AUTOMATE/test1')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to be_nil
@@ -230,7 +229,7 @@ describe MiqAeMethodService::MiqAeService do
 
   context "$evm.instance_set_display_name" do
     it "instance does not exist" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_set_display_name('#{@domain}/EVM/AUTOMATE/testadd', 'foo')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_set_display_name('#{@domain}/EVM/AUTOMATE/testadd', 'foo')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(false)
@@ -238,12 +237,12 @@ describe MiqAeMethodService::MiqAeService do
 
     it "instance does exist" do
       display_name = 'Supercalifragilisticexpialidocious'
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_set_display_name('#{@domain}/EVM/AUTOMATE/test1', #{display_name.inspect})"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_set_display_name('#{@domain}/EVM/AUTOMATE/test1', #{display_name.inspect})"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(true)
 
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_get_display_name('#{@domain}/EVM/AUTOMATE/test1')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_get_display_name('#{@domain}/EVM/AUTOMATE/test1')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(display_name)
@@ -252,24 +251,24 @@ describe MiqAeMethodService::MiqAeService do
 
   context "$evm.instance_update" do
     it "instance does not exist" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_update('#{@domain}/EVM/AUTOMATE/testadd', 'method1' => 'testattributevalue', 'var1' => 'variablevalue1')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_update('#{@domain}/EVM/AUTOMATE/testadd', 'method1' => 'testattributevalue', 'var1' => 'variablevalue1')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(false)
     end
 
     it "readonly domain" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_update('#{@domain}/EVM/AUTOMATE/test1', 'method1' => 'a', 'var1' => 'b')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_update('#{@domain}/EVM/AUTOMATE/test1', 'method1' => 'a', 'var1' => 'b')"
       assert_readonly_instance(method)
     end
 
     it "instance does not exist, create it, then update it" do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/testadd', { 'method1' => 'testattributevalue', 'var1' => 'variablevalue1'})"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/testadd', { 'method1' => 'testattributevalue', 'var1' => 'variablevalue1'})"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(true)
 
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_update('#{@domain}/EVM/AUTOMATE/testadd', { 'method1' => 'testattributevaluechanged', 'var1' => 'variablevalue1changed'})"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_update('#{@domain}/EVM/AUTOMATE/testadd', { 'method1' => 'testattributevaluechanged', 'var1' => 'variablevalue1changed'})"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(true)
@@ -278,7 +277,7 @@ describe MiqAeMethodService::MiqAeService do
 
   context "$evm.instance_delete" do
     it "nonexistant instance " do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_delete('#{@domain}/bogus/evenworse/fred')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_delete('#{@domain}/bogus/evenworse/fred')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(false)
@@ -309,35 +308,35 @@ describe MiqAeMethodService::MiqAeService do
     end
 
     it "readonly domain " do
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_delete('#{@domain}/EVM/AUTOMATE/test1')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_delete('#{@domain}/EVM/AUTOMATE/test1')"
       assert_readonly_instance(method)
     end
 
     it "make sure instance does not exist, create new instance, make sure it exists, delete it, then check if it exists" do
       # Now the instance should not exist
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/testadd')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/testadd')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(false)
 
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/testadd', { 'method1' => 'testattributevalue' , 'var1' => 'variablevalue1'})"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_create('#{@domain}/EVM/AUTOMATE/testadd', { 'method1' => 'testattributevalue' , 'var1' => 'variablevalue1'})"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(true)
 
       # Now the instance should exist
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/testadd')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/testadd')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(true)
 
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_delete('#{@domain}/EVM/AUTOMATE/testadd')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_delete('#{@domain}/EVM/AUTOMATE/testadd')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(true)
 
       # Now the instance should not exist
-      method   = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/testadd')"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.instance_exists?('#{@domain}/EVM/AUTOMATE/testadd')"
       @ae_method.update(:data => method)
       result = invoke_ae.root(@ae_result_key)
       expect(result).to eq(false)

--- a/spec/service_models/miq_ae_service_vm_spec.rb
+++ b/spec/service_models/miq_ae_service_vm_spec.rb
@@ -5,10 +5,10 @@ describe MiqAeMethodService::MiqAeServiceVm do
   before do
     @user = FactoryBot.create(:user_with_group)
     Spec::Support::MiqAutomateHelper.create_service_model_method('SPEC_DOMAIN', 'EVM', 'AUTOMATE', 'test1', 'test')
-    @ae_method     = ::MiqAeMethod.first
+    @ae_method = ::MiqAeMethod.first
     @ae_result_key = 'foo'
 
-    @vm   = FactoryBot.create(:vm_vmware, :name => "template1", :location => "abc/abc.vmx")
+    @vm = FactoryBot.create(:vm_vmware, :name => "template1", :location => "abc/abc.vmx")
     zone = FactoryBot.create(:zone)
     allow(MiqServer).to receive(:my_zone).and_return(zone.name)
   end
@@ -23,7 +23,7 @@ describe MiqAeMethodService::MiqAeServiceVm do
   end
 
   it "#ems_custom_keys" do
-    method   = "$evm.root['#{@ae_result_key}'] = $evm.root['vm'].ems_custom_keys"
+    method = "$evm.root['#{@ae_result_key}'] = $evm.root['vm'].ems_custom_keys"
     @ae_method.update(:data => method)
     ae_object = invoke_ae.root(@ae_result_key)
     expect(ae_object).to be_kind_of(Array)

--- a/spec/support/miq_automate_helper.rb
+++ b/spec/support/miq_automate_helper.rb
@@ -6,12 +6,12 @@ module Spec
                                   :priority => 10, :enabled => true,
                                   :tenant   => identifiers[:tenant])
         @aen1 = FactoryBot.create(:miq_ae_namespace, :name      => identifiers[:namespace],
-                                                      :parent_id => @aed.id)
+                                                     :parent_id => @aed.id)
         @aec1 = FactoryBot.create(:miq_ae_class, :name         => identifiers[:class],
-                                                  :namespace_id => @aen1.id)
+                                                 :namespace_id => @aen1.id)
         @aec1.ae_fields << build_fields(field_array)
         @aei1 = FactoryBot.create(:miq_ae_instance, :name     => identifiers[:instance],
-                                                     :class_id => @aec1.id)
+                                                    :class_id => @aec1.id)
         if identifiers[:method].present?
           @aem1 = FactoryBot.create(:miq_ae_method, :class_id => @aec1.id,
                                     :name => identifiers[:method], :scope => "instance",
@@ -25,6 +25,7 @@ module Spec
         field_array.collect do |field|
           field_obj = field_objects.detect { |f| f.name == field[:name] }
           next unless field_obj
+
           FactoryBot.build(:miq_ae_value, :field_id => field_obj.id, :value => field[:value])
         end.compact
       end
@@ -32,39 +33,39 @@ module Spec
       def self.build_fields(field_array, aem_params = false)
         field_array.collect do |field|
           FactoryBot.build(:miq_ae_field,
-                            :name          => field[:name],
-                            :aetype        => field[:type],
-                            :priority      => field[:priority],
-                            :default_value => aem_params ? field[:value] : field[:default_value],
-                            :substitute    => true)
+                           :name          => field[:name],
+                           :aetype        => field[:type],
+                           :priority      => field[:priority],
+                           :default_value => aem_params ? field[:value] : field[:default_value],
+                           :substitute    => true)
         end
       end
 
       def self.create_field(class_obj, instance_obj, method_obj, options)
         if method_obj.nil?
           field = FactoryBot.create(:miq_ae_field,
-                                     :class_id   => class_obj.id,
-                                     :name       => options[:name],
-                                     :aetype     => options[:type],
-                                     :priority   => options[:priority],
-                                     :substitute => true)
+                                    :class_id   => class_obj.id,
+                                    :name       => options[:name],
+                                    :aetype     => options[:type],
+                                    :priority   => options[:priority],
+                                    :substitute => true)
           create_field_value(instance_obj, field, options[:value]) unless options[:value].nil?
         else
           FactoryBot.create(:miq_ae_field,
-                             :method_id     => method_obj.id,
-                             :name          => options[:name],
-                             :aetype        => options[:type],
-                             :priority      => options[:priority],
-                             :substitute    => true,
-                             :default_value => options[:value])
+                            :method_id     => method_obj.id,
+                            :name          => options[:name],
+                            :aetype        => options[:type],
+                            :priority      => options[:priority],
+                            :substitute    => true,
+                            :default_value => options[:value])
         end
       end
 
       def self.create_field_value(instance_obj, field_obj, value)
         FactoryBot.create(:miq_ae_value,
-                           :instance_id => instance_obj.id,
-                           :field_id    => field_obj.id,
-                           :value       => value)
+                          :instance_id => instance_obj.id,
+                          :field_id    => field_obj.id,
+                          :value       => value)
       end
 
       def self.create_service_model_method(domain, namespace, klass, instance, method)


### PR DESCRIPTION
Run only layout cops: `rubocop -a -x `

```ruby
Usage: rubocop [options] [file1, file2, ...]
  -a, --auto-correct               Auto-correct offenses.
  -x, --fix-layout                 Run only layout cops, with auto-correct on.
```

