### PR TITLE
Test ruby 2.5.7/2.6.5, see: ManageIQ/manageiq#19414

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+---
 dist: xenial
 language: ruby
 rvm:
-- 2.4.6
-- 2.5.3
+- 2.5.7
+- 2.6.5
 sudo: false
 cache: bundler
 env:

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -863,7 +863,7 @@ describe MiqAeEngine do
       expect(test_class).to receive(:find_by!).with(any_args).and_return(test_class_instance)
       allow(MiqAeEngine).to receive(:create_automation_attribute_key)
       expect(MiqAeEngine._log).to receive(:error)
-        .with("Error delivering {\"User::user\"=>#{user.id}, nil=>nil} for object [TestClass.] with state [] to Automate: bad URI(is not URI?): _ wrong_uri _")
+        .with(/Error delivering {\"User::user\"=>#{user.id}, nil=>nil} for object \[TestClass.\] with state \[\] to Automate: bad URI/)
       MiqAeEngine.deliver(options)
     end
 


### PR DESCRIPTION
* Test ruby 2.5.7/2.6.5, see: ManageIQ/manageiq#19414
* Fix a test to be less strict about the URI error syntax since it was changed in
2.6.