### PR TITLE
Model InfraManager_EmsCluster was renamed to InfraManager_Cluster

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_legacy.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_legacy.rb
@@ -59,7 +59,7 @@ module MiqAeMethodService
       'vm_openstack'                                 => 'ManageIQ_Providers_Openstack_CloudManager_Vm',
       'ems_openstack'                                => 'ManageIQ_Providers_Openstack_CloudManager',
       # Openstack Infra
-      'ems_cluster_openstack_infra'                  => 'ManageIQ_Providers_Openstack_InfraManager_EmsCluster',
+      'ems_cluster_openstack_infra'                  => 'ManageIQ_Providers_Openstack_InfraManager_Cluster',
       'host_openstack_infra'                         => 'ManageIQ_Providers_Openstack_InfraManager_Host',
       'orchestration_stack_openstack_infra'          => 'ManageIQ_Providers_Openstack_InfraManager_OrchestrationStack',
       'ems_openstack_infra'                          => 'ManageIQ_Providers_Openstack_InfraManager',


### PR DESCRIPTION
Followup from changes in https://github.com/ManageIQ/manageiq-providers-ovirt/pull/418
and https://github.com/ManageIQ/manageiq/pull/19429

Fixes failing tests on master branch: https://travis-ci.org/ManageIQ/manageiq-automation_engine/builds/605863275