### PR TITLE
Correct style using rubocop (part 4)

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -3,3 +3,13 @@ GlobalVars:
   - $evm
   - $log
   - $miq_ae_logger
+
+Naming/FileName:
+  Exclude:
+  - 'spec/service_models/*.rb'
+  - 'lib/miq_automation_engine/service_models/*.rb'
+  - 'lib/manageiq-automation_engine.rb'
+
+Naming/ClassAndModuleCamelCase:
+  Exclude:
+  - 'lib/miq_automation_engine/service_models/*.rb'

--- a/app/models/miq_ae_datastore.rb
+++ b/app/models/miq_ae_datastore.rb
@@ -125,7 +125,7 @@ module MiqAeDatastore
 
   def self.reset_default_namespace
     ns = MiqAeNamespace.lookup_by_fqname(DEFAULT_OBJECT_NAMESPACE)
-    ns.destroy if ns
+    ns&.destroy
     seed_default_namespace
   end
 
@@ -136,8 +136,10 @@ module MiqAeDatastore
     import_yaml_dir(datastore_dir, domain_name, tenant)
     if domain_name.downcase == MANAGEIQ_DOMAIN.downcase
       ns = MiqAeDomain.lookup_by_fqname(MANAGEIQ_DOMAIN)
-      ns.update!(:source   => MiqAeDomain::SYSTEM_SOURCE, :enabled => true,
-                            :priority => MANAGEIQ_PRIORITY) if ns
+      if ns
+        ns.update!(:source => MiqAeDomain::SYSTEM_SOURCE, :enabled => true,
+                              :priority => MANAGEIQ_PRIORITY)
+      end
     end
   end
 
@@ -216,7 +218,7 @@ module MiqAeDatastore
       _log.info("Seeding ManageIQ domain...")
       begin
         reset_to_defaults
-      rescue => err
+      rescue StandardError => err
         _log.error("Seeding... Reset failed, #{err.message}")
       else
         _log.info("Seeding... Complete")

--- a/app/models/miq_ae_datastore/xml_import.rb
+++ b/app/models/miq_ae_datastore/xml_import.rb
@@ -34,7 +34,7 @@ module MiqAeDatastore
     def self.process_method(input)
       fields             = input.delete("MiqAeField")
       input["data"]      = input.delete("content")
-      input["data"].strip! unless input["data"].nil?
+      input["data"]&.strip!
       aem                = MiqAeMethod.new(input)
 
       # Find or Create the Method Input Definitions
@@ -89,7 +89,7 @@ module MiqAeDatastore
       input.delete("content")
       aei = MiqAeInstance.new(input)
       aei.ae_class = aec
-      fields.each { |f| process_field_value(aei, f) } unless fields.nil?
+      fields&.each { |f| process_field_value(aei, f) }
       aei
     end
 
@@ -134,18 +134,19 @@ module MiqAeDatastore
         create_domain(domain_name) if domain_name
         ae_namespaces = {}
         Benchmark.realtime_block(:datastore_import_time) do
-          classes.each do |c|
+          classes&.each do |c|
             namespace = c.delete("namespace")
             next if namespace == '$'
+
             namespace = File.join(domain_name, namespace) if domain_name && namespace != "$"
             ae_namespaces[namespace] ||= Benchmark.realtime_block(:build_namespaces) do
               MiqAeNamespace.find_or_create_by_fqname(namespace)
             end.first
             c["ae_namespace"] = ae_namespaces[namespace]
             process_class(c)
-          end unless classes.nil?
+          end
 
-          buttons.each { |b| process_button(b) } unless buttons.nil?
+          buttons&.each { |b| process_button(b) }
         end
       end
 

--- a/app/models/miq_ae_datastore/xml_yaml_converter.rb
+++ b/app/models/miq_ae_datastore/xml_yaml_converter.rb
@@ -9,7 +9,7 @@ module MiqAeDatastore
       MiqAeExport.new(temp_domain, export_options).export
     ensure
       ns = MiqAeDomain.lookup_by_fqname(temp_domain)
-      ns.destroy if ns
+      ns&.destroy
     end
   end
 end

--- a/app/models/miq_ae_yaml_export_zipfs.rb
+++ b/app/models/miq_ae_yaml_export_zipfs.rb
@@ -26,7 +26,7 @@ class MiqAeYamlExportZipfs < MiqAeYamlExport
     Zip::File.open(@temp_file_name, Zip::File::CREATE) do |zf|
       @zip_file = zf
       write_model
-      @zip_file.close unless @zip_file.nil?
+      @zip_file&.close
       FileUtils.mv(@temp_file_name, @options['zip_file'])
     end
   ensure

--- a/app/models/miq_ae_yaml_import_gitfs.rb
+++ b/app/models/miq_ae_yaml_import_gitfs.rb
@@ -38,7 +38,7 @@ class MiqAeYamlImportGitfs < MiqAeYamlImport
   end
 
   def domain_files(domain)
-    glob_str = if domain == '*' || domain == '.'
+    glob_str = if ['*', '.'].include?(domain)
                  File.join('**', DOMAIN_YAML_FILENAME)
                else
                  File.join('**', domain, DOMAIN_YAML_FILENAME)

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -90,16 +90,17 @@ module MiqAeEngine
       result = {}
       ems.hosts.each do |h|
         next unless h.power_state == "on"
+
         nvms = h.vms.collect { |v| v if v.power_state == "on" }.compact.length
-        if min_running_vms.nil? || nvms < min_running_vms
-          storages = h.writable_storages.find_all { |s| s.free_space > vm.provisioned_storage } # Filter out storages that do not have enough free space for the Vm
-          s = storages.max_by(&:free_space)
-          unless s.nil?
-            result["host"]    = h
-            result["storage"] = s
-            min_running_vms   = nvms
-          end
-        end
+        next unless min_running_vms.nil? || nvms < min_running_vms
+
+        storages = h.writable_storages.find_all { |s| s.free_space > vm.provisioned_storage } # Filter out storages that do not have enough free space for the Vm
+        s = storages.max_by(&:free_space)
+        next if s.nil?
+
+        result["host"]    = h
+        result["storage"] = s
+        min_running_vms   = nvms
       end
 
       ["host", "storage"].each { |k| obj[k] = result[k] } unless result.empty?

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
@@ -30,7 +30,7 @@ module MiqAeEngine
         else
           raise MiqAeException::MethodExpressionInvalid, "Invalid expression #{data}"
         end
-      rescue
+      rescue StandardError
         raise MiqAeException::MethodExpressionInvalid, "Invalid expression #{data}"
       end
     end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -55,7 +55,7 @@ module MiqAeEngine
 
       begin
         return MiqAeBuiltinMethod.send(mname, obj, inputs)
-      rescue => err
+      rescue StandardError => err
         raise MiqAeException::AbortInstantiation, err.message
       ensure
         # Destroy service to avoid storing object references
@@ -110,7 +110,7 @@ module MiqAeEngine
       rc, msg = run_method(*cmd)
       if ws
         ws.reload
-        ws.setters.each { |uri, value| workspace.varset(uri, value) } unless ws.setters.nil?
+        ws.setters&.each { |uri, value| workspace.varset(uri, value) }
         ws.delete
       end
       process_ruby_method_results(rc, msg)
@@ -228,8 +228,8 @@ module MiqAeEngine
         msg = "Method exited with rc=#{verbose_rc(rc)}"
         method_pid = nil
         threads = []
-      rescue => err
-        STDERR.puts "** AUTOMATE ** Method exec failed because #{err.class}:#{err.message}" if ENV.key?("CI")
+      rescue StandardError => err
+        STDERR.puts "** AUTOMATE ** Method exec failed because #{err.class}:#{err.message}" if ENV.key?("CI") # rubocop:disable Style/StderrPuts
         $miq_ae_logger.error("Method exec failed because (#{err.class}:#{err.message})")
         rc = MIQ_ABORT
         msg = "Method execution failed"

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_path.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_path.rb
@@ -44,7 +44,7 @@ module MiqAeEngine
       instance       = options[:has_instance_name] ? parts.pop : nil
       klass          = parts.pop
       ns             = parts.join('/')
-      [ns, klass, instance, attribute_name].each { |k| k.downcase! unless k.nil? } if options[:downcase]
+      [ns, klass, instance, attribute_name].each { |k| k&.downcase! } if options[:downcase]
       return ns, klass, instance, attribute_name
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_playbook_method.rb
@@ -14,7 +14,7 @@ module MiqAeEngine
         playbook = PLAYBOOK_CLASS.find(playbook_options[:playbook_id])
         $miq_ae_logger.info("Calling playbook.run with playbook: #{playbook.inspect}")
         task_id = playbook.run(playbook_options)
-      rescue => err
+      rescue StandardError => err
         $miq_ae_logger.error("Playbook Method Ended with error #{err.message}")
         reset
         raise MiqAeException::AbortInstantiation, err.message

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_reference.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_reference.rb
@@ -5,9 +5,9 @@ module MiqAeEngine
         value.map { |v| encode(v) }
       elsif value.kind_of?(Hash)
         value.each_with_object({}) { |(k, v), hash| hash[k] = encode(v) }
-      elsif /MiqAeMethodService::/ =~ value.class.to_s
+      elsif /MiqAeMethodService::/.match?(value.class.to_s)
         "href_slug::#{value.href_slug}"
-      elsif /MiqAePassword/ =~ value.class.to_s
+      elsif /MiqAePassword/.match?(value.class.to_s)
         "password::#{value.encStr}"
       else
         value

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_uri.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_uri.rb
@@ -15,12 +15,10 @@ module MiqAeEngine
 
     def self.query2hash(query)
       hash = {}
-      unless query.nil?
-        query.split('&').each do|a|
+      query&.split('&')&.each do |a|
           k, v = a.split('=')
           hash[URI.unescape(k)] = URI.unescape(v.to_s)
         end
-      end
       hash
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -179,9 +179,9 @@ module MiqAeEngine
     def pop_state_machine_info
       last_state_machine = @state_machine_objects.pop
       case root['ae_result']
-      when 'ok' then
+      when 'ok'
         @current_state_info.delete(last_state_machine)
-      when 'retry' then
+      when 'retry'
         save_current_state_info(last_state_machine)
       end
       reset_state_info(@state_machine_objects.last) unless @state_machine_objects.empty?
@@ -246,7 +246,13 @@ module MiqAeEngine
       # check for cyclical references
       @current.each do |c|
         hash = {:ns => ns, :klass => klass, :instance => instance, :message => message}
-        return true if hash.all? { |key, value| value.casecmp(c[key]).zero? rescue false }
+        return true if hash.all? do |key, value|
+                         begin
+                           value.casecmp(c[key]).zero?
+                         rescue StandardError
+                           false
+                         end
+                       end
       end
       false
     end

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -131,7 +131,7 @@ module MiqAeMethodService
       obj = @workspace.instantiate(uri, @workspace.ae_user, @workspace.current_object)
       return nil if obj.nil?
       MiqAeServiceObject.new(obj, self)
-    rescue => e
+    rescue StandardError => e
       $miq_ae_logger.error("instantiate failed : #{e.message}")
       nil
     end
@@ -235,7 +235,7 @@ module MiqAeMethodService
 
     def create_notification(values_hash = {})
       create_notification!(values_hash)
-    rescue
+    rescue StandardError
       nil
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -171,12 +171,16 @@ module MiqAeMethodService
 
     def self.ar_method
       yield
-    rescue Exception => err
+    rescue Exception => err # rubocop:disable Lint/RescueException
       $miq_ae_logger.error("MiqAeServiceMethods.ar_method raised: <#{err.class}>: <#{err.message}>")
       $miq_ae_logger.error(err.backtrace.join("\n"))
       raise
     ensure
-      ActiveRecord::Base.connection_pool.release_connection rescue nil
+      begin
+        ActiveRecord::Base.connection_pool.release_connection
+      rescue StandardError
+        nil
+      end
     end
     private_class_method :ar_method
   end

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_rbac.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_rbac.rb
@@ -40,7 +40,7 @@ module MiqAeMethodService
       end
 
       def rbac_enabled?
-        workspace && workspace.rbac_enabled?
+        workspace&.rbac_enabled?
       end
     end
   end

--- a/spec/data/provision/SPEC_DOMAIN/EVMApplications/Provisioning/WHERE.class/__methods__/least_utilized.rb
+++ b/spec/data/provision/SPEC_DOMAIN/EVMApplications/Provisioning/WHERE.class/__methods__/least_utilized.rb
@@ -11,22 +11,23 @@ begin
   min_registered_vms = nil
   ems.hosts.each do |h|
     next unless h.power_state == "on"
+
     nvms = h.vms.length
-    if min_registered_vms.nil? || nvms < min_registered_vms
-      s = h.storages.max_by(&:free_space)
-      unless s.nil?
-        host    = h
-        storage = s
-        min_registered_vms = nvms
-      end
-    end
+    next unless min_registered_vms.nil? || nvms < min_registered_vms
+
+    s = h.storages.max_by(&:free_space)
+    next if s.nil?
+
+    host    = h
+    storage = s
+    min_registered_vms = nvms
   end
 
   obj = $evm.object
   obj["host"]    = host    unless host.nil?
   obj["storage"] = storage unless storage.nil?
   exit MIQ_OK
-rescue => err
+rescue StandardError => err
   $evm.log("error", err.message)
   $evm.log("error", err.backtrace.join("\n"))
 end

--- a/spec/miq_ae_object_spec.rb
+++ b/spec/miq_ae_object_spec.rb
@@ -322,4 +322,11 @@ describe MiqAeEngine::MiqAeObject do
       %w[Integer integer Fixnum].each { |type| expect(described_class.convert_value_based_on_datatype("45", type)).to eq(45) }
     end
   end
+
+  context "data type is nil" do
+    it "returns original value" do
+      test_value = "test_value"
+      expect(described_class.convert_value_based_on_datatype(test_value, nil)).to eq(test_value)
+    end
+  end
 end

--- a/spec/models/miq_ae_method_compare_spec.rb
+++ b/spec/models/miq_ae_method_compare_spec.rb
@@ -79,10 +79,14 @@ describe MiqAeMethodCompare do
   def prep_method_file_names(meth1 = nil, meth2 = nil)
     @first_method = meth1 if meth1
     @second_method = meth2 if meth2
-    @method1_file = File.join(@export_dir, @domain, @namespace,
-                              "#{@classname}.class", '__methods__', "#{meth1}.yaml") if meth1
-    @method2_file = File.join(@export_dir, @domain, @namespace,
-                              "#{@classname}.class", '__methods__', "#{meth2}.yaml") if meth2
+    if meth1
+      @method1_file = File.join(@export_dir, @domain, @namespace,
+                                "#{@classname}.class", '__methods__', "#{meth1}.yaml")
+    end
+    if meth2
+      @method2_file = File.join(@export_dir, @domain, @namespace,
+                                "#{@classname}.class", '__methods__', "#{meth2}.yaml")
+    end
     @ns1 = MiqAeNamespace.lookup_by_fqname("#{@domain}/#{@namespace}")
     @class = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @classname)
   end

--- a/spec/service_models/miq_ae_service_service_spec.rb
+++ b/spec/service_models/miq_ae_service_service_spec.rb
@@ -112,12 +112,12 @@ describe MiqAeMethodService::MiqAeServiceService do
       service_template = FactoryBot.create(:service_template, :name => 'Dummy')
       service_name = 'service name'
       description = 'description'
-      method = <<EOF
-service_template = $evm.vmdb('service_template').find(#{service_template.id})
-$evm.vmdb('service').create(:name             => '#{service_name}',
+      method = <<-SCP
+        service_template = $evm.vmdb('service_template').find(#{service_template.id})
+        $evm.vmdb('service').create(:name             => '#{service_name}',
                             :description      => '#{description}',
                             :service_template => service_template)
-EOF
+      SCP
       @ae_method.update(:data => method)
       invoke_ae
 

--- a/spec/support/miq_automate_helper.rb
+++ b/spec/support/miq_automate_helper.rb
@@ -12,10 +12,12 @@ module Spec
         @aec1.ae_fields << build_fields(field_array)
         @aei1 = FactoryBot.create(:miq_ae_instance, :name     => identifiers[:instance],
                                                      :class_id => @aec1.id)
-        @aem1 = FactoryBot.create(:miq_ae_method, :class_id => @aec1.id,
-                                   :name => identifiers[:method], :scope => "instance",
-                                   :language => "ruby", :data => "puts 1",
-                                   :location => "inline") if identifiers[:method].present?
+        if identifiers[:method].present?
+          @aem1 = FactoryBot.create(:miq_ae_method, :class_id => @aec1.id,
+                                    :name => identifiers[:method], :scope => "instance",
+                                    :language => "ruby", :data => "puts 1",
+                                    :location => "inline")
+        end
         @aei1.ae_values << build_values(field_array, @aec1.ae_fields)
       end
 


### PR DESCRIPTION
Cops used:
Naming/FileName
Naming/ClassAndModuleCamelCase
Naming/HeredocDelimiterNaming
Naming/UncommunicativeBlockParamName

Style/AccessModifierDeclarations
Style/ClassVars
Style/MultilineIfModifier
Style/MultipleComparison
Style/MultilineWhenThen
Style/Next
Style/RaiseArgs
Style/RescueModifier
Style/RescueStandardError
Style/SafeNavigation
Style/StderrPuts

Performance/RedundantMatch
Performance/RegexpMatch

@miq-bot add_label  ivanchuk/no, refactoring, changelog/yes