### PR TITLE
Bump version to 1.3.0 for CVE-2019-16892

### DIFF
--- a/manageiq-automation_engine.gemspec
+++ b/manageiq-automation_engine.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
-  s.add_dependency "rubyzip", "~>1.2.2"
+  s.add_dependency "rubyzip", "~>1.3.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
includes rubyzip/rubyzip#403

needed for https://github.com/ManageIQ/manageiq/pull/19348

@jrafanie could you please take a look? 