### PR TITLE
Update rubyzip to 2.0.0

### DIFF
--- a/app/models/miq_ae_yaml_export_zipfs.rb
+++ b/app/models/miq_ae_yaml_export_zipfs.rb
@@ -18,11 +18,6 @@ class MiqAeYamlExportZipfs < MiqAeYamlExport
   end
 
   def export
-    require 'zip/filesystem'
-    # we need to set this flag to true until we can upgrade to rubyzip 2.0.0
-    # see https://github.com/rubyzip/rubyzip/pull/403#issue-317103816
-    Zip.validate_entry_sizes = true
-
     Zip::File.open(@temp_file_name, Zip::File::CREATE) do |zf|
       @zip_file = zf
       write_model

--- a/app/models/miq_ae_yaml_import_zipfs.rb
+++ b/app/models/miq_ae_yaml_import_zipfs.rb
@@ -6,11 +6,6 @@ class MiqAeYamlImportZipfs < MiqAeYamlImport
   end
 
   def load_zip
-    require 'zip/filesystem'
-    # we need to set this flag to true until we can upgrade to rubyzip 2.0.0
-    # see https://github.com/rubyzip/rubyzip/pull/403#issue-317103816
-    Zip.validate_entry_sizes = true
-
     raise MiqAeException::FileNotFound, "import file: #{@options['zip_file']} not found" \
       unless File.exist?(@options['zip_file'])
     @zip = Zip::File.open(@options['zip_file'])

--- a/manageiq-automation_engine.gemspec
+++ b/manageiq-automation_engine.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
-  s.add_dependency "rubyzip", "~>1.3.0"
+  s.add_dependency "rubyzip", "~>2.0.0"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"

--- a/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -975,11 +975,6 @@ describe MiqAeDatastore do
   end
 
   def create_bogus_zip_file
-    require 'zip/filesystem'
-    # we need to set this flag to true until we can upgrade to rubyzip 2.0.0
-    # see https://github.com/rubyzip/rubyzip/pull/403#issue-317103816
-    Zip.validate_entry_sizes = true
-
     Zip::File.open(@zip_file, Zip::File::CREATE) do |zh|
       zh.file.open("first.txt", "w") { |f| f.puts "Hello world" }
       zh.dir.mkdir("mydir")


### PR DESCRIPTION
We're currently using rubyzip 1.3.0 with "Zip.validate_entry_sizes = true" to address CVE-2019-16892 and should fix it.

Tested the automate side.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1781195
and ManageIQ/manageiq#19622 

## Depends on 
https://github.com/ManageIQ/manageiq/pull/19629