### PR TITLE
Warning message for imported service models related to non-existing ar_models

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -360,6 +360,8 @@ module MiqAeMethodService
     end
 
     def ar_method(&block)
+      return if @object.nil?
+
       self.class.ar_method(&block)
     end
 
@@ -373,6 +375,8 @@ module MiqAeMethodService
 
     def init_with(coder)
       @object = self.class.service_model_name_to_model(self.class.name)&.find_by(:id => coder['id'])
+      $miq_ae_logger.warn("There is no related active record object with id=#{coder['id']} for imported #{self.class}") if @object.nil?
+
       self
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -320,6 +320,8 @@ module MiqAeMethodService
     end
 
     def reload
+      raise ActiveRecord::RecordNotFound, "Couldn't find related ActiveRecord object" unless record_exists?
+
       object_send(:reload)
       self # Return self to prevent the internal object from being returned
     end

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -380,6 +380,10 @@ module MiqAeMethodService
       self
     end
 
+    def record_exists?
+      @object.present?
+    end
+
     private
 
     def verify_taggable_model

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -263,7 +263,7 @@ module MiqAeMethodService
         raise ArgumentError, "#{ar_klass.name} Object expected, but received #{obj.class.name}"
       end
 
-      @object = obj.kind_of?(ar_klass) ? obj : ar_method { ar_klass.find_by(:id => obj) }
+      @object = obj.kind_of?(ar_klass) ? obj : self.class.ar_method { ar_klass.find_by(:id => obj) }
       raise MiqAeException::ServiceNotFound, "#{ar_klass.name} Object [#{obj}] not found" if @object.nil?
     end
 

--- a/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
@@ -111,10 +111,8 @@ describe MiqAeMethodService::MiqAeServiceModelBase do
       yaml = svc_service.to_yaml
       service.delete
       model_from_yaml = YAML.safe_load(yaml, [MiqAeMethodService::MiqAeServiceService])
-      expect { model_from_yaml.reload }.to raise_error(
-        NoMethodError,
-        "undefined method `reload' for nil:NilClass"
-      )
+      expect(model_from_yaml.class).to eq(svc_service.class)
+      expect(model_from_yaml.record_exists?).to eq(false)
     end
   end
 


### PR DESCRIPTION
Adding the warning message for importing service models for non-existing active record objects. PR also includes the name changing for one of the service model method from 'ar_model_present?' to '#record_exists?'

this PR is based on https://github.com/ManageIQ/manageiq-automation_engine/issues/385#issuecomment-553672232