### PR TITLE
Add method to delete category

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -80,6 +80,26 @@ module MiqAeMethodService
       end
     end
 
+    def self.category_delete!(category)
+      ar_method do
+        cat = Classification.find_by_name(category)
+        raise "Category <#{category}> does not exist" if cat.nil?
+
+        if cat.entries.any? { |ent| AssignmentMixin.all_assignments(ent.tag.name).present? }
+          raise "This category contains tags which have been assigned. Please delete assignments before deleting the category."
+        end
+
+        cat.destroy!
+      end
+    end
+
+    def self.category_delete(category)
+      category_delete!(category)
+      true
+    rescue StandardError
+      false
+    end
+
     def self.tag_exists?(category, entry)
       ar_method do
         cat = Classification.find_by_name(category)


### PR DESCRIPTION
Both category_delete and category_delete! are added.

Only delete the category if it no longer contains any
tag that has been assigned. This is consistent with
the tag_delete method.

Added formatter for SimpleCov so that html file will be
created after rspec run.

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1744514

@miq-bot add_label enhancement, ivanchuk/no, changelog/yes
@miq-bot assign @tinaafitz  
@miq-bot add_reviewer @tinaafitz
@miq-bot add_reviewer @mkanoor 
@miq-bot add_reviewer @gmcculloug