### PR TITLE
Reducing the amount of data being stored in yaml file for svc_models

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -367,6 +367,15 @@ module MiqAeMethodService
       self.class == other.class && id == other.id
     end
 
+    def encode_with(coder)
+      coder['id'] = id
+    end
+
+    def init_with(coder)
+      @object = self.class.service_model_name_to_model(self.class.name)&.find_by(:id => coder['id'])
+      self
+    end
+
     private
 
     def verify_taggable_model

--- a/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
@@ -94,6 +94,30 @@ describe MiqAeMethodService::MiqAeServiceModelBase do
     end
   end
 
+  describe 'YAML import/export' do
+    let(:service)     { FactoryBot.create(:service, :name => 'test_service') }
+    let(:svc_service) { MiqAeMethodService::MiqAeServiceService.find(service.id) }
+
+    it 'exports only class name and ID' do
+      expect(svc_service.to_yaml)
+        .to eq("--- !ruby/object:#{svc_service.class.name}\nid: #{svc_service.id}\n")
+    end
+
+    it 'loads object from yaml' do
+      expect(YAML.safe_load(svc_service.to_yaml)).to eq(svc_service)
+    end
+
+    it 'loads invalid svc_model for objects without related ar_model' do
+      yaml = svc_service.to_yaml
+      service.delete
+      model_from_yaml = YAML.safe_load(yaml)
+      expect { model_from_yaml.reload }.to raise_error(
+        NoMethodError,
+        "undefined method `reload' for nil:NilClass"
+      )
+    end
+  end
+
   context 'with a VM service model' do
     let(:service_model) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_InfraManager_Vm }
 


### PR DESCRIPTION
This PR modifies the amount of data for automate service models YAML export. From now we will store only the class name and ID of related active_record object. The rest of the information will be loaded from related ar_model.

Based on https://github.com/ManageIQ/manageiq-automation_engine/issues/385