### PR TITLE
State var limit key type

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
@@ -1,6 +1,13 @@
 module MiqAeEngine
   class StateVarHash < HashWithIndifferentAccess
+    STATE_VAR_NAME_CLASSES = [NilClass, Numeric, String, Symbol, Date, Time].freeze
     SERIALIZE_KEY = 'binary_blob_id'.freeze
+
+    def []=(name, value)
+      validate_state_var_name!(name)
+
+      super
+    end
 
     def encode_with(coder)
       coder[SERIALIZE_KEY] =
@@ -22,6 +29,14 @@ module MiqAeEngine
       end
 
       self
+    end
+
+    private
+
+    def validate_state_var_name!(name)
+      if STATE_VAR_NAME_CLASSES.none? { |klass| name.kind_of?(klass) }
+        raise "State Var key (#{name.class.name})[#{name.inspect}] must be of type: #{STATE_VAR_NAME_CLASSES.join(', ')}"
+      end
     end
   end
 end

--- a/spec/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash_spec.rb
@@ -56,4 +56,18 @@ describe MiqAeEngine::StateVarHash do
       expect(restored_state_var).to eq({})
     end
   end
+
+  describe 'key names' do
+    let(:state_var_hash) { MiqAeEngine::StateVarHash.new }
+
+    [nil, 1, 3.14, 'test', :test, Date.new, Time.zone.now].each do |key|
+      it "allows hash key types for [#{key.class}]" do
+        state_var_hash[key] = 1
+      end
+    end
+
+    it 'raises an error for invalid hash key types' do
+      expect { state_var_hash[{}] = nil }.to raise_error(RuntimeError, /State Var key \(.*\] must be of type: .*/)
+    end
+  end
 end


### PR DESCRIPTION
Dependent on https://github.com/ManageIQ/manageiq-automation_engine/pull/405

This PR extends the `StateVarHash` class to limit what class types can be used as state var keys.

The current list includes: `NilClass, Numeric, String, Symbol, Date, Time`.   (Open to other suggestion, but the idea is to limit it to basic object types.)