### PR TITLE
Fix bug of modifying frozen string

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
@@ -95,7 +95,7 @@ module MiqAeEngine
 
     def find_instance_id(instance_name, class_id)
       return nil if instance_name.nil? || class_id.nil?
-      instance_name = ::ActiveRecordQueryParts.glob_to_sql_like(instance_name).downcase
+      instance_name = ::ActiveRecordQueryParts.glob_to_sql_like(instance_name.dup).downcase
       ae_instance_filter = MiqAeInstance.arel_table[:name].lower.matches(instance_name)
       ae_instances = MiqAeInstance.where(ae_instance_filter).where(:class_id => class_id)
       ae_instances.first.try(:id)

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -10,7 +10,7 @@ module MiqAeEngine
     COLLECT_SEPARATOR = ';'.freeze
     METHOD_SEPARATOR  = '.'.freeze
     DEFAULT_INSTANCE  = '.default'.freeze
-    MISSING_INSTANCE  = '.missing'
+    MISSING_INSTANCE  = '.missing'.freeze
     OPAQUE_PASSWORD   = '********'.freeze
     FIELD_ATTRIBUTES  = %w[collect on_entry on_exit on_error max_retries max_time].freeze
     FIELD_VALUES      = %w[value default_value].freeze


### PR DESCRIPTION
When MiqAeObject::MISSING_INSTANCE is passed in as instance_name,
the "glob_to_sql_like" method try to modify this string using
".tr!('*?', '%_')". Therefore, a copy should be passed instead of
the original string.