### PR TITLE
Changing the automate datastore import validation.

### DIFF
--- a/app/models/miq_ae_git_import.rb
+++ b/app/models/miq_ae_git_import.rb
@@ -22,7 +22,10 @@ class MiqAeGitImport
 
   def single_domain_import
     import_service = MiqAeYamlImportGitfs.new(@options['domain'] || '*', @options)
-    raise MiqAeException::InvalidDomain, _("multiple domains") if import_service.domain_files('*').size > 1
+    if import_service.domain_files('*').size > 1
+      raise MiqAeException::InvalidDomain, _("Multiple Domain import is not supported.")
+    end
+
     import_service.import
   end
 

--- a/app/models/miq_ae_yaml_import.rb
+++ b/app/models/miq_ae_yaml_import.rb
@@ -15,10 +15,6 @@ class MiqAeYamlImport
   def import
     if @options.key?('import_dir') && !File.directory?(@options['import_dir'])
       raise MiqAeException::DirectoryNotFound, "Directory [#{@options['import_dir']}] not found"
-    elsif (!User.current_user.nil? && @options['zip_file'] && domain_locked?(@options['import_as'])) ||
-          (@options['git_repository_id'] && system_domain?(File.dirname(sorted_domain_files.first)))
-      # exception for local import into the locked domain or git import into the base system domain
-      raise MiqAeException::DomainNotAccessible, 'locked domain'
     end
     start_import(@options['preview'], @domain_name)
   end
@@ -77,10 +73,31 @@ class MiqAeYamlImport
     domains.keys.sort_by { |k| domains[k] }
   end
 
+  def preimport_check(domain_name, source_dom_source, dest_dom_source)
+    dest_domain_name = @options['import_as'] == '*' || @options['import_as'].nil? ? @domain_name : @options['import_as']
+    if source_dom_source == MiqAeDomain::SYSTEM_SOURCE
+      if @options['git_repository_id']
+        raise MiqAeException::InvalidDomain, _('Git based system domain import is not supported.')
+      elsif !base_domain?(domain_name)
+        raise MiqAeException::InvalidDomain, _('System domain import is not supported.')
+      elsif domain_name != dest_domain_name
+        raise MiqAeException::InvalidDomain, _('Domain name change for a system domain import is not supported.')
+      end
+    elsif domain_locked?(dest_domain_name)
+      if @options['git_repository_id'] && dest_dom_source == MiqAeDomain::SYSTEM_SOURCE
+        raise MiqAeException::DomainNotAccessible, _('Git based system domain import is not supported.')
+      elsif @options['zip_file'] || (@options['git_repository_id'] && system_domain?(dest_domain_name))
+        raise MiqAeException::DomainNotAccessible, _('Cannot import into a locked domain.')
+      end
+    end
+  end
+
   def import_domain(domain_folder, domain_name)
     domain_yaml = domain_properties(domain_folder, domain_name)
     domain_name = domain_yaml.fetch_path('object', 'attributes', 'name')
+    domain_source = domain_yaml.fetch_path('object', 'attributes', 'source')
     domain_obj = MiqAeDomain.lookup_by_fqname(domain_name, false)
+    preimport_check(domain_folder, domain_source, domain_obj&.source) unless User.current_user.nil?
     track_stats('domain', domain_obj)
     MiqAeDomain.transaction do
       if domain_obj && !@preview && @options['overwrite']
@@ -325,5 +342,9 @@ class MiqAeYamlImport
 
   def system_domain?(domain_name)
     MiqAeDomain.find_by(:name => domain_name)&.source == MiqAeDomain::SYSTEM_SOURCE
+  end
+
+  def base_domain?(domain_name)
+    MiqAeDatastore.default_domain_names.include?(domain_name)
   end
 end

--- a/spec/models/miq_ae_git_import_spec.rb
+++ b/spec/models/miq_ae_git_import_spec.rb
@@ -106,7 +106,7 @@ describe MiqAeGitImport do
             .and_return(miq_ae_yaml_import_gitfs)
           allow(miq_ae_yaml_import_gitfs).to receive(:domain_files) { ['BB8/__domain__.yaml', 'BB8/__domain__.yaml'] }
           expect { miq_ae_git_import.import }.to raise_exception(
-            MiqAeException::InvalidDomain, 'multiple domains'
+            MiqAeException::InvalidDomain, 'Multiple Domain import is not supported.'
           )
         end
       end

--- a/spec/models/miq_ae_yaml_import_spec.rb
+++ b/spec/models/miq_ae_yaml_import_spec.rb
@@ -2,7 +2,7 @@ describe MiqAeYamlImport do
   let(:domain) { "domain" }
   let(:options) { {} }
   let(:miq_ae_yaml_import) { described_class.new(domain, options) }
-  let(:options) { {"overwrite" => true, "tenant" => Tenant.root_tenant} }
+  let(:options) { {"overwrite" => true, "tenant" => Tenant.root_tenant, 'zip_file' => 'file'} }
 
   before do
     EvmSpecHelper.local_guid_miq_server_zone
@@ -35,6 +35,137 @@ describe MiqAeYamlImport do
         expect { miq_ae_yaml_import.import }.to raise_exception(ArgumentError)
         dom.reload
         expect(dom.ae_namespaces.first.id).to eq(ns.id)
+      end
+    end
+  end
+
+  describe "#import" do
+    let(:user) { FactoryBot.create(:user_with_group) }
+    let(:path) { "path" }
+    let(:dom_yaml) do
+      {
+        "object_type" => "domain",
+        "version"     => 1.0,
+        "object"      => {
+          "attributes" => {
+            "name"                => domain,
+            "description"         => nil,
+            "display_name"        => nil,
+            "source"              => source,
+            "top_level_namespace" => nil
+          }
+        }
+      }
+    end
+
+    before do
+      allow(miq_ae_yaml_import).to receive(:domain_folder).with(domain).and_return(path)
+      allow(miq_ae_yaml_import).to receive(:namespace_files).with(path) { [] }
+      allow(miq_ae_yaml_import).to receive(:read_domain_yaml).with(path, domain) { dom_yaml }
+      User.current_user = user
+    end
+
+    def basic_validation(attributes = {})
+      att = { :name => domain, :source => source }.merge(attributes)
+      expect(MiqAeDomain.all.count).to eq(1)
+      dom = MiqAeDomain.last
+      expect(dom.name).to eq(att[:name])
+      expect(dom.source).to eq(att[:source])
+    end
+
+    def create_test_domain(attributes = {})
+      att = { :name => domain, :source => source }.merge(attributes)
+      MiqAeDomain.create(att).save!
+      FactoryBot.create(:miq_ae_namespace, :parent => MiqAeDomain.last)
+    end
+
+    context 'user source' do
+      let(:source) { 'user' }
+
+      it 'imports domain' do
+        miq_ae_yaml_import.import
+        basic_validation
+      end
+
+      it 'overwrites existing domains' do
+        create_test_domain
+        dom = miq_ae_yaml_import.import
+        expect(dom.children).to eq([])
+        basic_validation
+      end
+
+      it 'overwrites locked domains from git' do
+        create_test_domain(:source => "#{source}_locked")
+        options['zip_file'] = nil
+        options['git_repository_id'] = 1
+        dom = miq_ae_yaml_import.import
+        expect(dom.children).to eq([])
+        basic_validation(:source => "#{source}_locked")
+      end
+
+      it 'does not import into locked domain' do
+        create_test_domain(:source => "#{source}_locked")
+        expect { miq_ae_yaml_import.import }
+          .to raise_error(MiqAeException::DomainNotAccessible, 'Cannot import into a locked domain.')
+      end
+
+      it 'does not overwrite system domains from git' do
+        options['zip_file'] = nil
+        options['git_repository_id'] = 1
+        create_test_domain(:source => "system")
+        expect { miq_ae_yaml_import.import }
+          .to raise_error(MiqAeException::DomainNotAccessible, 'Git based system domain import is not supported.')
+      end
+    end
+
+    context 'system source' do
+      let(:source) { 'system' }
+      let(:domain) { 'ManageIQ' }
+      let(:path)   { domain }
+
+      it 'imports domain' do
+        miq_ae_yaml_import.import
+        basic_validation
+      end
+
+      it 'overwrites existing domains' do
+        create_test_domain
+        dom = miq_ae_yaml_import.import
+        expect(dom.children).to eq([])
+        basic_validation
+      end
+
+      it 'does not import system domains from git' do
+        options['zip_file'] = nil
+        options['git_repository_id'] = 1
+        expect { miq_ae_yaml_import.import }
+          .to raise_error(MiqAeException::InvalidDomain, 'Git based system domain import is not supported.')
+      end
+
+      context 'with custom name' do
+        let(:domain) { 'path' }
+        let(:path)   { domain }
+
+        it 'does not import' do
+          expect { miq_ae_yaml_import.import }
+            .to raise_error(MiqAeException::InvalidDomain, 'System domain import is not supported.')
+        end
+      end
+
+      context 'with different destination name' do
+        let(:options) do
+          {
+            "overwrite" => true,
+            "tenant"    => Tenant.root_tenant,
+            'zip_file'  => 'file',
+            'import_as' => 'different_name'
+          }
+        end
+
+        it 'does not import' do
+          expect { miq_ae_yaml_import.import }
+            .to raise_error(MiqAeException::InvalidDomain, 'Domain name change for a system domain import is not supported.')
+        end
       end
     end
   end


### PR DESCRIPTION
Increasing amount of checks for the automate import validation. 

Since it is not allowed to remove any automate system domain from the UI, we are removing an option to import your custom system domains into the datastore. PR also includes some refactoring of the validation checks and the error message creation logic. It is based on https://bugzilla.redhat.com/show_bug.cgi?id=1753586 and it is related to https://github.com/ManageIQ/manageiq-ui-classic/pull/6434

Diagram bellow shows the validation logic for the automate import:
![Diagram](https://user-images.githubusercontent.com/19405716/70298091-bb49fe80-17f0-11ea-8168-57385fb4622b.png)
