### PR TITLE
[HAMMER] Fix manageiq-content specs on hammer

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_template_ansible_playbook.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_template_ansible_playbook.rb
@@ -1,5 +1,6 @@
 module MiqAeMethodService
   class MiqAeServiceServiceTemplateAnsiblePlaybook < MiqAeServiceServiceTemplateGeneric
+    expose :config_info, :association => true
     expose :job_template
   end
 end


### PR DESCRIPTION
(Note:  Marked as `[WIP]` until it is determined that https://github.com/ManageIQ/manageiq-content/pull/559 is safe to stay in `hammer` as is [ [ref](https://github.com/ManageIQ/manageiq-content/pull/559#issuecomment-554580025) ] )

The following PR was recently backported to `hammer`:

https://github.com/ManageIQ/manageiq-content/pull/559

This made use of the `config_info` association to accomplish its goals.  It was possible to use this method without the changes made here since a PR was merged and available as of `ivanchuk` that exposed all service associations to Miq AE service models:

https://github.com/ManageIQ/manageiq-automation_engine/pull/308

But that PR was not merged to `hammer`.  Do to the risk of backporting that PR, this is a one off addition to allow the functionality of ManageIQ/manageiq-content#559 (low risk) to function without requiring a backport of everything in ManageIQ/manageiq-automation_engine#308 (high risk).


Links
-----

* Failing test run:  https://travis-ci.org/ManageIQ/manageiq-content/builds/612036937
* Offending PR: https://github.com/ManageIQ/manageiq-content/pull/559
* PR allowing the above to work on `master`/`ivanchuk`:  https://github.com/ManageIQ/manageiq-automation_engine/pull/308