### PR TITLE
State var yaml to binary blob

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -18,7 +18,7 @@ module MiqAeEngine
       @datastore_cache   = {}
       @class_methods     = {}
       @dom_search        = MiqAeDomainSearch.new
-      @persist_state_hash = HashWithIndifferentAccess.new
+      @persist_state_hash = StateVarHash.new
       @current_state_info = {}
       @state_machine_objects = []
       @ae_user = nil

--- a/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
@@ -1,0 +1,27 @@
+module MiqAeEngine
+  class StateVarHash < HashWithIndifferentAccess
+    SERIALIZE_KEY = 'binary_blob_id'.freeze
+
+    def encode_with(coder)
+      coder[SERIALIZE_KEY] =
+        blank? ? 0 : BinaryBlob.new.tap { |bb| bb.store_data("YAML", to_h) }.id
+    end
+
+    def init_with(coder)
+      return if coder[SERIALIZE_KEY].zero?
+
+      binary_blob = BinaryBlob.find_by(:id => coder[SERIALIZE_KEY])
+      if binary_blob
+        blob_hash = binary_blob.data
+        binary_blob.destroy
+
+        $miq_ae_logger.info("Reloading state var data: #{blob_hash.to_yaml}")
+        update(blob_hash)
+      else
+        $miq_ae_logger.warn("Failed to load BinaryBlob with ID [#{coder[SERIALIZE_KEY]}] for #{self.class.name}")
+      end
+
+      self
+    end
+  end
+end

--- a/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
@@ -339,7 +339,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
     let(:workspace) do
       double("MiqAeEngine::MiqAeWorkspaceRuntime",
              :root               => options,
-             :persist_state_hash => {},
+             :persist_state_hash => MiqAeEngine::StateVarHash.new,
              :ae_user            => user)
     end
     let(:miq_ae_service) { MiqAeMethodService::MiqAeService.new(workspace) }
@@ -360,7 +360,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
     let(:workspace) do
       double("MiqAeEngine::MiqAeWorkspaceRuntime",
              :root               => options,
-             :persist_state_hash => {},
+             :persist_state_hash => MiqAeEngine::StateVarHash.new,
              :ae_user            => user)
     end
     let(:miq_ae_service) { MiqAeMethodService::MiqAeService.new(workspace) }

--- a/spec/engine/miq_ae_state_machine_retry_spec.rb
+++ b/spec/engine/miq_ae_state_machine_retry_spec.rb
@@ -184,7 +184,7 @@ describe "MiqAeStateMachineRetry" do
 
   it "check persistent hash" do
     setup_model(method_script_state_var)
-    expected = {'three' => 3, 'one'  => 1, 'two'  => 2, 'gravy' => 'train'}
+    expected = MiqAeEngine::StateVarHash.new('three' => 3, 'one' => 1, 'two' => 2, 'gravy' => 'train')
     send_ae_request_via_queue(@automate_args)
     status, _message, ws = deliver_ae_request_from_queue
     expect(status).not_to eq(MiqQueue::STATUS_ERROR)
@@ -280,6 +280,6 @@ describe "MiqAeStateMachineRetry" do
     expect(MiqQueue.count).to eq(2)
     q = MiqQueue.where(:state => 'ready').first
     expect(q[:server_guid]).to be_nil
-    expect(YAML.load(q.args.first[:ae_state_data])).to eq(ae_state_data)
+    expect(YAML.safe_load(q.args.first[:ae_state_data], [MiqAeEngine::StateVarHash])).to eq(ae_state_data)
   end
 end

--- a/spec/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash_spec.rb
@@ -1,0 +1,59 @@
+describe MiqAeEngine::StateVarHash do
+  let!(:start_var_hash) { MiqAeEngine::StateVarHash.new }
+
+  describe 'with an empty hash' do
+    let(:blank_yaml_string) { "--- !ruby/object:MiqAeEngine::StateVarHash\nbinary_blob_id: 0\n" }
+
+    it 'should return a blob id of zero' do
+      expect(YAML.dump(start_var_hash)).to eq(blank_yaml_string)
+    end
+
+    it 'should return an empty hash struct without calling BinaryBlob find' do
+      expect(BinaryBlob).to_not receive(:find_by)
+
+      new_start_var_hash = YAML.safe_load(blank_yaml_string, [MiqAeEngine::StateVarHash])
+
+      expect(new_start_var_hash).to be_a(MiqAeEngine::StateVarHash)
+      expect(new_start_var_hash).to be_blank
+    end
+  end
+
+  describe 'with hash entries' do
+    let(:state_var_hash) { MiqAeEngine::StateVarHash.new(:x => 1, 'y' => 'two') }
+
+    it 'should create a binary blob entry with YAML.dump' do
+      expect(BinaryBlob.count).to be_zero
+
+      matcher = /binary_blob_id: (?<blob_id>\d*)/.match(YAML.dump(state_var_hash))
+
+      expect(BinaryBlob.pluck(:id, :data_type)).to eq([[matcher[:blob_id].to_i, "YAML"]])
+    end
+
+    it 'should delete binary_blob when loaded' do
+      yaml_out = YAML.dump(state_var_hash)
+      expect(BinaryBlob.count).to be(1)
+
+      YAML.safe_load(yaml_out, [MiqAeEngine::StateVarHash])
+      expect(BinaryBlob.count).to be_zero
+    end
+
+    it 'should create a new copy of the original hash object when reloaded' do
+      expect($miq_ae_logger).to receive(:info).with(/Reloading state var data/).and_call_original
+
+      new_start_var_hash = YAML.safe_load(YAML.dump(state_var_hash), [MiqAeEngine::StateVarHash])
+
+      expect(new_start_var_hash).to eq(state_var_hash)
+      expect(new_start_var_hash.object_id).to_not eq(start_var_hash.object_id)
+    end
+
+    it 'should log a warning and return empty hash if binary_blob instance is not found' do
+      yaml_out = YAML.dump(state_var_hash)
+      BinaryBlob.destroy_all
+
+      expect($miq_ae_logger).to receive(:warn).with(/Failed to load BinaryBlob with ID/).and_call_original
+
+      restored_state_var = YAML.safe_load(yaml_out, [MiqAeEngine::StateVarHash])
+      expect(restored_state_var).to eq({})
+    end
+  end
+end

--- a/spec/miq_ae_ansible_template_method_spec.rb
+++ b/spec/miq_ae_ansible_template_method_spec.rb
@@ -5,7 +5,7 @@ describe MiqAeEngine::MiqAeAnsibleTemplateMethod do
     let(:aw) { FactoryBot.create(:automate_workspace, :user => user, :tenant => user.current_tenant) }
     let(:root_hash) { { 'name' => 'Flintstone' } }
     let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
-    let(:persist_hash) { {} }
+    let(:persist_hash) { MiqAeEngine::StateVarHash.new }
     let(:options) { {"test" => 13} }
     let(:method_name) { "Freddy Kreuger" }
     let(:method_key) { "FreddyKreuger_ansible_method_task_id" }

--- a/spec/miq_ae_deserialize_workspace_spec.rb
+++ b/spec/miq_ae_deserialize_workspace_spec.rb
@@ -5,7 +5,7 @@ describe "MiqAeDeserializeWorkspace" do
       attr_reader :persist_state_hash
       def initialize(workspace)
         @workspace = workspace
-        @persist_state_hash = {}
+        @persist_state_hash = MiqAeEngine::StateVarHash.new
       end
 
       def root

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -151,7 +151,7 @@ describe MiqAeEngine do
           root = {'ae_result' => 'retry'}
           @ws = double('ws')
           allow(@ws).to receive_messages(:root => root)
-          allow(@ws).to receive_messages(:persist_state_hash => {})
+          allow(@ws).to receive_messages(:persist_state_hash => MiqAeEngine::StateVarHash.new)
           allow(@ws).to receive_messages(:current_state_info => {})
           allow(MiqAeEngine).to receive(:resolve_automation_object).and_return(@ws)
         end

--- a/spec/miq_ae_playbook_method_spec.rb
+++ b/spec/miq_ae_playbook_method_spec.rb
@@ -4,7 +4,7 @@ describe MiqAeEngine::MiqAePlaybookMethod do
     let(:aw) { FactoryBot.create(:automate_workspace, :user => user, :tenant => user.current_tenant) }
     let(:root_hash) { { 'name' => 'Flintstone' } }
     let(:root_object) { Spec::Support::MiqAeMockObject.new(root_hash) }
-    let(:persist_hash) { {} }
+    let(:persist_hash) { MiqAeEngine::StateVarHash.new }
     let(:options) { {"test" => 13, :hosts => hosts, :log_output => 'error'} }
     let(:method_name) { "Freddy Kreuger" }
     let(:method_key) { "FreddyKreuger_ansible_method_task_id" }

--- a/spec/service_models/miq_ae_service_generic_object_spec.rb
+++ b/spec/service_models/miq_ae_service_generic_object_spec.rb
@@ -26,7 +26,7 @@ describe MiqAeMethodService::MiqAeServiceGenericObject do
 
   let(:user) { FactoryBot.create(:user_with_group) }
   let(:workspace) do
-    double('ws', :persist_state_hash => {},
+    double('ws', :persist_state_hash => MiqAeEngine::StateVarHash.new,
                  :ae_user            => user,
                  :rbac_enabled?      => false,
                  :root               => {})

--- a/spec/support/miq_ae_mock_service.rb
+++ b/spec/support/miq_ae_mock_service.rb
@@ -14,7 +14,7 @@ module Spec
       attr_writer :current_object
       attr_accessor :inputs, :object
 
-      def initialize(root, persist_state_hash = {})
+      def initialize(root, persist_state_hash = MiqAeEngine::StateVarHash.new)
         @root = root
         @persist_state_hash = persist_state_hash
         @inputs = {}


### PR DESCRIPTION
This PR creates a new class `StateVarHash` which extends the `HashWithIndifferentAccess` normally used to store the state_var hash data.  

The key impact of this change is that the new class overrides the YAML dump/load logic and will create a binary_blob record used to store the hash data.  When automate performs a retry the state_var hash will add minimal YAML data to the MiqQueue record instead of serializing the YAML representation of the state_var hash.  (If the state_var is an empty hash, no binary blob record will be created and the `binary_blob_id` will be set to 0.)

Reducing the data stored on the queue to something like:
```yaml
--- !ruby/object:MiqAeEngine::StateVarHash
binary_blob_id: <####>
```

Followup PR https://github.com/ManageIQ/manageiq-automation_engine/pull/406 limits the state_var key to a few simple scalar types.

The first commit is the core changes to add the class and implement it, the second commit is only spec changes.

Existing spec tests cover the serialization of the state_vars during an automate retry.
[spec/engine/miq_ae_state_machine_retry_spec.rb#L273](https://github.com/ManageIQ/manageiq-automation_engine/blob/03cbde7b3cc682f2a32b92009fa736c17e97f848/spec/engine/miq_ae_state_machine_retry_spec.rb#L273)
[spec/engine/miq_ae_state_machine_retry_spec.rb#L185](https://github.com/ManageIQ/manageiq-automation_engine/blob/03cbde7b3cc682f2a32b92009fa736c17e97f848/spec/engine/miq_ae_state_machine_retry_spec.rb#L185)