### PR TITLE
Set validate_entry_sizes flag to true for rubyzip 1.3.0

### DIFF
--- a/app/models/miq_ae_yaml_export_zipfs.rb
+++ b/app/models/miq_ae_yaml_export_zipfs.rb
@@ -19,6 +19,9 @@ class MiqAeYamlExportZipfs < MiqAeYamlExport
 
   def export
     require 'zip/filesystem'
+    # we need to set this flag to true until we can upgrade to rubyzip 2.0.0
+    # see https://github.com/rubyzip/rubyzip/pull/403#issue-317103816
+    Zip.validate_entry_sizes = true
 
     Zip::File.open(@temp_file_name, Zip::File::CREATE) do |zf|
       @zip_file = zf

--- a/app/models/miq_ae_yaml_import_zipfs.rb
+++ b/app/models/miq_ae_yaml_import_zipfs.rb
@@ -7,6 +7,9 @@ class MiqAeYamlImportZipfs < MiqAeYamlImport
 
   def load_zip
     require 'zip/filesystem'
+    # we need to set this flag to true until we can upgrade to rubyzip 2.0.0
+    # see https://github.com/rubyzip/rubyzip/pull/403#issue-317103816
+    Zip.validate_entry_sizes = true
 
     raise MiqAeException::FileNotFound, "import file: #{@options['zip_file']} not found" \
       unless File.exist?(@options['zip_file'])

--- a/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -976,6 +976,10 @@ describe MiqAeDatastore do
 
   def create_bogus_zip_file
     require 'zip/filesystem'
+    # we need to set this flag to true until we can upgrade to rubyzip 2.0.0
+    # see https://github.com/rubyzip/rubyzip/pull/403#issue-317103816
+    Zip.validate_entry_sizes = true
+
     Zip::File.open(@zip_file, Zip::File::CREATE) do |zh|
       zh.file.open("first.txt", "w") { |f| f.puts "Hello world" }
       zh.dir.mkdir("mydir")


### PR DESCRIPTION
Per conversation with Satoe and LJ, we should set this flag because we're not ready to update to rubyzip 2.0.0; they set it to false by default in 1.3.0 for backwards compatibility. 

The flag must be set in order to use the validation against zip bombs described in rubyzip/rubyzip#403.

See main repo PR https://github.com/ManageIQ/manageiq/pull/19360