### PR TITLE
Disable streaming_refresh in MiqAeServiceEmsEvent spec and fix CI

### DIFF
--- a/spec/service_models/miq_ae_service_ems_event_spec.rb
+++ b/spec/service_models/miq_ae_service_ems_event_spec.rb
@@ -1,5 +1,7 @@
 describe MiqAeMethodService::MiqAeServiceEmsEvent do
   before do
+    Settings.ems_refresh.vmwarews.streaming_refresh = false
+
     @ems           = FactoryBot.create(:ems_vmware_with_authentication,
                                         :zone => FactoryBot.create(:zone)
                                        )


### PR DESCRIPTION
In those tests, we are testing whether method  `EmsRefresh.queue_refresh` was called with certain parameters when method  [`EmsEvent::Automate.refresh`](https://github.com/ManageIQ/manageiq-automation_engine/blob/baeea09c1241fefda279ebeff139177040ccbca5/spec/service_models/miq_ae_service_ems_event_spec.rb#L24) is called.

`EmsEvent::Automate.refresh` has [guard condition](https://github.com/ManageIQ/manageiq/blob/c79c6219d51dbb8aaa385a2acd3c28adfda3a739/app/models/ems_event/automate.rb#L14) and when `Settings.ems_refresh.vmwarews.streaming_refresh = true` - no code from `EmsEvent::Automate.refresh`  is executed and there is method `EmsRefresh.queue_refresh` called and we call the method for test.

Before https://github.com/ManageIQ/manageiq-providers-vmware/pull/434 we were using `Settings.prototype.ems_vmware.update_driven_refresh` and it was to `nil` or `false` and then guard did not apply.



## Links
CI failure: https://travis-ci.com/ManageIQ/manageiq-cross_repo-tests/jobs/263025345 
Caused by: https://github.com/ManageIQ/manageiq-providers-vmware/pull/434

@miq-bot add_label test

@miq-bot assign @gmcculloug 