### PR TITLE
Switch find_by_* to lookup_by_*

### DIFF
--- a/app/models/miq_ae_class_copy.rb
+++ b/app/models/miq_ae_class_copy.rb
@@ -6,7 +6,7 @@ class MiqAeClassCopy
   def initialize(class_fqname)
     @class_fqname = class_fqname
     @src_domain, @partial_ns, @ae_class = MiqAeClassCopy.split(@class_fqname, false)
-    @src_class = MiqAeClass.find_by_fqname(@class_fqname)
+    @src_class = MiqAeClass.lookup_by_fqname(@class_fqname)
     raise "Source class not found #{@class_fqname}" unless @src_class
   end
 
@@ -42,7 +42,7 @@ class MiqAeClassCopy
 
   def target_ns(domain, ns)
     return "#{domain}/#{@partial_ns}" if ns.nil?
-    ns_obj = MiqAeNamespace.find_by_fqname(ns, false)
+    ns_obj = MiqAeNamespace.lookup_by_fqname(ns, false)
     ns_obj && !ns_obj.domain? ? ns : "#{domain}/#{ns}"
   end
 
@@ -78,7 +78,7 @@ class MiqAeClassCopy
   end
 
   def validate
-    dest_class = MiqAeClass.find_by_fqname("#{@target_ns_fqname}/#{@target_name}")
+    dest_class = MiqAeClass.lookup_by_fqname("#{@target_ns_fqname}/#{@target_name}")
     $log.info("Destination class: #{dest_class}")
     if dest_class
       $log.info("Overwrite flag: #{@overwrite}")

--- a/app/models/miq_ae_datastore.rb
+++ b/app/models/miq_ae_datastore.rb
@@ -124,18 +124,18 @@ module MiqAeDatastore
   end
 
   def self.reset_default_namespace
-    ns = MiqAeNamespace.find_by_fqname(DEFAULT_OBJECT_NAMESPACE)
+    ns = MiqAeNamespace.lookup_by_fqname(DEFAULT_OBJECT_NAMESPACE)
     ns.destroy if ns
     seed_default_namespace
   end
 
   private_class_method def self.reset_domain(datastore_dir, domain_name, tenant)
     _log.info("Resetting domain #{domain_name} from #{datastore_dir}")
-    ns = MiqAeDomain.find_by_fqname(domain_name)
+    ns = MiqAeDomain.lookup_by_fqname(domain_name)
     ns.destroy if ns
     import_yaml_dir(datastore_dir, domain_name, tenant)
     if domain_name.downcase == MANAGEIQ_DOMAIN.downcase
-      ns = MiqAeDomain.find_by_fqname(MANAGEIQ_DOMAIN)
+      ns = MiqAeDomain.lookup_by_fqname(MANAGEIQ_DOMAIN)
       ns.update!(:source   => MiqAeDomain::SYSTEM_SOURCE, :enabled => true,
                             :priority => MANAGEIQ_PRIORITY) if ns
     end
@@ -211,7 +211,7 @@ module MiqAeDatastore
   end
 
   def self.seed
-    ns = MiqAeDomain.find_by_fqname(MANAGEIQ_DOMAIN)
+    ns = MiqAeDomain.lookup_by_fqname(MANAGEIQ_DOMAIN)
     unless ns
       _log.info("Seeding ManageIQ domain...")
       begin
@@ -264,11 +264,11 @@ module MiqAeDatastore
   end
 
   def self.restore_attrs_for_domains(hash)
-    hash.each { |dom, attrs| MiqAeDomain.find_by_fqname(dom, false).update(attrs) }
+    hash.each { |dom, attrs| MiqAeDomain.lookup_by_fqname(dom, false).update(attrs) }
   end
 
   def self.path_includes_domain?(path, options = {})
     nsd, = ::MiqAeEngine::MiqAePath.split(path, options)
-    MiqAeNamespace.find_by_fqname(nsd, false) != nil
+    MiqAeNamespace.lookup_by_fqname(nsd, false) != nil
   end
 end

--- a/app/models/miq_ae_datastore/xml_export.rb
+++ b/app/models/miq_ae_datastore/xml_export.rb
@@ -22,14 +22,14 @@ module MiqAeDatastore
       xml = Builder::XmlMarkup.new(:indent => 2)
       xml.instruct!
       xml.MiqAeDatastore(:version => '1.0') do
-        c = MiqAeClass.find_by_namespace_and_name(ns, class_name)
+        c = MiqAeClass.lookup_by_namespace_and_name(ns, class_name)
         c.to_export_xml(:builder => xml, :skip_instruct => true, :indent => 2)
       end
     end
 
     def self.export_sub_namespaces(ns, xml)
       ns.ae_namespaces.each do |n|
-        sn = MiqAeNamespace.find_by_fqname(n.fqname)
+        sn = MiqAeNamespace.lookup_by_fqname(n.fqname)
         export_all_classes_for_namespace(sn, xml)
         export_sub_namespaces(sn, xml)
       end
@@ -39,7 +39,7 @@ module MiqAeDatastore
       _log.info("Exporting namespace: #{namespace} to XML")
       xml = Builder::XmlMarkup.new(:indent => 2)
       xml.instruct!
-      rec = MiqAeNamespace.find_by_fqname(namespace)
+      rec = MiqAeNamespace.lookup_by_fqname(namespace)
       if rec.nil?
         _log.info("Namespace:  <#{namespace}> not found.")
         return nil

--- a/app/models/miq_ae_datastore/xml_import.rb
+++ b/app/models/miq_ae_datastore/xml_import.rb
@@ -153,7 +153,7 @@ module MiqAeDatastore
     end
 
     def self.create_domain(domain)
-      MiqAeDomain.find_by_fqname(domain) ||
+      MiqAeDomain.lookup_by_fqname(domain) ||
       MiqAeDomain.create!(:enabled => true, :priority => 100, :tenant => Tenant.root_tenant, :name => domain)
     end
 

--- a/app/models/miq_ae_datastore/xml_yaml_converter.rb
+++ b/app/models/miq_ae_datastore/xml_yaml_converter.rb
@@ -8,7 +8,7 @@ module MiqAeDatastore
       export_options['export_as'] = domain_name
       MiqAeExport.new(temp_domain, export_options).export
     ensure
-      ns = MiqAeDomain.find_by_fqname(temp_domain)
+      ns = MiqAeDomain.lookup_by_fqname(temp_domain)
       ns.destroy if ns
     end
   end

--- a/app/models/miq_ae_instance_copy.rb
+++ b/app/models/miq_ae_instance_copy.rb
@@ -7,7 +7,7 @@ class MiqAeInstanceCopy
   def initialize(instance_fqname, validate_schema = true)
     @src_domain, @partial_ns, @ae_class, @instance_name = MiqAeInstanceCopy.split(instance_fqname, true)
     @class_fqname = "#{@src_domain}/#{@partial_ns}/#{@ae_class}"
-    @src_class = MiqAeClass.find_by_fqname("#{@src_domain}/#{@partial_ns}/#{@ae_class}")
+    @src_class = MiqAeClass.lookup_by_fqname("#{@src_domain}/#{@partial_ns}/#{@ae_class}")
     raise "Source class not found #{@class_fqname}" unless @src_class
     @src_instance = MiqAeInstance.find_by(:name => @instance_name, :class_id => @src_class.id)
     raise "Source instance #{@instance_name} not found #{@class_fqname}" unless @src_instance
@@ -51,7 +51,7 @@ class MiqAeInstanceCopy
   private
 
   def find_or_create_class
-    @dest_class = MiqAeClass.find_by_fqname("#{@target_domain}/#{@target_ns}/#{@target_class_name}")
+    @dest_class = MiqAeClass.lookup_by_fqname("#{@target_domain}/#{@target_ns}/#{@target_class_name}")
     return unless @dest_class.nil?
     @dest_class = MiqAeClassCopy.new(@class_fqname).to_domain(@target_domain, @target_ns)
   end

--- a/app/models/miq_ae_method_copy.rb
+++ b/app/models/miq_ae_method_copy.rb
@@ -6,7 +6,7 @@ class MiqAeMethodCopy
   def initialize(method_fqname)
     @src_domain, @partial_ns, @ae_class, @method_name = MiqAeMethodCopy.split(method_fqname, true)
     @class_fqname = "#{@src_domain}/#{@partial_ns}/#{@ae_class}"
-    @src_class = MiqAeClass.find_by_fqname("#{@src_domain}/#{@partial_ns}/#{@ae_class}")
+    @src_class = MiqAeClass.lookup_by_fqname("#{@src_domain}/#{@partial_ns}/#{@ae_class}")
     raise "Source class not found #{@class_fqname}" unless @src_class
     @src_method = MiqAeMethod.find_by(:name => @method_name, :class_id => @src_class.id)
     raise "Source method #{@method_name} not found #{@class_fqname}" unless @src_method
@@ -46,7 +46,7 @@ class MiqAeMethodCopy
   private
 
   def find_or_create_class
-    @dest_class = MiqAeClass.find_by_fqname("#{@target_domain}/#{@target_ns}/#{@target_class_name}")
+    @dest_class = MiqAeClass.lookup_by_fqname("#{@target_domain}/#{@target_ns}/#{@target_class_name}")
     return unless @dest_class.nil?
     @dest_class = MiqAeClassCopy.new(@class_fqname).to_domain(@target_domain, @target_ns)
   end
@@ -68,7 +68,7 @@ class MiqAeMethodCopy
   end
 
   def create_method
-    @dest_method = MiqAeMethod.find_by_class_id_and_name(@dest_class.id, @target_name)
+    @dest_method = MiqAeMethod.lookup_by_class_id_and_name(@dest_class.id, @target_name)
     if @dest_method
       @dest_method.destroy if @overwrite
       raise "Instance #{@target_name} exists in #{@target_ns_fqname} class #{@target_class_name}" unless @overwrite

--- a/app/models/miq_ae_yaml_export.rb
+++ b/app/models/miq_ae_yaml_export.rb
@@ -256,7 +256,7 @@ class MiqAeYamlExport
 
   def domain_object
     raise MiqAeException::DomainNotAccessible, "Domain [#{@domain}] not accessible" unless domain_accessible?
-    MiqAeDomain.find_by_fqname(@domain).tap do |dom|
+    MiqAeDomain.lookup_by_fqname(@domain).tap do |dom|
       if dom.nil?
         _log.error("Domain: <#{@domain}> not found.")
         raise MiqAeException::DomainNotFound, "Domain [#{@domain}] not found in MiqAeDatastore"
@@ -267,7 +267,7 @@ class MiqAeYamlExport
 
   def get_namespace_object(namespace)
     fqname = File.join(@domain, namespace)
-    MiqAeNamespace.find_by_fqname(fqname) || begin
+    MiqAeNamespace.lookup_by_fqname(fqname) || begin
       _log.error("Namespace: <#{fqname}> not found.")
       raise MiqAeException::NamespaceNotFound, "Namespace: [#{fqname}] not found in MiqAeDatastore"
     end

--- a/app/models/miq_ae_yaml_import.rb
+++ b/app/models/miq_ae_yaml_import.rb
@@ -79,7 +79,7 @@ class MiqAeYamlImport
   def import_domain(domain_folder, domain_name)
     domain_yaml = domain_properties(domain_folder, domain_name)
     domain_name = domain_yaml.fetch_path('object', 'attributes', 'name')
-    domain_obj = MiqAeDomain.find_by_fqname(domain_name, false)
+    domain_obj = MiqAeDomain.lookup_by_fqname(domain_name, false)
     track_stats('domain', domain_obj)
     MiqAeDomain.transaction do
       if domain_obj && !@preview && @options['overwrite']
@@ -157,7 +157,7 @@ class MiqAeYamlImport
                "#{domain_name}#{namespace_folder.sub(domain_folder(@domain_name), '')}"
              end
     _log.info("Importing namespace: <#{fqname}>")
-    namespace_obj = MiqAeNamespace.find_by_fqname(fqname, false)
+    namespace_obj = MiqAeNamespace.lookup_by_fqname(fqname, false)
     track_stats('namespace', namespace_obj)
     namespace_obj ||= add_namespace(fqname) unless @preview
     attrs = namespace_yaml.fetch_path('object', 'attributes').slice('display_name', 'description')
@@ -204,7 +204,7 @@ class MiqAeYamlImport
 
   def existing_class_object(ns_obj, class_yaml)
     class_attrs = class_yaml.fetch_path('object', 'attributes')
-    class_obj = MiqAeClass.find_by_namespace_id_and_name(ns_obj.id, class_attrs['name']) unless ns_obj.nil?
+    class_obj = MiqAeClass.lookup_by_namespace_id_and_name(ns_obj.id, class_attrs['name']) unless ns_obj.nil?
     track_stats('class', class_obj)
     class_obj
   end
@@ -302,7 +302,7 @@ class MiqAeYamlImport
   def new_domain_name_valid?
     return true if @options['overwrite']
 
-    domain_obj = MiqAeDomain.find_by_fqname(@options['import_as'], false)
+    domain_obj = MiqAeDomain.lookup_by_fqname(@options['import_as'], false)
     if domain_obj
       _log.info("Cannot import - A domain exists with new domain name: #{@options['import_as']}.")
       return false

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
@@ -34,7 +34,7 @@ module MiqAeEngine
 
     def search(uri, ns, klass, instance, method)
       unless @partial_ns.include?(ns)
-        fqns = MiqAeNamespace.find_by_fqname(ns, false)
+        fqns = MiqAeNamespace.lookup_by_fqname(ns, false)
         if fqns && !fqns.domain?
           @fqns_id_cache[ns] = fqns.id
           return ns
@@ -79,7 +79,7 @@ module MiqAeEngine
       fqname = fqns_parts.join('/')
       return @fqns_id_cache[fqname] if @fqns_id_cache.key?(fqname)
 
-      ns = MiqAeNamespace.find_by_fqname(fqname, false)
+      ns = MiqAeNamespace.lookup_by_fqname(fqname, false)
       @fqns_id_cache[fqname] = ns.id if ns
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -276,7 +276,7 @@ module MiqAeEngine
       method_obj.embedded_methods.each do |name|
         method_name, klass, ns = embedded_method_name(name)
         match_ns = workspace.overlay_method(ns, klass, method_name)
-        cls = ::MiqAeClass.find_by_fqname("#{match_ns}/#{klass}")
+        cls = ::MiqAeClass.lookup_by_fqname("#{match_ns}/#{klass}")
         aem = ::MiqAeMethod.find_by(:class_id => cls.id, :name => method_name) if cls
         raise MiqAeException::MethodNotFound, "Embedded method #{name} not found" unless aem
         fqname = "/#{match_ns}/#{klass}/#{method_name}"

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -152,7 +152,7 @@ module MiqAeEngine
       Benchmark.current_realtime[:fetch_namespace_count] += 1
       Benchmark.realtime_block(:fetch_namespace_time) do
         @workspace.datastore(ns.downcase, :namespace) do
-          MiqAeNamespace.find_by_fqname(ns)
+          MiqAeNamespace.lookup_by_fqname(ns)
         end
       end.first
     end
@@ -515,8 +515,8 @@ module MiqAeEngine
       ns.shift
       updated_ns = @workspace.overlay_method(ns.join('/'), klass, method_name)
       if updated_ns != namespace
-        cls = ::MiqAeClass.find_by_fqname("#{updated_ns}/#{klass}")
-        aem = ::MiqAeMethod.find_by_class_id_and_name(cls.id, method_name) if cls
+        cls = ::MiqAeClass.lookup_by_fqname("#{updated_ns}/#{klass}")
+        aem = ::MiqAeMethod.lookup_by_class_id_and_name(cls.id, method_name) if cls
       end
       aem
     end

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -269,7 +269,7 @@ module MiqAeMethodService
       ns, klass, instance = MiqAeEngine::MiqAePath.split(path)
       $log.info("Instance Create for ns: #{ns} class #{klass} instance: #{instance}")
 
-      aec = MiqAeClass.find_by_namespace_and_name(ns, klass)
+      aec = MiqAeClass.lookup_by_namespace_and_name(ns, klass)
       return false if aec.nil?
 
       aei = aec.ae_instances.detect { |i| instance.casecmp(i.name).zero? }
@@ -312,7 +312,7 @@ module MiqAeMethodService
       result = {}
 
       ns, klass, instance = MiqAeEngine::MiqAePath.split(path)
-      aec = MiqAeClass.find_by_namespace_and_name(ns, klass)
+      aec = MiqAeClass.lookup_by_namespace_and_name(ns, klass)
       unless aec.nil?
         instance.gsub!(".", '\.')
         instance.gsub!("*", ".*")
@@ -355,7 +355,7 @@ module MiqAeMethodService
       dom, ns, klass, instance = MiqAeEngine::MiqAePath.get_domain_ns_klass_inst(path)
       return false unless visible_domain?(dom)
 
-      aec = MiqAeClass.find_by_namespace_and_name("#{dom}/#{ns}", klass)
+      aec = MiqAeClass.lookup_by_namespace_and_name("#{dom}/#{ns}", klass)
       return nil if aec.nil?
 
       aec.ae_instances.detect { |i| instance.casecmp(i.name).zero? }
@@ -370,7 +370,7 @@ module MiqAeMethodService
     def editable_instance?(path)
       dom, = MiqAeEngine::MiqAePath.get_domain_ns_klass_inst(path)
       return false unless owned_domain?(dom)
-      domain = MiqAeDomain.find_by_fqname(dom, false)
+      domain = MiqAeDomain.lookup_by_fqname(dom, false)
       return false unless domain
       $log.warn "path=#{path.inspect} : is not editable" unless domain.editable?(@workspace.ae_user)
       domain.editable?(@workspace.ae_user)

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -67,7 +67,7 @@ module MiqAeMethodService
 
     def self.category_exists?(category)
       ar_method do
-        Classification.find_by_name(category).present?
+        Classification.lookup_by_name(category).present?
       end
     end
 
@@ -82,7 +82,7 @@ module MiqAeMethodService
 
     def self.category_delete!(category)
       ar_method do
-        cat = Classification.find_by_name(category)
+        cat = Classification.lookup_by_name(category)
         raise "Category <#{category}> does not exist" if cat.nil?
 
         if cat.entries.any? { |ent| AssignmentMixin.all_assignments(ent.tag.name).present? }
@@ -102,14 +102,14 @@ module MiqAeMethodService
 
     def self.tag_exists?(category, entry)
       ar_method do
-        cat = Classification.find_by_name(category)
+        cat = Classification.lookup_by_name(category)
         cat.present? && cat.find_entry_by_name(entry).present?
       end
     end
 
     def self.tag_create(category, options = {})
       ar_method do
-        cat = Classification.find_by_name(category)
+        cat = Classification.lookup_by_name(category)
         raise "Category <#{category}> does not exist" if cat.nil?
 
         ar_options = {}
@@ -121,7 +121,7 @@ module MiqAeMethodService
 
     def self.tag_delete!(category, entry)
       ar_method do
-        cat = Classification.find_by_name(category)
+        cat = Classification.lookup_by_name(category)
         raise "Category <#{category}> does not exist" if cat.nil?
 
         ent = cat.find_entry_by_name(entry)
@@ -144,12 +144,12 @@ module MiqAeMethodService
       # Need to add the username into the array of params
       # TODO: This code should pass a real username, similar to how the web-service
       #      passes the name of the user that logged into the web-service.
-      args.insert(1, User.find_by_userid("admin")) if args.kind_of?(Array)
+      args.insert(1, User.lookup_by_userid("admin")) if args.kind_of?(Array)
       MiqAeServiceModelBase.wrap_results(MiqProvisionVirtWorkflow.from_ws(*args))
     end
 
     def self.create_automation_request(options, userid = "admin", auto_approve = false)
-      user = User.find_by_userid!(userid)
+      user = User.lookup_by_userid!(userid)
       MiqAeServiceModelBase.wrap_results(AutomationRequest.create_request(options, user, auto_approve))
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -26,7 +26,8 @@ module MiqAeMethodService
 
     def self.allowed_find_method?(m)
       return false if m.starts_with?('find_or_create') || m.starts_with?('find_or_initialize')
-      m.starts_with?('find')
+
+      m.starts_with?('find', 'lookup_by')
     end
 
     # Expose the ActiveRecord find, all, count, and first

--- a/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
@@ -150,7 +150,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
 
     it "warns about non-existence of category" do
       ct_not_exist = "ct_not_exist"
-      expect(Classification.find_by_name(ct_not_exist)).to be_nil
+      expect(Classification.lookup_by_name(ct_not_exist)).to be_nil
 
       method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:category_delete!, #{ct_not_exist.inspect})"
       @ae_method.update(:data => method)
@@ -163,7 +163,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
       @ae_method.update(:data => method)
 
       expect(invoke_ae.root(@ae_result_key)).to be_truthy
-      expect(Classification.find_by_name(ct.name)).to be_nil
+      expect(Classification.lookup_by_name(ct.name)).to be_nil
     end
 
     it "deletes category if there is no assignment" do
@@ -173,7 +173,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
       @ae_method.update(:data => method)
 
       expect(invoke_ae.root(@ae_result_key)).to be_truthy
-      expect(Classification.find_by_name(ct.name)).to be_nil
+      expect(Classification.lookup_by_name(ct.name)).to be_nil
     end
 
     it "could not delete category if there is assignment" do
@@ -186,7 +186,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
       @ae_method.update(:data => method)
 
       expect { invoke_ae.root(@ae_result_key) }.to raise_error(MiqAeException::UnknownMethodRc)
-      expect(Classification.find_by_name(ct.name)).to_not be_nil
+      expect(Classification.lookup_by_name(ct.name)).to_not be_nil
     end
   end
 
@@ -195,7 +195,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
 
     it "returns false if category does not exist" do
       ct_not_exist = "ct_not_exist"
-      expect(Classification.find_by_name(ct_not_exist)).to be_nil
+      expect(Classification.lookup_by_name(ct_not_exist)).to be_nil
 
       method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:category_delete, #{ct_not_exist.inspect})"
       @ae_method.update(:data => method)
@@ -208,7 +208,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
       @ae_method.update(:data => method)
 
       expect(invoke_ae.root(@ae_result_key)).to be true
-      expect(Classification.find_by_name(ct.name)).to be_nil
+      expect(Classification.lookup_by_name(ct.name)).to be_nil
     end
 
     it "deletes category if there is no assignment" do
@@ -218,7 +218,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
       @ae_method.update(:data => method)
 
       expect(invoke_ae.root(@ae_result_key)).to be true
-      expect(Classification.find_by_name(ct.name)).to be_nil
+      expect(Classification.lookup_by_name(ct.name)).to be_nil
     end
 
     it "returns false if there is assignment" do
@@ -231,7 +231,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
       @ae_method.update(:data => method)
 
       expect(invoke_ae.root(@ae_result_key)).to be false
-      expect(Classification.find_by_name(ct.name)).to_not be_nil
+      expect(Classification.lookup_by_name(ct.name)).to_not be_nil
     end
   end
 

--- a/spec/engine/miq_ae_method_spec.rb
+++ b/spec/engine/miq_ae_method_spec.rb
@@ -330,7 +330,7 @@ describe MiqAeEngine::MiqAeMethod do
       end
 
       it 'can properly call functions in embedded methods' do
-        allow(::MiqAeClass).to receive(:find_by_fqname).with('Shared/Methods').and_return(klass)
+        allow(::MiqAeClass).to receive(:lookup_by_fqname).with('Shared/Methods').and_return(klass)
         allow(::MiqAeMethod).to receive(:find_by).with(:class_id => klass.id, :name => 'TopMethod').and_return(embed_method)
         allow($miq_ae_logger).to receive(:info).and_call_original
         allow(workspace).to receive(:overlay_method).with('Shared', 'Methods', 'TopMethod').and_return('Shared')
@@ -341,7 +341,7 @@ describe MiqAeEngine::MiqAeMethod do
       end
 
       it 'raises error when a embeded method is not found' do
-        allow(::MiqAeClass).to receive(:find_by_fqname).with('Shared/Methods').and_return(nil)
+        allow(::MiqAeClass).to receive(:lookup_by_fqname).with('Shared/Methods').and_return(nil)
         allow($miq_ae_logger).to receive(:info).and_call_original
         allow(workspace).to receive(:overlay_method).with('Shared', 'Methods', 'TopMethod').and_return('Shared')
 
@@ -351,7 +351,7 @@ describe MiqAeEngine::MiqAeMethod do
       context "exception" do
         let(:embeds) { ['/Shared/Methods/RaiseException'] }
         it 'can log stack trace in embedded methods' do
-          allow(::MiqAeClass).to receive(:find_by_fqname).with('Shared/Methods').and_return(klass)
+          allow(::MiqAeClass).to receive(:lookup_by_fqname).with('Shared/Methods').and_return(klass)
           allow(::MiqAeMethod).to receive(:find_by).with(:class_id => klass.id, :name => 'RaiseException').and_return(exception_method)
           allow($miq_ae_logger).to receive(:info).and_call_original
           allow($miq_ae_logger).to receive(:error).and_call_original
@@ -363,7 +363,7 @@ describe MiqAeEngine::MiqAeMethod do
 
       shared_examples "nested embeds" do
         it 'can load methods within  methods' do
-          allow(::MiqAeClass).to receive(:find_by_fqname).with('Shared/Methods').and_return(klass)
+          allow(::MiqAeClass).to receive(:lookup_by_fqname).with('Shared/Methods').and_return(klass)
           allow(::MiqAeMethod).to receive(:find_by).with(:class_id => klass.id, :name => 'Level1').and_return(level1_method)
           allow(::MiqAeMethod).to receive(:find_by).with(:class_id => klass.id, :name => 'Level2').and_return(level2_method)
           allow(::MiqAeMethod).to receive(:find_by).with(:class_id => klass.id, :name => 'Level3').and_return(level3_method)

--- a/spec/engine/miq_ae_state_machine_multi_spec.rb
+++ b/spec/engine/miq_ae_state_machine_multi_spec.rb
@@ -142,7 +142,7 @@ describe "MultipleStateMachineSteps" do
   end
 
   def tweak_instance(class_fqname, instance, field_name, attribute, value)
-    klass = MiqAeClass.find_by_fqname(class_fqname)
+    klass = MiqAeClass.lookup_by_fqname(class_fqname)
     field = klass.ae_fields.detect { |f| f.name == field_name }
     ins   = klass.ae_instances.detect { |inst| inst.name == instance }
     update_value(ins, field, attribute, value)

--- a/spec/engine/miq_ae_state_machine_steps_spec.rb
+++ b/spec/engine/miq_ae_state_machine_steps_spec.rb
@@ -118,7 +118,7 @@ describe "MiqAeStateMachineSteps" do
   end
 
   def tweak_instance(class_fqname, instance, field_name, attribute, value)
-    klass = MiqAeClass.find_by_fqname(class_fqname)
+    klass = MiqAeClass.lookup_by_fqname(class_fqname)
     field = klass.ae_fields.detect { |f| f.name == field_name }
     ins   = klass.ae_instances.detect { |inst| inst.name == instance }
     update_value(ins, field, attribute, value)

--- a/spec/miq_ae_collect_spec.rb
+++ b/spec/miq_ae_collect_spec.rb
@@ -44,7 +44,7 @@ describe "MiqAeCollect" do
   end
 
   it "collect on instance level overrides collect on class level" do
-    c1 = MiqAeClass.find_by_namespace_and_name("#{@domain}/TEST", "COLLECT")
+    c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/TEST", "COLLECT")
     i1 = c1.ae_instances.detect { |i| i.name == "INFO"   }
     f1 = c1.ae_fields.detect    { |f| f.name == "weekdays" }
     i1.set_field_collect(f1, "weekdays = [description]")

--- a/spec/miq_ae_domain_spec.rb
+++ b/spec/miq_ae_domain_spec.rb
@@ -50,7 +50,7 @@ describe MiqAeDomain do
     end
 
     def update_domain_attributes(domain_name, attrs)
-      dom = MiqAeDomain.find_by_fqname(domain_name)
+      dom = MiqAeDomain.lookup_by_fqname(domain_name)
       dom.update!(attrs)
     end
 
@@ -69,19 +69,19 @@ describe MiqAeDomain do
 
     context "Domain Overlays" do
       it "partial namespace should use the higher priority user instance" do
-        ns = MiqAeNamespace.find_by_fqname('evm')
+        ns = MiqAeNamespace.lookup_by_fqname('evm')
         expect(ns).to be_nil
         assert_method_executed('evm/AUTOMATE/test1', 'user', @user)
       end
 
       it "fully qualified namespace should execute the root method" do
-        ns = MiqAeNamespace.find_by_fqname('root/evm')
+        ns = MiqAeNamespace.lookup_by_fqname('root/evm')
         expect(ns).not_to be_nil
         assert_method_executed('root/evm/AUTOMATE/test2', 'root', @user)
       end
 
       it "partial namespace with wild card in relationship" do
-        ns = MiqAeNamespace.find_by_fqname('evm')
+        ns = MiqAeNamespace.lookup_by_fqname('evm')
         expect(ns).to be_nil
         assert_method_executed('evm/AUTOMATE/test_wildcard', 'user', @user)
       end
@@ -99,14 +99,14 @@ describe MiqAeDomain do
       end
 
       it "an enabled namespace should get picked up if the instance exists" do
-        n3 = MiqAeNamespace.find_by_fqname('inert')
+        n3 = MiqAeNamespace.lookup_by_fqname('inert')
         expect(n3.enabled?).to be_falsey
         n3.update!(:enabled => true)
         assert_method_executed('evm/AUTOMATE/should_get_used', 'inert', @user)
       end
 
       it "partial namespace should use the higher priority users case insensitive instance" do
-        ns = MiqAeNamespace.find_by_fqname('evm')
+        ns = MiqAeNamespace.lookup_by_fqname('evm')
         expect(ns).to be_nil
         assert_method_executed('evm/AUTOMATE/TeSt1', 'user', @user)
       end

--- a/spec/miq_ae_method_spec.rb
+++ b/spec/miq_ae_method_spec.rb
@@ -9,7 +9,7 @@ describe MiqAeMethod do
     end
 
     def setup_methods
-      object_class = MiqAeClass.find_by_fqname("#{MiqAeDatastore::DEFAULT_OBJECT_NAMESPACE}/Object")
+      object_class = MiqAeClass.lookup_by_fqname("#{MiqAeDatastore::DEFAULT_OBJECT_NAMESPACE}/Object")
       method_data = '$evm.log("info", "Default Class Method")
         exit MIQ_OK'
       method_options = {:language => 'ruby', :class_id => object_class.id,

--- a/spec/miq_ae_object_spec.rb
+++ b/spec/miq_ae_object_spec.rb
@@ -171,7 +171,7 @@ describe MiqAeEngine::MiqAeObject do
   it "disabled inheritance" do
     @user = FactoryBot.create(:user_with_group)
     create_state_ae_model(:name => 'LUIGI', :ae_class => 'CLASS1', :ae_namespace => 'A/C', :instance_name => 'FRED')
-    klass = MiqAeClass.find_by_name('CLASS1')
+    klass = MiqAeClass.lookup_by_name('CLASS1')
     klass.update!(:inherits => '/LUIGI/A/C/missing')
     workspace = MiqAeEngine.instantiate("/A/C/CLASS1/FRED", @user)
     expect(workspace.root).not_to be_nil

--- a/spec/miq_ae_provision_spec.rb
+++ b/spec/miq_ae_provision_spec.rb
@@ -130,7 +130,7 @@ describe "MiqAeProvision" do
 
     it "should have Network class" do
       fqname = "#{@domain}/EVMApplications/Provisioning/Network"
-      klass = MiqAeClass.find_by_fqname(fqname)
+      klass = MiqAeClass.lookup_by_fqname(fqname)
       expect(klass).not_to be_nil
       expect(klass.ae_instances.length).not_to eq(0)
 

--- a/spec/miq_ae_state_machine_spec.rb
+++ b/spec/miq_ae_state_machine_spec.rb
@@ -42,7 +42,7 @@ describe "MiqAeStateMachine" do
 
   it "sets error properly during a provision request" do
     EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
-    c1 = MiqAeClass.find_by_namespace_and_name("#{@domain}/Factory", "VM")
+    c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/Factory", "VM")
     i1 = c1.ae_instances.detect { |i| i.name == "ProvisionCheck" }
     f1 = c1.ae_fields.detect    { |f| f.name == "execute"   }
     i1.set_field_attribute(f1, "provision_check(result => 'error')", :value)
@@ -58,7 +58,7 @@ describe "MiqAeStateMachine" do
   it "raises exception properly during a provision request" do
     EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
 
-    c1 = MiqAeClass.find_by_namespace_and_name("#{@domain}/Factory", "VM")
+    c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/Factory", "VM")
     i1 = c1.ae_instances.detect { |i| i.name == "ProvisionCheck" }
     f1 = c1.ae_fields.detect    { |f| f.name == "execute"   }
     i1.set_field_attribute(f1, "provision_check(result => 'exception')", :value)
@@ -75,7 +75,7 @@ describe "MiqAeStateMachine" do
     EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
     t0 = Time.now
 
-    c1 = MiqAeClass.find_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
+    c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
     i1 = c1.ae_instances.detect { |i| i.name == "Provisioning" }
     f1 = c1.ae_fields.detect    { |f| f.name == "EmailOwner"   }
     i1.set_field_attribute(f1, "log_object", :on_exit)
@@ -91,7 +91,7 @@ describe "MiqAeStateMachine" do
   it "executes on_entry instance methods properly" do
     EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
 
-    c1 = MiqAeClass.find_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
+    c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
     i1 = c1.ae_instances.detect { |i| i.name == "Provisioning" }
     f1 = c1.ae_fields.detect    { |f| f.name == "AcquireIPAddress"   }
     method_string = "update_provision_status(status => 'Testing on entry method',status_state => 'on_entry')"
@@ -111,7 +111,7 @@ describe "MiqAeStateMachine" do
   it "executes on_entry fully qualified class methods properly" do
     EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
 
-    c1 = MiqAeClass.find_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
+    c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
     i1 = c1.ae_instances.detect { |i| i.name == "Provisioning" }
     f1 = c1.ae_fields.detect    { |f| f.name == "AcquireIPAddress"   }
     method_string = "SPEC_DOMAIN/factory/method.test_class_method(status => 'Testing class on entry method',status_state => 'on_entry')"
@@ -123,7 +123,7 @@ describe "MiqAeStateMachine" do
   it "executes on_entry partially qualified class methods properly" do
     EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
 
-    c1 = MiqAeClass.find_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
+    c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
     i1 = c1.ae_instances.detect { |i| i.name == "Provisioning" }
     f1 = c1.ae_fields.detect    { |f| f.name == "AcquireIPAddress" }
     method_string = "/factory/method.test_class_method(status => 'Test',status_state => 'on_entry')"
@@ -135,7 +135,7 @@ describe "MiqAeStateMachine" do
   it "executes method:: method properly" do
     EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
 
-    c1 = MiqAeClass.find_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
+    c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
     i1 = c1.ae_instances.detect { |i| i.name == "Provisioning" }
     f1 = c1.ae_fields.detect    { |f| f.name == "AcquireIPAddress" }
     method_string = "METHOD::update_provision_status(status => 'Test',status_state => 'value')"
@@ -147,7 +147,7 @@ describe "MiqAeStateMachine" do
   it "executes class method notation method:: properly" do
     EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "state_machine"), @domain)
 
-    c1 = MiqAeClass.find_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
+    c1 = MiqAeClass.lookup_by_namespace_and_name("#{@domain}/Factory", "StateMachine")
     i1 = c1.ae_instances.detect { |i| i.name == "Provisioning" }
     f1 = c1.ae_fields.detect    { |f| f.name == "AcquireIPAddress" }
     method_string = "METHOD::/factory/method.test_class_method(status => 'Test',status_state => 'on_entry')"

--- a/spec/miq_method_override_spec.rb
+++ b/spec/miq_method_override_spec.rb
@@ -30,7 +30,7 @@ describe MiqAeDomain do
     end
 
     def set_enabled(domain, state)
-      dom = MiqAeDomain.find_by_fqname(domain)
+      dom = MiqAeDomain.lookup_by_fqname(domain)
       dom.update!(:enabled => state)
     end
   end

--- a/spec/models/miq_ae_class_compare_fields_spec.rb
+++ b/spec/models/miq_ae_class_compare_fields_spec.rb
@@ -19,13 +19,13 @@ describe MiqAeClassCompareFields do
     end
 
     it "both class in DB should be equivalent" do
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
       class_check_status(class1, class1, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
     end
 
     it "one class in DB and other in YAML should be equivalent" do
       export_model(@domain)
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
       class2 = MiqAeClassYaml.new(@class1_file)
       class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
     end
@@ -39,14 +39,14 @@ describe MiqAeClassCompareFields do
     end
 
     it "both class in DB should be equivalent" do
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @second_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @second_class)
       class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
     end
 
     it "one class in DB and other in YAML should be equivalent" do
       export_model(@domain)
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
       class2 = MiqAeClassYaml.new(@class2_file)
       class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
     end
@@ -60,14 +60,14 @@ describe MiqAeClassCompareFields do
     end
 
     it "both classes in DB should be incompatible" do
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @second_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @second_class)
       class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
     end
 
     it "one class in DB and other in YAML should be incompatible" do
       export_model(@domain)
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
       class2 = MiqAeClassYaml.new(@class2_file)
       class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
     end
@@ -81,15 +81,15 @@ describe MiqAeClassCompareFields do
     end
 
     it "both classes in DB should be incompatible" do
-      ns1 = MiqAeNamespace.find_by_fqname("#{@domain}/#{@namespace}")
-      class1 = MiqAeClass.find_by_namespace_id_and_name(ns1.id, @first_class)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(ns1.id, @second_class)
+      ns1 = MiqAeNamespace.lookup_by_fqname("#{@domain}/#{@namespace}")
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(ns1.id, @first_class)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(ns1.id, @second_class)
       class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
     end
 
     it "one class in DB and other in YAML should be incompatible" do
       export_model(@domain)
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
       class2 = MiqAeClassYaml.new(@class2_file)
       class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
     end
@@ -103,14 +103,14 @@ describe MiqAeClassCompareFields do
     end
 
     it "both classes in DB should be compatible" do
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @second_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @second_class)
       class_check_status(class1, class2, MiqAeClassCompareFields::COMPATIBLE_SCHEMA)
     end
 
     it "one class in DB and other in YAML should be compatible" do
       export_model(@domain)
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
       class2 = MiqAeClassYaml.new(@class2_file)
       class_check_status(class1, class2, MiqAeClassCompareFields::COMPATIBLE_SCHEMA)
     end
@@ -124,14 +124,14 @@ describe MiqAeClassCompareFields do
     end
 
     it "both classes in DB should be compatible" do
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @second_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @second_class)
       class_check_status(class1, class2, MiqAeClassCompareFields::COMPATIBLE_SCHEMA)
     end
 
     it "one class in DB and other in YAML should be compatible" do
       export_model(@domain)
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
       class2 = MiqAeClassYaml.new(@class2_file)
       class_check_status(class1, class2, MiqAeClassCompareFields::COMPATIBLE_SCHEMA)
     end
@@ -145,14 +145,14 @@ describe MiqAeClassCompareFields do
     end
 
     it "both classes in DB should be incompatible" do
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @second_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @second_class)
       class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
     end
 
     it "one class in DB and other in YAML should be incompatible" do
       export_model(@domain)
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
       class2 = MiqAeClassYaml.new(@class2_file)
       class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
     end
@@ -166,14 +166,14 @@ describe MiqAeClassCompareFields do
     end
 
     it "both classes in DB should be incompatible" do
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @second_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @second_class)
       class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
     end
 
     it "one class in DB and other in YAML should be incompatible" do
       export_model(@domain)
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @first_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @first_class)
       class2 = MiqAeClassYaml.new(@class2_file)
       class_check_status(class1, class2, MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA)
     end
@@ -190,7 +190,7 @@ describe MiqAeClassCompareFields do
     @second_class = class2 if class2
     @class1_file = File.join(@export_dir, @domain, @namespace, "#{@first_class}.class", "__class__.yaml") if class1
     @class2_file = File.join(@export_dir, @domain, @namespace, "#{@second_class}.class", "__class__.yaml") if class2
-    @ns1 = MiqAeNamespace.find_by_fqname("#{@domain}/#{@namespace}")
+    @ns1 = MiqAeNamespace.lookup_by_fqname("#{@domain}/#{@namespace}")
   end
 
   def export_model(domain, export_options = {})

--- a/spec/models/miq_ae_class_copy_spec.rb
+++ b/spec/models/miq_ae_class_copy_spec.rb
@@ -14,53 +14,53 @@ describe MiqAeClassCopy do
 
   context "clone the class to a new domain" do
     before do
-      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+      @ns1 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@src_ns}", false)
     end
 
     it "after copy both classes in DB should be congruent" do
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @src_class)
       class2 = MiqAeClassCopy.new(@src_fqname).to_domain(@dest_domain)
       class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
-      @ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@src_ns}", false)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns2.id, @src_class)
+      @ns2 = MiqAeNamespace.lookup_by_fqname("#{@dest_domain}/#{@src_ns}", false)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(@ns2.id, @src_class)
       expect(class2).not_to be_nil
     end
   end
 
   context "clone the class to a new domain with a different namespace" do
     before do
-      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+      @ns1 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@src_ns}", false)
     end
 
     it "after copy both classes in DB should be congruent" do
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @src_class)
       new_ns   = "NS3/NS4"
       class2 = MiqAeClassCopy.new(@src_fqname).to_domain(@dest_domain, new_ns)
       class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
-      @ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{new_ns}", false)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns2.id, @src_class)
+      @ns2 = MiqAeNamespace.lookup_by_fqname("#{@dest_domain}/#{new_ns}", false)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(@ns2.id, @src_class)
       expect(class2).not_to be_nil
     end
   end
 
   context "copy to a new classname in the same domain" do
     before do
-      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+      @ns1 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@src_ns}", false)
     end
 
     it "after copy both classes in DB should be congruent" do
       new_name = "SAME_AS_#{@src_class}"
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @src_class)
       class2 = MiqAeClassCopy.new(@src_fqname).as(new_name)
       class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, new_name)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, new_name)
       expect(class2).not_to be_nil
     end
   end
 
   context "copy to a existing class in the same domain" do
     before do
-      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+      @ns1 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@src_ns}", false)
     end
 
     it "copy should fail with error" do
@@ -70,17 +70,17 @@ describe MiqAeClassCopy do
 
   context "copy to a new class name in the same domain but different namespace" do
     before do
-      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
+      @ns1 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@src_ns}", false)
     end
 
     it "after copy both classes in DB should be congruent" do
       new_name = "SAME_AS_#{@src_class}"
       new_ns   = "NS3/NS4"
-      class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @src_class)
       class2 = MiqAeClassCopy.new(@src_fqname).as(new_name, new_ns)
       class_check_status(class1, class2, MiqAeClassCompareFields::CONGRUENT_SCHEMA)
-      @ns2 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{new_ns}", false)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(@ns2.id, new_name)
+      @ns2 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{new_ns}", false)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(@ns2.id, new_name)
       expect(class2).not_to be_nil
     end
   end

--- a/spec/models/miq_ae_domain_spec.rb
+++ b/spec/models/miq_ae_domain_spec.rb
@@ -19,31 +19,31 @@ describe MiqAeDomain do
 
     it "should change priority based on ordered list of ids" do
       after = {'TEST4' => 1, 'TEST3' => 2, 'TEST2' => 3, 'TEST1' => 4}
-      ids   = after.collect { |dom, _| MiqAeDomain.find_by_fqname(dom).id }
+      ids   = after.collect { |dom, _| MiqAeDomain.lookup_by_fqname(dom).id }
       MiqAeDomain.reset_priority_by_ordered_ids(ids)
-      after.each { |dom, pri| expect(MiqAeDomain.find_by_fqname(dom).priority).to eql(pri) }
+      after.each { |dom, pri| expect(MiqAeDomain.lookup_by_fqname(dom).priority).to eql(pri) }
     end
 
     it "after a domain with lowest priority is deleted" do
-      MiqAeDomain.destroy(MiqAeDomain.find_by_fqname('TEST1').id)
+      MiqAeDomain.destroy(MiqAeDomain.lookup_by_fqname('TEST1').id)
       after = {'TEST2' => 1, 'TEST3' => 2, 'TEST4' => 3}
-      after.each { |dom, pri| expect(MiqAeDomain.find_by_fqname(dom).priority).to eql(pri) }
+      after.each { |dom, pri| expect(MiqAeDomain.lookup_by_fqname(dom).priority).to eql(pri) }
     end
 
     it "after a domain with middle priority is deleted" do
-      MiqAeDomain.destroy(MiqAeDomain.find_by_fqname('TEST3').id)
+      MiqAeDomain.destroy(MiqAeDomain.lookup_by_fqname('TEST3').id)
       after = {'TEST1' => 1, 'TEST2' => 2, 'TEST4' => 3}
-      after.each { |dom, pri| expect(MiqAeDomain.find_by_fqname(dom).priority).to eql(pri) }
+      after.each { |dom, pri| expect(MiqAeDomain.lookup_by_fqname(dom).priority).to eql(pri) }
     end
 
     it "after a domain with highest priority is deleted" do
-      MiqAeDomain.destroy(MiqAeDomain.find_by_fqname('TEST4').id)
+      MiqAeDomain.destroy(MiqAeDomain.lookup_by_fqname('TEST4').id)
       after = {'TEST1' => 1, 'TEST2' => 2, 'TEST3' => 3}
-      after.each { |dom, pri| expect(MiqAeDomain.find_by_fqname(dom).priority).to eql(pri) }
+      after.each { |dom, pri| expect(MiqAeDomain.lookup_by_fqname(dom).priority).to eql(pri) }
     end
 
     it "after all domains are deleted" do
-      %w[TEST1 TEST2 TEST3 TEST4].each { |name| MiqAeDomain.find_by_fqname(name).destroy }
+      %w[TEST1 TEST2 TEST3 TEST4].each { |name| MiqAeDomain.lookup_by_fqname(name).destroy }
       d1 = FactoryBot.create(:miq_ae_domain, :name => 'TEST1')
       expect(d1.priority).to eql(1)
     end

--- a/spec/models/miq_ae_instance_compare_values_spec.rb
+++ b/spec/models/miq_ae_instance_compare_values_spec.rb
@@ -62,8 +62,8 @@ describe MiqAeInstanceCompareValues do
     @second_instance = inst2 if inst2
     @instance1_file = File.join(@export_dir, @domain, @namespace, "#{@classname}.class", "#{inst1}.yaml") if inst1
     @instance2_file = File.join(@export_dir, @domain, @namespace, "#{@classname}.class", "#{inst2}.yaml") if inst2
-    @ns1 = MiqAeNamespace.find_by_fqname("#{@domain}/#{@namespace}")
-    @class = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @classname)
+    @ns1 = MiqAeNamespace.lookup_by_fqname("#{@domain}/#{@namespace}")
+    @class = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @classname)
   end
 
   def export_model(domain, export_options = {})

--- a/spec/models/miq_ae_instance_copy_spec.rb
+++ b/spec/models/miq_ae_instance_copy_spec.rb
@@ -17,15 +17,15 @@ describe MiqAeInstanceCopy do
 
   context 'clone instance' do
     before do
-      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
-      @class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      @ns1 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@src_ns}", false)
+      @class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @src_class)
       @inst1  = MiqAeInstance.find_by_class_id_and_name(@class1.id, @src_instance)
     end
 
     it 'after copy both instances in DB should be congruent' do
       MiqAeInstanceCopy.new(@src_fqname).to_domain(@dest_domain)
-      ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@src_ns}", false)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
+      ns2 = MiqAeNamespace.lookup_by_fqname("#{@dest_domain}/#{@src_ns}", false)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(ns2.id, @src_class)
       inst2  = MiqAeInstance.find_by_class_id_and_name(class2.id, @src_instance)
       validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
     end
@@ -46,16 +46,16 @@ describe MiqAeInstanceCopy do
 
     it 'copy instance to a different namespace in the same domain' do
       MiqAeInstanceCopy.new(@src_fqname).as(@src_instance, @dest_ns, true)
-      ns2 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@dest_ns}", false)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
+      ns2 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@dest_ns}", false)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(ns2.id, @src_class)
       inst2  = MiqAeInstance.find_by_class_id_and_name(class2.id, @src_instance)
       validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
     end
 
     it 'copy instance to a different namespace in a different domain' do
       MiqAeInstanceCopy.new(@src_fqname).to_domain(@dest_domain, @dest_ns, true)
-      ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@dest_ns}", false)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
+      ns2 = MiqAeNamespace.lookup_by_fqname("#{@dest_domain}/#{@dest_ns}", false)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(ns2.id, @src_class)
       inst2  = MiqAeInstance.find_by_class_id_and_name(class2.id, @src_instance)
       validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
     end
@@ -63,8 +63,8 @@ describe MiqAeInstanceCopy do
 
   context 'incompatible schema' do
     before do
-      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
-      @class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
+      @ns1 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@src_ns}", false)
+      @class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @src_class)
       @inst1  = MiqAeInstance.find_by_class_id_and_name(@class1.id, @src_instance)
     end
 
@@ -76,8 +76,8 @@ describe MiqAeInstanceCopy do
       cp = MiqAeInstanceCopy.new(@src_fqname)
       cp.flags = MiqAeClassCompareFields::INCOMPATIBLE_SCHEMA
       cp.as('incompatible_one', 'NS2', true)
-      ns2 = MiqAeNamespace.find_by_fqname("#{@src_domain}/ns2", false)
-      ic_class = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
+      ns2 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/ns2", false)
+      ic_class = MiqAeClass.lookup_by_namespace_id_and_name(ns2.id, @src_class)
       expect(MiqAeInstance.find_by_class_id_and_name(ic_class.id, 'incompatible_one')).not_to be_nil
     end
   end

--- a/spec/models/miq_ae_method_compare_spec.rb
+++ b/spec/models/miq_ae_method_compare_spec.rb
@@ -20,13 +20,13 @@ describe MiqAeMethodCompare do
     end
 
     it 'both methods in DB should be equivalent' do
-      meth1  = MiqAeMethod.find_by_class_id_and_name(@class.id, @first_method)
+      meth1 = MiqAeMethod.lookup_by_class_id_and_name(@class.id, @first_method)
       method_check_status(meth1, meth1, MiqAeMethodCompare::CONGRUENT_METHOD)
     end
 
     it 'one method in DB and other in YAML should be equivalent' do
       export_model(@domain)
-      meth1 = MiqAeMethod.find_by_class_id_and_name(@class.id, @first_method)
+      meth1 = MiqAeMethod.lookup_by_class_id_and_name(@class.id, @first_method)
       meth2 = MiqAeMethodYaml.new(@method1_file)
       method_check_status(meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
     end
@@ -38,14 +38,14 @@ describe MiqAeMethodCompare do
     end
 
     it 'both method in DB should be incompatible' do
-      meth1  = MiqAeMethod.find_by_class_id_and_name(@class.id, @first_method)
-      meth2  = MiqAeMethod.find_by_class_id_and_name(@class.id, @second_method)
+      meth1  = MiqAeMethod.lookup_by_class_id_and_name(@class.id, @first_method)
+      meth2  = MiqAeMethod.lookup_by_class_id_and_name(@class.id, @second_method)
       method_check_status(meth1, meth2, MiqAeMethodCompare::INCOMPATIBLE_METHOD)
     end
 
     it 'one method in DB and other in YAML should be incompatible' do
       export_model(@domain)
-      meth1 = MiqAeMethod.find_by_class_id_and_name(@class.id, @first_method)
+      meth1 = MiqAeMethod.lookup_by_class_id_and_name(@class.id, @first_method)
       meth2 = MiqAeMethodYaml.new(@method2_file)
       method_check_status(meth1, meth2, MiqAeMethodCompare::INCOMPATIBLE_METHOD)
     end
@@ -57,14 +57,14 @@ describe MiqAeMethodCompare do
     end
 
     it 'both method in DB should be compatible' do
-      meth1  = MiqAeMethod.find_by_class_id_and_name(@class.id, @first_method)
-      meth2  = MiqAeMethod.find_by_class_id_and_name(@class.id, @second_method)
+      meth1  = MiqAeMethod.lookup_by_class_id_and_name(@class.id, @first_method)
+      meth2  = MiqAeMethod.lookup_by_class_id_and_name(@class.id, @second_method)
       method_check_status(meth1, meth2, MiqAeMethodCompare::COMPATIBLE_METHOD)
     end
 
     it 'one method in DB and other in YAML should be compatible' do
       export_model(@domain)
-      meth1 = MiqAeMethod.find_by_class_id_and_name(@class.id, @first_method)
+      meth1 = MiqAeMethod.lookup_by_class_id_and_name(@class.id, @first_method)
       meth2 = MiqAeMethodYaml.new(@method2_file)
       method_check_status(meth1, meth2, MiqAeMethodCompare::COMPATIBLE_METHOD)
     end
@@ -83,8 +83,8 @@ describe MiqAeMethodCompare do
                               "#{@classname}.class", '__methods__', "#{meth1}.yaml") if meth1
     @method2_file = File.join(@export_dir, @domain, @namespace,
                               "#{@classname}.class", '__methods__', "#{meth2}.yaml") if meth2
-    @ns1 = MiqAeNamespace.find_by_fqname("#{@domain}/#{@namespace}")
-    @class = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @classname)
+    @ns1 = MiqAeNamespace.lookup_by_fqname("#{@domain}/#{@namespace}")
+    @class = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @classname)
   end
 
   def export_model(domain, export_options = {})

--- a/spec/models/miq_ae_method_copy_spec.rb
+++ b/spec/models/miq_ae_method_copy_spec.rb
@@ -18,56 +18,56 @@ describe MiqAeMethodCopy do
 
   context 'clone method' do
     before do
-      @ns1 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@src_ns}", false)
-      @class1 = MiqAeClass.find_by_namespace_id_and_name(@ns1.id, @src_class)
-      @meth1  = MiqAeMethod.find_by_class_id_and_name(@class1.id, @src_method)
+      @ns1 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@src_ns}", false)
+      @class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @src_class)
+      @meth1  = MiqAeMethod.lookup_by_class_id_and_name(@class1.id, @src_method)
     end
 
     it 'after copy both inline methods in DB should be congruent' do
       MiqAeMethodCopy.new(@src_fqname).to_domain(@dest_domain)
-      ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@src_ns}", false)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
-      meth2  = MiqAeMethod.find_by_class_id_and_name(class2.id, @src_method)
+      ns2 = MiqAeNamespace.lookup_by_fqname("#{@dest_domain}/#{@src_ns}", false)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(ns2.id, @src_class)
+      meth2  = MiqAeMethod.lookup_by_class_id_and_name(class2.id, @src_method)
       validate_method(@meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
     end
 
     it 'after copy both builtin methods in DB should be congruent' do
       builtin_fqname = "#{@src_domain}/#{@src_ns}/#{@src_class}/#{@builtin_method}"
-      meth1  = MiqAeMethod.find_by_class_id_and_name(@class1.id, @builtin_method)
+      meth1 = MiqAeMethod.lookup_by_class_id_and_name(@class1.id, @builtin_method)
       MiqAeMethodCopy.new(builtin_fqname).to_domain(@dest_domain)
-      ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@src_ns}", false)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
-      meth2  = MiqAeMethod.find_by_class_id_and_name(class2.id, @builtin_method)
+      ns2 = MiqAeNamespace.lookup_by_fqname("#{@dest_domain}/#{@src_ns}", false)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(ns2.id, @src_class)
+      meth2 = MiqAeMethod.lookup_by_class_id_and_name(class2.id, @builtin_method)
       validate_method(meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
     end
 
     it 'overwrite an existing method' do
-      meth2  = MiqAeMethod.find_by_class_id_and_name(@class1.id, @dest_method)
+      meth2 = MiqAeMethod.lookup_by_class_id_and_name(@class1.id, @dest_method)
       validate_method(@meth1, meth2, MiqAeMethodCompare::INCOMPATIBLE_METHOD)
       MiqAeMethodCopy.new(@src_fqname).as(@dest_method, nil, true)
-      meth2  = MiqAeMethod.find_by_class_id_and_name(@class1.id, @dest_method)
+      meth2 = MiqAeMethod.lookup_by_class_id_and_name(@class1.id, @dest_method)
       validate_method(@meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
     end
 
     it 'overwrite an existing method should raise error' do
-      meth2  = MiqAeMethod.find_by_class_id_and_name(@class1.id, @dest_method)
+      meth2 = MiqAeMethod.lookup_by_class_id_and_name(@class1.id, @dest_method)
       validate_method(@meth1, meth2, MiqAeMethodCompare::INCOMPATIBLE_METHOD)
       expect { MiqAeMethodCopy.new(@src_fqname).as(@dest_method) }.to raise_error(RuntimeError)
     end
 
     it 'copy method to a different namespace in the same domain' do
       MiqAeMethodCopy.new(@src_fqname).as(@src_method, @dest_ns, true)
-      ns2 = MiqAeNamespace.find_by_fqname("#{@src_domain}/#{@dest_ns}", false)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
-      meth2  = MiqAeMethod.find_by_class_id_and_name(class2.id, @src_method)
+      ns2 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@dest_ns}", false)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(ns2.id, @src_class)
+      meth2 = MiqAeMethod.lookup_by_class_id_and_name(class2.id, @src_method)
       validate_method(@meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
     end
 
     it 'copy method to a different namespace in a different domain' do
       MiqAeMethodCopy.new(@src_fqname).to_domain(@dest_domain, @dest_ns, true)
-      ns2 = MiqAeNamespace.find_by_fqname("#{@dest_domain}/#{@dest_ns}", false)
-      class2 = MiqAeClass.find_by_namespace_id_and_name(ns2.id, @src_class)
-      meth2  = MiqAeMethod.find_by_class_id_and_name(class2.id, @src_method)
+      ns2 = MiqAeNamespace.lookup_by_fqname("#{@dest_domain}/#{@dest_ns}", false)
+      class2 = MiqAeClass.lookup_by_namespace_id_and_name(ns2.id, @src_class)
+      meth2 = MiqAeMethod.lookup_by_class_id_and_name(class2.id, @src_method)
       validate_method(@meth1, meth2, MiqAeMethodCompare::CONGRUENT_METHOD)
     end
 

--- a/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -281,7 +281,7 @@ describe MiqAeDatastore do
       it "import single user domain" do
         options = {'yaml_file' => @yaml_file}
         assert_single_domain_import(options, options)
-        dom = MiqAeDomain.find_by_fqname(@customer_domain.name, false)
+        dom = MiqAeDomain.lookup_by_fqname(@customer_domain.name, false)
         expect(dom).not_to be_enabled
       end
 
@@ -297,7 +297,7 @@ describe MiqAeDatastore do
         options = {'yaml_file' => @yaml_file}
         @customer_domain.update(:source => MiqAeDomain::SYSTEM_SOURCE)
         assert_single_domain_import(options, options)
-        dom = MiqAeDomain.find_by_fqname(@customer_domain.name, false)
+        dom = MiqAeDomain.lookup_by_fqname(@customer_domain.name, false)
         expect(dom).to be_enabled
       end
 
@@ -341,7 +341,7 @@ describe MiqAeDatastore do
       export_model(@manageiq_domain.name, export_options)
       reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts(@domain_counts)
-      dom = MiqAeDomain.find_by_fqname(@manageiq_domain.name, false)
+      dom = MiqAeDomain.lookup_by_fqname(@manageiq_domain.name, false)
       expect(dom.source).to eq(MiqAeDomain::SYSTEM_SOURCE)
       expect(dom).to be_enabled
     end
@@ -352,7 +352,7 @@ describe MiqAeDatastore do
       reset_and_import(@export_dir, @manageiq_domain.name)
       check_counts(@domain_counts)
 
-      ns = MiqAeNamespace.find_by_fqname(@manageiq_domain.name, false)
+      ns = MiqAeNamespace.lookup_by_fqname(@manageiq_domain.name, false)
       expect(ns.priority).to equal(0)
     end
 
@@ -378,7 +378,7 @@ describe MiqAeDatastore do
       reset_and_import(@export_dir, @manageiq_domain.name, import_options)
       check_counts('dom'  => 2, 'ns'    => 6,  'class' => 8,  'inst'  => 20,
                    'meth' => 8, 'field' => 24, 'value' => 16)
-      expect(MiqAeDomain.find_by_fqname(import_options['import_as'])).not_to be_nil
+      expect(MiqAeDomain.lookup_by_fqname(import_options['import_as'])).not_to be_nil
     end
 
     it "domain, using export_as (new domain name), to directory" do
@@ -402,7 +402,7 @@ describe MiqAeDatastore do
       export_model(@manageiq_domain.name, export_options)
       reset_and_import(@export_dir, @export_as, import_options)
       check_counts(@domain_counts)
-      expect(MiqAeDomain.find_by_fqname(@export_as)).not_to be_nil
+      expect(MiqAeDomain.lookup_by_fqname(@export_as)).not_to be_nil
     end
 
     it "domain, import only namespace, to directory" do
@@ -536,8 +536,8 @@ describe MiqAeDatastore do
       reset_and_import(@export_dir, @manageiq_domain.name)
       check_counts('dom'  => 1, 'ns'    => 1, 'class' => 1, 'inst'  => 2,
                    'meth' => 3, 'field' => 6, 'value' => 4)
-      @manageiq_domain = MiqAeNamespace.find_by_fqname('manageiq', false)
-      @aen1_aec1       = MiqAeClass.find_by_name('manageiq_test_class_1')
+      @manageiq_domain = MiqAeNamespace.lookup_by_fqname('manageiq', false)
+      @aen1_aec1       = MiqAeClass.lookup_by_name('manageiq_test_class_1')
       @aen1_aec1_aei2  = FactoryBot.create(:miq_ae_instance,
                                             :name     => 'test_instance3',
                                             :class_id => @aen1_aec1.id)
@@ -620,8 +620,8 @@ describe MiqAeDatastore do
     end
 
     def assert_method_data(name, location, data)
-      aen1_aec1  = MiqAeClass.find_by_name('manageiq_test_class_1')
-      method = MiqAeMethod.find_by_class_id_and_name(aen1_aec1.id, name)
+      aen1_aec1 = MiqAeClass.lookup_by_name('manageiq_test_class_1')
+      method = MiqAeMethod.lookup_by_class_id_and_name(aen1_aec1.id, name)
       expect(method.location).to eql location
       expect(method.data).to eq(data)
     end
@@ -666,11 +666,11 @@ describe MiqAeDatastore do
       @customer_domain.update(:enabled => true)
       export_model(MiqAeYamlImportExportMixin::ALL_DOMAINS, export_options)
       reset_and_import(@export_dir, MiqAeYamlImportExportMixin::ALL_DOMAINS, import_options)
-      expect(MiqAeDomain.find_by_fqname(@manageiq_domain.name, false).priority).to eql(0)
-      cust_domain = MiqAeDomain.find_by_fqname(@customer_domain.name, false)
+      expect(MiqAeDomain.lookup_by_fqname(@manageiq_domain.name, false).priority).to eql(0)
+      cust_domain = MiqAeDomain.lookup_by_fqname(@customer_domain.name, false)
       expect(cust_domain.priority).to eql(1)
       expect(cust_domain).to be_enabled
-      expect(MiqAeNamespace.find_by_fqname('$', false)).not_to be_nil
+      expect(MiqAeNamespace.lookup_by_fqname('$', false)).not_to be_nil
     end
   end
 
@@ -908,8 +908,8 @@ describe MiqAeDatastore do
     @manageiq_domain = MiqAeDomain.find_by_name("manageiq")
     @aen1            = MiqAeNamespace.find_by_name('manageiq_namespace_1')
     @aen1_1          = MiqAeNamespace.find_by_name('manageiq_namespace_1_1')
-    @aen1_aec1       = MiqAeClass.find_by_name('manageiq_test_class_1')
-    @aen1_aec2       = MiqAeClass.find_by_name('manageiq_test_class_2')
+    @aen1_aec1       = MiqAeClass.lookup_by_name('manageiq_test_class_1')
+    @aen1_aec2       = MiqAeClass.lookup_by_name('manageiq_test_class_2')
     @class_dir       = "#{@aen1_aec1.fqname}.class"
     @class_file      = File.join(@export_dir, @class_dir, '__class__.yaml')
     @instance_file   = File.join(@export_dir, @class_dir, 'manageiq_test_instance1.yaml')
@@ -920,8 +920,8 @@ describe MiqAeDatastore do
     @customer_domain    = MiqAeDomain.find_by_name("customer")
     @customer_aen1      = MiqAeNamespace.find_by_name('customer_namespace_1')
     @customer_aen1_1    = MiqAeNamespace.find_by_name('customer_namespace_1_1')
-    @customer_aen1_aec1 = MiqAeClass.find_by_name('customer_test_class_1')
-    @customer_aen1_aec2 = MiqAeClass.find_by_name('customer_test_class_2')
+    @customer_aen1_aec1 = MiqAeClass.lookup_by_name('customer_test_class_1')
+    @customer_aen1_aec2 = MiqAeClass.lookup_by_name('customer_test_class_2')
     @class_name         = @customer_aen1_aec1.name
   end
 
@@ -954,7 +954,7 @@ describe MiqAeDatastore do
   end
 
   def validate_additional_columns
-    klass = MiqAeClass.find_by_name(@class_name)
+    klass = MiqAeClass.lookup_by_name(@class_name)
     return unless klass
     klass.ae_instances.each do |inst|
       inst.ae_values.select { |v| v.value == @relations_value }.each do |rel|


### PR DESCRIPTION
The find_by_* methods defined in manageiq repo has conflicts with
rails dynamic finding and now they have been changed to lookup_by_*.
Switching the callers in this repo to the lookup_by_* methods.

Depend on https://github.com/ManageIQ/manageiq/pull/19313

@miq-bot add_label ivanchuk/no, changelog/yes, refactoring