### PR TITLE
Add cc and bcc into builtin method send_email's inputs fields.

### DIFF
--- a/app/models/miq_ae_datastore.rb
+++ b/app/models/miq_ae_datastore.rb
@@ -159,7 +159,9 @@ module MiqAeDatastore
     email_method.inputs.build([{:name => 'to',      :priority => 1, :datatype => 'string'},
                                {:name => 'from',    :priority => 2, :datatype => 'string'},
                                {:name => 'subject', :priority => 3, :datatype => 'string'},
-                               {:name => 'body',    :priority => 4, :datatype => 'string'}])
+                               {:name => 'body',    :priority => 4, :datatype => 'string'},
+                               {:name => 'cc',      :priority => 5, :datatype => 'array'},
+                               {:name => 'bcc',     :priority => 6, :datatype => 'array'}])
     email_method.save!
   end
 


### PR DESCRIPTION
Fix an issue where CC and BCC email address are not being sent.

https://bugzilla.redhat.com/show_bug.cgi?id=1783511

@miq-bot add_label bug, hammer/yes, ivanchuk/yes, changelog/yes