### PR TITLE
Correct style using rubocop (part 3)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'bundler/setup'
 begin
   require 'rspec/core/rake_task'
 
-  APP_RAKEFILE = File.expand_path("../spec/manageiq/Rakefile", __FILE__)
+  APP_RAKEFILE = File.expand_path('spec/manageiq/Rakefile', __dir__)
   load 'rails/tasks/engine.rake'
   load 'rails/tasks/statistics.rake'
 rescue LoadError

--- a/app/models/miq_ae_browser.rb
+++ b/app/models/miq_ae_browser.rb
@@ -106,7 +106,7 @@ class MiqAeBrowser
   end
 
   def find_base_object(path, options)
-    parts = path.split('/').select { |p| p != "" }
+    parts = path.split('/').reject { |p| p == "" }
     object = find_domain(parts[0], options)
     parts[1..-1].each { |part| object = children(object, options).find { |obj| part.casecmp(obj.ae_object.name).zero? } }
     object

--- a/app/models/miq_ae_datastore.rb
+++ b/app/models/miq_ae_datastore.rb
@@ -213,13 +213,13 @@ module MiqAeDatastore
   def self.seed
     ns = MiqAeDomain.find_by_fqname(MANAGEIQ_DOMAIN)
     unless ns
-      _log.info "Seeding ManageIQ domain..."
+      _log.info("Seeding ManageIQ domain...")
       begin
         reset_to_defaults
       rescue => err
-        _log.error "Seeding... Reset failed, #{err.message}"
+        _log.error("Seeding... Reset failed, #{err.message}")
       else
-        _log.info "Seeding... Complete"
+        _log.info("Seeding... Complete")
       end
     end
     _log.info("Resetting domain priorities at startup...")
@@ -271,4 +271,5 @@ module MiqAeDatastore
     nsd, = ::MiqAeEngine::MiqAePath.split(path, options)
     MiqAeNamespace.find_by_fqname(nsd, false) != nil
   end
-end # module MiqAeDatastore
+end
+# module MiqAeDatastore

--- a/app/models/miq_ae_method_compare.rb
+++ b/app/models/miq_ae_method_compare.rb
@@ -60,8 +60,8 @@ class MiqAeMethodCompare
   end
 
   def add_to_incompatibilities_if_different(method)
-    old_value = @old_method.send(method) if @old_method.respond_to? method
-    new_value = @new_method.send(method) if @new_method.respond_to? method
+    old_value = @old_method.send(method) if @old_method.respond_to?(method)
+    new_value = @new_method.send(method) if @new_method.respond_to?(method)
     return if old_value == new_value
     @incompatibilities << {'attribute' => method, 'old_data' => old_value, 'new_data' => new_value}
   end

--- a/app/models/miq_ae_yaml_export_consolidated.rb
+++ b/app/models/miq_ae_yaml_export_consolidated.rb
@@ -17,7 +17,7 @@ class MiqAeYamlExportConsolidated < MiqAeYamlExport
     path = File.join(base_path, export_hash['output_filename']).split('/')
     path.shift  if base_path[0, 1] == '/'
     data = export_hash['export_data']
-    data = YAML.load(data) if export_hash['output_filename'].ends_with?('.yaml')
+    data = YAML.safe_load(data, [Symbol, Time], [], :aliases => true) if export_hash['output_filename'].ends_with?('.yaml')
     path << data
     @yaml_model.store_path(*path)
   end

--- a/app/models/miq_ae_yaml_import.rb
+++ b/app/models/miq_ae_yaml_import.rb
@@ -321,4 +321,5 @@ class MiqAeYamlImport
   def domain_locked?(domain_name)
     MiqAeDomain.find_by(:name => domain_name)&.contents_locked? ? true : false
   end
-end # class
+end
+# class

--- a/app/models/miq_ae_yaml_import_gitfs.rb
+++ b/app/models/miq_ae_yaml_import_gitfs.rb
@@ -87,7 +87,7 @@ class MiqAeYamlImportGitfs < MiqAeYamlImport
   end
 
   def load_file(file)
-    YAML.load(@gwt.read_file(file))
+    YAML.safe_load(@gwt.read_file(file), [Symbol])
   end
 
   def load_method_ruby(method_file_name)

--- a/app/models/miq_ae_yaml_import_zipfs.rb
+++ b/app/models/miq_ae_yaml_import_zipfs.rb
@@ -94,7 +94,7 @@ class MiqAeYamlImportZipfs < MiqAeYamlImport
   end
 
   def load_file(file)
-    YAML.load(@zip.file.read(file))
+    YAML.safe_load(@zip.file.read(file))
   end
 
   def load_method_ruby(method_file_name)

--- a/bin/rails
+++ b/bin/rails
@@ -2,10 +2,10 @@
 # This command will automatically be run when you run "rails" with Rails gems
 # installed from the root of your application.
 
-ENGINE_ROOT = File.expand_path('../..', __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/manageiq/automation_engine/engine', __FILE__)
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/manageiq/automation_engine/engine', __dir__)
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
 require 'rails/all'

--- a/bin/setup
+++ b/bin/setup
@@ -5,7 +5,7 @@ gem_root = Pathname.new(__dir__).join("..")
 
 unless gem_root.join("spec/manageiq").exist?
   puts "== Cloning manageiq sample app =="
-  system "git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq"
+  system("git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq")
 end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s

--- a/lib/manageiq/automation_engine/syntax_checker.rb
+++ b/lib/manageiq/automation_engine/syntax_checker.rb
@@ -4,8 +4,8 @@ module ManageIQ
   module AutomationEngine
     class SyntaxChecker
       def self.check(ruby)
-        Open3.popen3 "ruby -wc" do |stdin, stdout, stderr|
-          stdin.write ruby
+        Open3.popen3("ruby -wc") do |stdin, stdout, stderr|
+          stdin.write(ruby)
           stdin.close
           output = stdout.read
           errors = stderr.read

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
@@ -23,7 +23,7 @@ module MiqAeEngine
     def load_expression(data)
       raise MiqAeException::MethodExpressionEmpty, "Empty expression" if data.blank?
       begin
-        hash = YAML.load(data)
+        hash = YAML.safe_load(data, [Symbol])
         if hash[:expression] && hash[:db]
           @exp = hash[:expression]
           @exp_object = hash[:db]

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -216,10 +216,10 @@ module MiqAeEngine
           yield stdin if block_given?
           stdin.close
           threads << Thread.new do
-            stdout.each_line { |msg| $miq_ae_logger.info "Method STDOUT: #{msg.strip}" }
+            stdout.each_line { |msg| $miq_ae_logger.info("Method STDOUT: #{msg.strip}") }
           end
           threads << Thread.new do
-            stderr.each_line { |msg| $miq_ae_logger.error "Method STDERR: #{msg.strip}" }
+            stderr.each_line { |msg| $miq_ae_logger.error("Method STDERR: #{msg.strip}") }
           end
           threads.each(&:join)
           wait_thread.value

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -192,11 +192,11 @@ module MiqAeEngine
 
     def attribute_value_to_xml(value, xml)
       case value.class.to_s
-      when 'MiqAePassword'            then xml.Password OPAQUE_PASSWORD
-      when 'String'                   then xml.String   value
-      when 'Fixnum'                   then xml.Fixnum   value
-      when 'Symbol'                   then xml.Symbol   value.to_s
-      when 'TrueClass', 'FalseClass'  then xml.Boolean  value.to_s
+      when 'MiqAePassword'            then xml.Password(OPAQUE_PASSWORD)
+      when 'String'                   then xml.String(  value)
+      when 'Fixnum'                   then xml.Fixnum(  value)
+      when 'Symbol'                   then xml.Symbol(  value.to_s)
+      when 'TrueClass', 'FalseClass'  then xml.Boolean( value.to_s)
       when /MiqAeMethodService::(.*)/ then xml.tag!($1.gsub(/::/, '-'), :object_id => value.object_id, :id => value.id)
       when 'Array'                    then xml.Array  do
         value.each_index do |i|
@@ -209,10 +209,10 @@ module MiqAeEngine
         end
       end
       when 'DRb::DRbUnknown'
-        $miq_ae_logger.error "Found DRbUnknown for value: #{value.inspect} in XML: #{xml.inspect}"
-        xml.String value
+        $miq_ae_logger.error("Found DRbUnknown for value: #{value.inspect} in XML: #{xml.inspect}")
+        xml.String(value)
       else
-        xml.tag!(value.class.to_s.gsub(/::/, '-')) { xml.cdata! value.inspect }
+        xml.tag!(value.class.to_s.gsub(/::/, '-')) { xml.cdata!(value.inspect) }
       end
     end
 
@@ -273,8 +273,8 @@ module MiqAeEngine
         value = args.delete(args_key)
         args["#{key}_id"] = value if attribute_for_vmdb_object?(klass, value) && !@attributes.key?(key)
         args[key] = MiqAeObject.convert_value_based_on_datatype(value, klass)
-      else
-        args[args_key.downcase] = args.delete(args_key) if args_key != args_key.downcase
+      elsif args_key != args_key.downcase
+        args[args_key.downcase] = args.delete(args_key)
       end
     end
 
@@ -637,12 +637,11 @@ module MiqAeEngine
           Benchmark.current_realtime[:relationship_followed_count] += 1
           rels << @workspace.instantiate(r, @workspace.ae_user, self)
         end
-        process_collects(collect, rels)
       else
         Benchmark.current_realtime[:relationship_followed_count] += 1
         rels = @workspace.instantiate(relationship, @workspace.ae_user, self)
-        process_collects(collect, rels)
       end
+      process_collects(collect, rels)
       @rels[name] = rels
       $miq_ae_logger.info("Followed  Relationship [#{relationship}]")
     end
@@ -673,11 +672,11 @@ module MiqAeEngine
 
       parts = k.split(PATH_SEPARATOR)
       left = parts.pop
-      unless parts.empty?
+      if parts.empty?
+        obj = self
+      else
         path = parts.first.blank? ? PATH_SEPARATOR : parts.join(PATH_SEPARATOR)
         obj = @workspace.get_obj_from_path(path)
-      else
-        obj = self
       end
       obj.attributes[left.downcase] = v unless obj.nil?
     end
@@ -760,12 +759,10 @@ module MiqAeEngine
           else
             hash[left]       = self[right]
           end
-        else
-          if ltype == :value
+        elsif ltype == :value
             hash[rels[left]] = rels[right]
-          else
+        else
             hash[left]       = rels[right]
-          end
         end
       end
       process_collect_set_attribute(lh, hash) unless hash.length.zero?
@@ -777,13 +774,13 @@ module MiqAeEngine
       method  = result[3].strip.downcase unless result[3].nil?
       cattr ||= name                     unless rels.nil?  # Set cattr to name ONLY if coming from relationship
 
-      if rels.kind_of?(Array)
-        value = rels.collect { |r| r[name] }
-      elsif rels.nil?
-        value = self[name]
-      else
-        value = rels[name]
-      end
+      value = if rels.kind_of?(Array)
+                rels.collect { |r| r[name] }
+              elsif rels.nil?
+                self[name]
+              else
+                rels[name]
+              end
       process_collect_set_attribute(cattr, value)
     end
 
@@ -791,7 +788,7 @@ module MiqAeEngine
       return [] if rel.blank?
 
       scheme, userinfo, host, port, registry, path, opaque, query, fragment = MiqAeUri.split(rel)
-      return [rel] unless MiqAePath.has_wildcard?(path)
+      return [rel] unless MiqAePath.wildcard?(path)
 
       ns, klass, instance = MiqAePath.split(path)
 
@@ -840,16 +837,16 @@ module MiqAeEngine
     def classify_value(value)
       if value.starts_with?("'")
         raise "Unmatched Single Quoted String <#{e}> in Collect" unless value.ends_with?("'")
-        return value[1..-2]
+        value[1..-2]
       elsif value.starts_with?("\"")
         raise "Unmatched Double Quoted String <#{e}> in Collect" unless value.ends_with?("\"")
-        return value[1..-2]
+        value[1..-2]
       elsif /^[+-]?[0-9]+\s*$/.match(value)
-        return value.to_i
+        value.to_i
       elsif /^[-+]?[0-9]+\.[0-9]+\s*$/.match(value)
-        return value.to_f
+        value.to_f
       else
-        return self[value]
+        self[value]
       end
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_path.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_path.rb
@@ -48,7 +48,7 @@ module MiqAeEngine
       return ns, klass, instance, attribute_name
     end
 
-    def self.has_wildcard?(path)
+    def self.wildcard?(path)
       return false if path.nil?
       path.last == "*"
     end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_info.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_info.rb
@@ -17,7 +17,7 @@ module MiqAeEngine
     end
 
     def load_previous_state_info(yaml)
-      @current_state_info = YAML.load(yaml)
+      @current_state_info = YAML.safe_load(yaml)
     end
   end
 end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
@@ -3,8 +3,9 @@ module MiqAeEngine
 
     STATE_METHOD_REGEX = Regexp.new(/^METHOD::(.*$)/i)
     def state_runnable?(f)
-      return false unless (@workspace.root['ae_state'] == f['name'])
-      return false unless (@workspace.root['ae_result'] == 'ok')
+      return false unless @workspace.root['ae_state'] == f['name']
+      return false unless @workspace.root['ae_result'] == 'ok'
+
       true
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -133,7 +133,7 @@ module MiqAeMethodService
       MiqAeServiceObject.new(obj, self)
     rescue => e
       $miq_ae_logger.error("instantiate failed : #{e.message}")
-      return nil
+      nil
     end
 
     def object(path = nil)
@@ -236,7 +236,7 @@ module MiqAeMethodService
     def create_notification(values_hash = {})
       create_notification!(values_hash)
     rescue
-      return nil
+      nil
     end
 
     def create_notification!(values_hash = {})
@@ -257,12 +257,12 @@ module MiqAeMethodService
     end
 
     def instance_exists?(path)
-      _log.info "<< path=#{path.inspect}"
-      !!(__find_instance_from_path(path))
+      _log.info("<< path=#{path.inspect}")
+      !!__find_instance_from_path(path)
     end
 
     def instance_create(path, values_hash = {})
-      _log.info "<< path=#{path.inspect}, values_hash=#{values_hash.inspect}"
+      _log.info("<< path=#{path.inspect}, values_hash=#{values_hash.inspect}")
 
       return false unless editable_instance?(path)
 
@@ -282,13 +282,13 @@ module MiqAeMethodService
     end
 
     def instance_get_display_name(path)
-      _log.info "<< path=#{path.inspect}"
+      _log.info("<< path=#{path.inspect}")
       aei = __find_instance_from_path(path)
       aei.try(:display_name)
     end
 
     def instance_set_display_name(path, display_name)
-      _log.info "<< path=#{path.inspect}, display_name=#{display_name.inspect}"
+      _log.info("<< path=#{path.inspect}, display_name=#{display_name.inspect}")
       aei = __find_instance_from_path(path)
       return false if aei.nil?
 
@@ -297,7 +297,7 @@ module MiqAeMethodService
     end
 
     def instance_update(path, values_hash)
-      _log.info "<< path=#{path.inspect}, values_hash=#{values_hash.inspect}"
+      _log.info("<< path=#{path.inspect}, values_hash=#{values_hash.inspect}")
       return false unless editable_instance?(path)
 
       aei = __find_instance_from_path(path)
@@ -308,7 +308,7 @@ module MiqAeMethodService
     end
 
     def instance_find(path, options = {})
-      _log.info "<< path=#{path.inspect}"
+      _log.info("<< path=#{path.inspect}")
       result = {}
 
       ns, klass, instance = MiqAeEngine::MiqAePath.split(path)
@@ -333,7 +333,7 @@ module MiqAeMethodService
     end
 
     def instance_get(path)
-      _log.info "<< path=#{path.inspect}"
+      _log.info("<< path=#{path.inspect}")
       aei = __find_instance_from_path(path)
       return nil if aei.nil?
 
@@ -341,7 +341,7 @@ module MiqAeMethodService
     end
 
     def instance_delete(path)
-      _log.info "<< path=#{path.inspect}"
+      _log.info("<< path=#{path.inspect}")
       return false unless editable_instance?(path)
 
       aei = __find_instance_from_path(path)

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -164,7 +164,7 @@ module MiqAeMethodService
     end
 
     def self.drb_undumped(klass)
-      _log.info "Entered: klass=#{klass.name}"
+      _log.info("Entered: klass=#{klass.name}")
       klass.include(DRbUndumped) unless klass.ancestors.include?(DRbUndumped)
     end
     private_class_method :drb_undumped

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -105,22 +105,22 @@ module MiqAeMethodService
 
     def owner=(owner)
       if owner.nil? || owner.kind_of?(MiqAeMethodService::MiqAeServiceUser)
-        if owner.nil?
-          @object.evm_owner = nil
-        else
-          @object.evm_owner = User.find_by(:id => owner.id)
-        end
+        @object.evm_owner = if owner.nil?
+                              nil
+                            else
+                              User.find_by(:id => owner.id)
+                            end
         @object.save
       end
     end
 
     def group=(group)
       if group.nil? || group.kind_of?(MiqAeMethodService::MiqAeServiceMiqGroup)
-        if group.nil?
-          @object.miq_group = nil
-        else
-          @object.miq_group = MiqGroup.find_by(:id => group.id)
-        end
+        @object.miq_group = if group.nil?
+                              nil
+                            else
+                              MiqGroup.find_by(:id => group.id)
+                            end
         @object.save
       end
     end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template.rb
@@ -2,22 +2,22 @@ module MiqAeMethodService
   class MiqAeServiceServiceTemplate < MiqAeServiceModelBase
     def owner=(owner)
       if owner.nil? || owner.kind_of?(MiqAeMethodService::MiqAeServiceUser)
-        if owner.nil?
-          @object.evm_owner = nil
-        else
-          @object.evm_owner = User.find_by(:id => owner.id)
-        end
+        @object.evm_owner = if owner.nil?
+                              nil
+                            else
+                              User.find_by(:id => owner.id)
+                            end
         @object.save
       end
     end
 
     def group=(group)
       if group.nil? || group.kind_of?(MiqAeMethodService::MiqAeServiceMiqGroup)
-        if group.nil?
-          @object.miq_group = nil
-        else
-          @object.miq_group = MiqGroup.find_by(:id => group.id)
-        end
+        @object.miq_group = if group.nil?
+                              nil
+                            else
+                              MiqGroup.find_by(:id => group.id)
+                            end
         @object.save
       end
     end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
@@ -66,7 +66,7 @@ module MiqAeMethodService
     end
 
     def unlink_storage
-      _log.info "Unlinking storage on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}>"
+      _log.info("Unlinking storage on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}>")
       object_send(:update_attributes, :storage_id => nil)
       true
     end
@@ -85,7 +85,7 @@ module MiqAeMethodService
     end
 
     def ems_custom_set(attribute, value)
-      _log.info "Setting EMS Custom Key on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> with key=#{attribute.inspect} to #{value.inspect}"
+      _log.info("Setting EMS Custom Key on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> with key=#{attribute.inspect} to #{value.inspect}")
       sync_or_async_ems_operation(false, "set_custom_field", [attribute, value])
       true
     end
@@ -95,7 +95,7 @@ module MiqAeMethodService
 
       ar_method do
         @object.evm_owner = owner && owner.instance_variable_get("@object")
-        _log.info "Setting EVM Owning User on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{@object.evm_owner.inspect}"
+        _log.info("Setting EVM Owning User on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{@object.evm_owner.inspect}")
         @object.save
       end
     end
@@ -105,7 +105,7 @@ module MiqAeMethodService
 
       ar_method do
         @object.miq_group = group && group.instance_variable_get("@object")
-        _log.info "Setting EVM Owning Group on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{@object.miq_group.inspect}"
+        _log.info("Setting EVM Owning Group on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{@object.miq_group.inspect}")
         @object.save
       end
     end

--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_retirement_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_retirement_mixin.rb
@@ -16,12 +16,12 @@ module MiqAeServiceRetirementMixin
   end
 
   def retires_on=(date)
-    _log.info "Setting Retirement Date on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{date.inspect}"
+    _log.info("Setting Retirement Date on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{date.inspect}")
     ar_method { @object.update_attributes(:retires_on => date) }
   end
 
   def retirement_warn=(days)
-    _log.info "Setting Retirement Warning on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{days.inspect}"
+    _log.info("Setting Retirement Warning on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{days.inspect}")
     ar_method { @object.update_attributes(:retirement_warn => days) }
   end
 end

--- a/manageiq-automation_engine.gemspec
+++ b/manageiq-automation_engine.gemspec
@@ -1,4 +1,4 @@
-$:.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push(File.expand_path('lib', __dir__))
 
 # Maintain your gem's version:
 require "manageiq/automation_engine/version"
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
-  s.add_dependency "rubyzip", "~>1.2.2"
+  s.add_dependency("rubyzip", "~>1.2.2")
 
-  s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
-  s.add_development_dependency "simplecov"
+  s.add_development_dependency("codeclimate-test-reporter", "~> 1.0.0")
+  s.add_development_dependency("simplecov")
 end

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -200,7 +200,7 @@ describe MiqAeEngine do
             :method_name => 'deliver',
             :zone        => MiqServer.my_zone,
             :role        => 'automate',
-            :msg_timeout => 60.minutes,
+            :msg_timeout => 60.minutes
           )
         end
 
@@ -216,7 +216,7 @@ describe MiqAeEngine do
             :method_name => 'deliver',
             :zone        => nil,
             :role        => 'automate',
-            :msg_timeout => 60.minutes,
+            :msg_timeout => 60.minutes
           )
         end
       end

--- a/spec/miq_ae_object_spec.rb
+++ b/spec/miq_ae_object_spec.rb
@@ -69,7 +69,7 @@ describe MiqAeEngine::MiqAeObject do
   end
 
   it "#process_args_as_attributes with a single element array" do
-    result = @miq_obj.process_args_as_attributes({"Array::vms" => "VmOrTemplate::#{@vm.id}"})
+    result = @miq_obj.process_args_as_attributes("Array::vms" => "VmOrTemplate::#{@vm.id}")
     expect(result["vms"]).to be_kind_of(Array)
     expect(result["vms"].length).to eq(1)
   end
@@ -86,7 +86,7 @@ describe MiqAeEngine::MiqAeObject do
 
   it "#process_args_as_attributes with an array" do
     vm2 = FactoryBot.create(:vm_vmware)
-    result = @miq_obj.process_args_as_attributes({"Array::vms" => "VmOrTemplate::#{@vm.id},VmOrTemplate::#{vm2.id}"})
+    result = @miq_obj.process_args_as_attributes("Array::vms" => "VmOrTemplate::#{@vm.id},VmOrTemplate::#{vm2.id}")
     expect(result["vms"]).to be_kind_of(Array)
     expect(result["vms"].length).to eq(2)
   end
@@ -181,7 +181,7 @@ describe MiqAeEngine::MiqAeObject do
     it "should not raise an exception before exceeding max_time" do
       Timecop.freeze(Time.parse('2013-01-01 00:59:59 UTC')) do
         @ws.root['ae_state_started'] = '2013-01-01 00:00:00 UTC'
-        expect { @miq_obj.enforce_state_maxima({'max_time' => '1.hour'}) }.to_not raise_error
+        expect { @miq_obj.enforce_state_maxima('max_time' => '1.hour') }.to_not raise_error
       end
     end
 

--- a/spec/miq_ae_provision_spec.rb
+++ b/spec/miq_ae_provision_spec.rb
@@ -140,17 +140,17 @@ describe "MiqAeProvision" do
       networks = ws.root['networks']
       expect(networks).not_to be_nil
       expect(networks).to be_a_kind_of(Array)
-      networks.each { |network|
+      networks.each do |network|
         expect(network).to be_a_kind_of(Hash)
         [:scope, :vlan, :vc_id, :dhcp_servers].each { |key| expect(network).to have_key(key) }
         expect(network[:dhcp_servers]).to be_a_kind_of(Array)
-        network[:dhcp_servers].each { |dhcp|
+        network[:dhcp_servers].each do |dhcp|
           expect(dhcp).to be_a_kind_of(Hash)
           [:domain, :ip, :name].each { |key| expect(dhcp).to have_key(key) }
           expect(dhcp[:domain]).to be_a_kind_of(Hash)
           [:base_dn, :bind_dn, :bind_password, :ldap_host, :ldap_port, :user_type, :name].each { |key| expect(dhcp[:domain]).to have_key(key) }
-        }
-      }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Cops used:
Naming/PredicateName

Security/YAMLLoad

Style/BlockDelimiters
Style/BracesAroundHashParameters
Style/CommentedKeyword
Style/ConditionalAssignment
Style/ExpandPathArgument
Style/IdenticalConditionalBranches
Style/IfInsideElse
Style/InverseMethods
Style/MethodCallWithArgsParentheses
Style/ParenthesesAroundCondition
Style/RedundantParentheses
Style/SpecialGlobalVars
Style/TrailingCommaInArguments
Style/UnlessElse
Style/RedundantReturn

@miq-bot add_label ivanchuk/no, refactoring