### PR TITLE
Test an EMS that doesn't use streaming refresh

### DIFF
--- a/spec/service_models/miq_ae_service_ems_event_spec.rb
+++ b/spec/service_models/miq_ae_service_ems_event_spec.rb
@@ -1,9 +1,7 @@
 describe MiqAeMethodService::MiqAeServiceEmsEvent do
   before do
-    @ems           = FactoryBot.create(:ems_vmware_with_authentication,
-                                        :zone => FactoryBot.create(:zone)
-                                       )
-    @vm            = FactoryBot.create(:vm_vmware)
+    @ems           = FactoryBot.create(:ems_redhat_with_authentication, :zone => FactoryBot.create(:zone))
+    @vm            = FactoryBot.create(:vm_redhat)
     @ems_event     = FactoryBot.create(:ems_event,
                                         :vm_or_template        => @vm,
                                         :ext_management_system => @ems


### PR DESCRIPTION
Test the EmsEvent refresh handler with an EMS that doesn't use streaming
refresh.

Alternative to: https://github.com/ManageIQ/manageiq-automation_engine/pull/394