### PR TITLE
Correct style using rubocop (part 3)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'bundler/setup'
 begin
   require 'rspec/core/rake_task'
 
-  APP_RAKEFILE = File.expand_path("../spec/manageiq/Rakefile", __FILE__)
+  APP_RAKEFILE = File.expand_path('spec/manageiq/Rakefile', __dir__)
   load 'rails/tasks/engine.rake'
   load 'rails/tasks/statistics.rake'
 rescue LoadError

--- a/app/models/miq_ae_browser.rb
+++ b/app/models/miq_ae_browser.rb
@@ -106,7 +106,7 @@ class MiqAeBrowser
   end
 
   def find_base_object(path, options)
-    parts = path.split('/').select { |p| p != "" }
+    parts = path.split('/').reject { |p| p == "" }
     object = find_domain(parts[0], options)
     parts[1..-1].each { |part| object = children(object, options).find { |obj| part.casecmp(obj.ae_object.name).zero? } }
     object

--- a/app/models/miq_ae_datastore.rb
+++ b/app/models/miq_ae_datastore.rb
@@ -213,13 +213,13 @@ module MiqAeDatastore
   def self.seed
     ns = MiqAeDomain.find_by_fqname(MANAGEIQ_DOMAIN)
     unless ns
-      _log.info "Seeding ManageIQ domain..."
+      _log.info("Seeding ManageIQ domain...")
       begin
         reset_to_defaults
       rescue => err
-        _log.error "Seeding... Reset failed, #{err.message}"
+        _log.error("Seeding... Reset failed, #{err.message}")
       else
-        _log.info "Seeding... Complete"
+        _log.info("Seeding... Complete")
       end
     end
     _log.info("Resetting domain priorities at startup...")
@@ -271,4 +271,4 @@ module MiqAeDatastore
     nsd, = ::MiqAeEngine::MiqAePath.split(path, options)
     MiqAeNamespace.find_by_fqname(nsd, false) != nil
   end
-end # module MiqAeDatastore
+end

--- a/app/models/miq_ae_method_compare.rb
+++ b/app/models/miq_ae_method_compare.rb
@@ -60,8 +60,8 @@ class MiqAeMethodCompare
   end
 
   def add_to_incompatibilities_if_different(method)
-    old_value = @old_method.send(method) if @old_method.respond_to? method
-    new_value = @new_method.send(method) if @new_method.respond_to? method
+    old_value = @old_method.send(method) if @old_method.respond_to?(method)
+    new_value = @new_method.send(method) if @new_method.respond_to?(method)
     return if old_value == new_value
     @incompatibilities << {'attribute' => method, 'old_data' => old_value, 'new_data' => new_value}
   end

--- a/app/models/miq_ae_yaml_import.rb
+++ b/app/models/miq_ae_yaml_import.rb
@@ -321,4 +321,4 @@ class MiqAeYamlImport
   def domain_locked?(domain_name)
     MiqAeDomain.find_by(:name => domain_name)&.contents_locked? ? true : false
   end
-end # class
+end

--- a/bin/rails
+++ b/bin/rails
@@ -2,10 +2,10 @@
 # This command will automatically be run when you run "rails" with Rails gems
 # installed from the root of your application.
 
-ENGINE_ROOT = File.expand_path('../..', __FILE__)
-ENGINE_PATH = File.expand_path('../../lib/manageiq/automation_engine/engine', __FILE__)
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/manageiq/automation_engine/engine', __dir__)
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
 
 require 'rails/all'

--- a/bin/setup
+++ b/bin/setup
@@ -5,7 +5,7 @@ gem_root = Pathname.new(__dir__).join("..")
 
 unless gem_root.join("spec/manageiq").exist?
   puts "== Cloning manageiq sample app =="
-  system "git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq"
+  system("git clone https://github.com/ManageIQ/manageiq.git --branch master --depth 1 spec/manageiq")
 end
 
 require gem_root.join("spec/manageiq/lib/manageiq/environment").to_s

--- a/lib/manageiq/automation_engine/syntax_checker.rb
+++ b/lib/manageiq/automation_engine/syntax_checker.rb
@@ -4,8 +4,8 @@ module ManageIQ
   module AutomationEngine
     class SyntaxChecker
       def self.check(ruby)
-        Open3.popen3 "ruby -wc" do |stdin, stdout, stderr|
-          stdin.write ruby
+        Open3.popen3("ruby -wc") do |stdin, stdout, stderr|
+          stdin.write(ruby)
           stdin.close
           output = stdout.read
           errors = stderr.read

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -216,10 +216,10 @@ module MiqAeEngine
           yield stdin if block_given?
           stdin.close
           threads << Thread.new do
-            stdout.each_line { |msg| $miq_ae_logger.info "Method STDOUT: #{msg.strip}" }
+            stdout.each_line { |msg| $miq_ae_logger.info("Method STDOUT: #{msg.strip}") }
           end
           threads << Thread.new do
-            stderr.each_line { |msg| $miq_ae_logger.error "Method STDERR: #{msg.strip}" }
+            stderr.each_line { |msg| $miq_ae_logger.error("Method STDERR: #{msg.strip}") }
           end
           threads.each(&:join)
           wait_thread.value

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_path.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_path.rb
@@ -48,7 +48,7 @@ module MiqAeEngine
       return ns, klass, instance, attribute_name
     end
 
-    def self.has_wildcard?(path)
+    def self.wildcard?(path)
       return false if path.nil?
       path.last == "*"
     end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_state_machine.rb
@@ -3,8 +3,9 @@ module MiqAeEngine
 
     STATE_METHOD_REGEX = Regexp.new(/^METHOD::(.*$)/i)
     def state_runnable?(f)
-      return false unless (@workspace.root['ae_state'] == f['name'])
-      return false unless (@workspace.root['ae_result'] == 'ok')
+      return false unless @workspace.root['ae_state'] == f['name']
+      return false unless @workspace.root['ae_result'] == 'ok'
+
       true
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -131,7 +131,7 @@ module MiqAeEngine
         if scheme == "miqaedb"
           obj = MiqAeObject.new(self, ns, klass, instance)
 
-          @current.push({:ns => ns, :klass => klass, :instance => instance, :object => obj, :message => message})
+          @current.push(:ns => ns, :klass => klass, :instance => instance, :object => obj, :message => message)
           pushed = true
           @nodes << obj
           link_parent_child(root, obj) if root
@@ -202,7 +202,7 @@ module MiqAeEngine
       objs = path.nil? ? roots : get_obj_from_path(path)
       result = objs.collect { |obj| to_hash(obj) }.compact
       s = ""
-      XmlHash.from_hash({"MiqAeObject" => result}, :rootname => "MiqAeWorkspace").to_xml.write(s, 2)
+      XmlHash.from_hash({"MiqAeObject" => result}, {:rootname => "MiqAeWorkspace"}).to_xml.write(s, 2)
       s
     end
 
@@ -320,7 +320,8 @@ module MiqAeEngine
         until plist.empty?
           part = plist.shift
           next if part.blank? || part == "."
-          raise MiqAeException::InvalidPathFormat, "bad part [#{part}] in path [#{path}]" if (part != "..")
+          raise MiqAeException::InvalidPathFormat, "bad part [#{part}] in path [#{path}]" if part != ".."
+
           obj = obj.node_parent
         end
       else

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -133,7 +133,7 @@ module MiqAeMethodService
       MiqAeServiceObject.new(obj, self)
     rescue => e
       $miq_ae_logger.error("instantiate failed : #{e.message}")
-      return nil
+      nil
     end
 
     def object(path = nil)
@@ -236,7 +236,7 @@ module MiqAeMethodService
     def create_notification(values_hash = {})
       create_notification!(values_hash)
     rescue
-      return nil
+      nil
     end
 
     def create_notification!(values_hash = {})
@@ -257,12 +257,12 @@ module MiqAeMethodService
     end
 
     def instance_exists?(path)
-      _log.info "<< path=#{path.inspect}"
-      !!(__find_instance_from_path(path))
+      _log.info("<< path=#{path.inspect}")
+      !!__find_instance_from_path(path)
     end
 
     def instance_create(path, values_hash = {})
-      _log.info "<< path=#{path.inspect}, values_hash=#{values_hash.inspect}"
+      _log.info("<< path=#{path.inspect}, values_hash=#{values_hash.inspect}")
 
       return false unless editable_instance?(path)
 
@@ -282,13 +282,13 @@ module MiqAeMethodService
     end
 
     def instance_get_display_name(path)
-      _log.info "<< path=#{path.inspect}"
+      _log.info("<< path=#{path.inspect}")
       aei = __find_instance_from_path(path)
       aei.try(:display_name)
     end
 
     def instance_set_display_name(path, display_name)
-      _log.info "<< path=#{path.inspect}, display_name=#{display_name.inspect}"
+      _log.info("<< path=#{path.inspect}, display_name=#{display_name.inspect}")
       aei = __find_instance_from_path(path)
       return false if aei.nil?
 
@@ -297,7 +297,7 @@ module MiqAeMethodService
     end
 
     def instance_update(path, values_hash)
-      _log.info "<< path=#{path.inspect}, values_hash=#{values_hash.inspect}"
+      _log.info("<< path=#{path.inspect}, values_hash=#{values_hash.inspect}")
       return false unless editable_instance?(path)
 
       aei = __find_instance_from_path(path)
@@ -308,7 +308,7 @@ module MiqAeMethodService
     end
 
     def instance_find(path, options = {})
-      _log.info "<< path=#{path.inspect}"
+      _log.info("<< path=#{path.inspect}")
       result = {}
 
       ns, klass, instance = MiqAeEngine::MiqAePath.split(path)
@@ -333,7 +333,7 @@ module MiqAeMethodService
     end
 
     def instance_get(path)
-      _log.info "<< path=#{path.inspect}"
+      _log.info("<< path=#{path.inspect}")
       aei = __find_instance_from_path(path)
       return nil if aei.nil?
 
@@ -341,7 +341,7 @@ module MiqAeMethodService
     end
 
     def instance_delete(path)
-      _log.info "<< path=#{path.inspect}"
+      _log.info("<< path=#{path.inspect}")
       return false unless editable_instance?(path)
 
       aei = __find_instance_from_path(path)

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -164,7 +164,7 @@ module MiqAeMethodService
     end
 
     def self.drb_undumped(klass)
-      _log.info "Entered: klass=#{klass.name}"
+      _log.info("Entered: klass=#{klass.name}")
       klass.include(DRbUndumped) unless klass.ancestors.include?(DRbUndumped)
     end
     private_class_method :drb_undumped

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -105,22 +105,22 @@ module MiqAeMethodService
 
     def owner=(owner)
       if owner.nil? || owner.kind_of?(MiqAeMethodService::MiqAeServiceUser)
-        if owner.nil?
-          @object.evm_owner = nil
-        else
-          @object.evm_owner = User.find_by(:id => owner.id)
-        end
+        @object.evm_owner = if owner.nil?
+                              nil
+                            else
+                              User.find_by(:id => owner.id)
+                            end
         @object.save
       end
     end
 
     def group=(group)
       if group.nil? || group.kind_of?(MiqAeMethodService::MiqAeServiceMiqGroup)
-        if group.nil?
-          @object.miq_group = nil
-        else
-          @object.miq_group = MiqGroup.find_by(:id => group.id)
-        end
+        @object.miq_group = if group.nil?
+                              nil
+                            else
+                              MiqGroup.find_by(:id => group.id)
+                            end
         @object.save
       end
     end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template.rb
@@ -2,22 +2,22 @@ module MiqAeMethodService
   class MiqAeServiceServiceTemplate < MiqAeServiceModelBase
     def owner=(owner)
       if owner.nil? || owner.kind_of?(MiqAeMethodService::MiqAeServiceUser)
-        if owner.nil?
-          @object.evm_owner = nil
-        else
-          @object.evm_owner = User.find_by(:id => owner.id)
-        end
+        @object.evm_owner = if owner.nil?
+                              nil
+                            else
+                              User.find_by(:id => owner.id)
+                            end
         @object.save
       end
     end
 
     def group=(group)
       if group.nil? || group.kind_of?(MiqAeMethodService::MiqAeServiceMiqGroup)
-        if group.nil?
-          @object.miq_group = nil
-        else
-          @object.miq_group = MiqGroup.find_by(:id => group.id)
-        end
+        @object.miq_group = if group.nil?
+                              nil
+                            else
+                              MiqGroup.find_by(:id => group.id)
+                            end
         @object.save
       end
     end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
@@ -66,7 +66,7 @@ module MiqAeMethodService
     end
 
     def unlink_storage
-      _log.info "Unlinking storage on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}>"
+      _log.info("Unlinking storage on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}>")
       object_send(:update, :storage_id => nil)
       true
     end
@@ -85,7 +85,7 @@ module MiqAeMethodService
     end
 
     def ems_custom_set(attribute, value)
-      _log.info "Setting EMS Custom Key on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> with key=#{attribute.inspect} to #{value.inspect}"
+      _log.info("Setting EMS Custom Key on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> with key=#{attribute.inspect} to #{value.inspect}")
       sync_or_async_ems_operation(false, "set_custom_field", [attribute, value])
       true
     end
@@ -95,7 +95,7 @@ module MiqAeMethodService
 
       ar_method do
         @object.evm_owner = owner && owner.instance_variable_get("@object")
-        _log.info "Setting EVM Owning User on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{@object.evm_owner.inspect}"
+        _log.info("Setting EVM Owning User on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{@object.evm_owner.inspect}")
         @object.save
       end
     end
@@ -105,7 +105,7 @@ module MiqAeMethodService
 
       ar_method do
         @object.miq_group = group && group.instance_variable_get("@object")
-        _log.info "Setting EVM Owning Group on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{@object.miq_group.inspect}"
+        _log.info("Setting EVM Owning Group on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{@object.miq_group.inspect}")
         @object.save
       end
     end

--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_retirement_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_retirement_mixin.rb
@@ -16,12 +16,12 @@ module MiqAeServiceRetirementMixin
   end
 
   def retires_on=(date)
-    _log.info "Setting Retirement Date on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{date.inspect}"
+    _log.info("Setting Retirement Date on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{date.inspect}")
     ar_method { @object.update(:retires_on => date) }
   end
 
   def retirement_warn=(days)
-    _log.info "Setting Retirement Warning on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{days.inspect}"
+    _log.info("Setting Retirement Warning on #{@object.class.name} id:<#{@object.id}>, name:<#{@object.name}> to #{days.inspect}")
     ar_method { @object.update(:retirement_warn => days) }
   end
 end

--- a/manageiq-automation_engine.gemspec
+++ b/manageiq-automation_engine.gemspec
@@ -1,4 +1,4 @@
-$:.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push(File.expand_path('lib', __dir__))
 
 # Maintain your gem's version:
 require "manageiq/automation_engine/version"

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -200,7 +200,7 @@ describe MiqAeEngine do
             :method_name => 'deliver',
             :zone        => MiqServer.my_zone,
             :role        => 'automate',
-            :msg_timeout => 60.minutes,
+            :msg_timeout => 60.minutes
           )
         end
 
@@ -216,7 +216,7 @@ describe MiqAeEngine do
             :method_name => 'deliver',
             :zone        => nil,
             :role        => 'automate',
-            :msg_timeout => 60.minutes,
+            :msg_timeout => 60.minutes
           )
         end
       end

--- a/spec/miq_ae_object_spec.rb
+++ b/spec/miq_ae_object_spec.rb
@@ -69,7 +69,7 @@ describe MiqAeEngine::MiqAeObject do
   end
 
   it "#process_args_as_attributes with a single element array" do
-    result = @miq_obj.process_args_as_attributes({"Array::vms" => "VmOrTemplate::#{@vm.id}"})
+    result = @miq_obj.process_args_as_attributes("Array::vms" => "VmOrTemplate::#{@vm.id}")
     expect(result["vms"]).to be_kind_of(Array)
     expect(result["vms"].length).to eq(1)
   end
@@ -86,7 +86,7 @@ describe MiqAeEngine::MiqAeObject do
 
   it "#process_args_as_attributes with an array" do
     vm2 = FactoryBot.create(:vm_vmware)
-    result = @miq_obj.process_args_as_attributes({"Array::vms" => "VmOrTemplate::#{@vm.id},VmOrTemplate::#{vm2.id}"})
+    result = @miq_obj.process_args_as_attributes("Array::vms" => "VmOrTemplate::#{@vm.id},VmOrTemplate::#{vm2.id}")
     expect(result["vms"]).to be_kind_of(Array)
     expect(result["vms"].length).to eq(2)
   end
@@ -181,7 +181,7 @@ describe MiqAeEngine::MiqAeObject do
     it "should not raise an exception before exceeding max_time" do
       Timecop.freeze(Time.parse('2013-01-01 00:59:59 UTC')) do
         @ws.root['ae_state_started'] = '2013-01-01 00:00:00 UTC'
-        expect { @miq_obj.enforce_state_maxima({'max_time' => '1.hour'}) }.to_not raise_error
+        expect { @miq_obj.enforce_state_maxima('max_time' => '1.hour') }.to_not raise_error
       end
     end
 

--- a/spec/miq_ae_provision_spec.rb
+++ b/spec/miq_ae_provision_spec.rb
@@ -140,17 +140,17 @@ describe "MiqAeProvision" do
       networks = ws.root['networks']
       expect(networks).not_to be_nil
       expect(networks).to be_a_kind_of(Array)
-      networks.each { |network|
+      networks.each do |network|
         expect(network).to be_a_kind_of(Hash)
         [:scope, :vlan, :vc_id, :dhcp_servers].each { |key| expect(network).to have_key(key) }
         expect(network[:dhcp_servers]).to be_a_kind_of(Array)
-        network[:dhcp_servers].each { |dhcp|
+        network[:dhcp_servers].each do |dhcp|
           expect(dhcp).to be_a_kind_of(Hash)
           [:domain, :ip, :name].each { |key| expect(dhcp).to have_key(key) }
           expect(dhcp[:domain]).to be_a_kind_of(Hash)
           [:base_dn, :bind_dn, :bind_password, :ldap_host, :ldap_port, :user_type, :name].each { |key| expect(dhcp[:domain]).to have_key(key) }
-        }
-      }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Cops used:
Naming/PredicateName

Style/BlockDelimiters
Style/BracesAroundHashParameters
Style/CommentedKeyword
Style/ConditionalAssignment
Style/ExpandPathArgument
Style/IdenticalConditionalBranches
Style/IfInsideElse
Style/InverseMethods
Style/MethodCallWithArgsParentheses
Style/ParenthesesAroundCondition
Style/RedundantParentheses
Style/SpecialGlobalVars
Style/TrailingCommaInArguments
Style/UnlessElse
Style/RedundantReturn

@miq-bot add_label ivanchuk/no, refactoring