### PR TITLE
Use YAML.load to load classes beyond the basic types

### DIFF
--- a/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
@@ -104,13 +104,13 @@ describe MiqAeMethodService::MiqAeServiceModelBase do
     end
 
     it 'loads object from yaml' do
-      expect(YAML.safe_load(svc_service.to_yaml)).to eq(svc_service)
+      expect(YAML.safe_load(svc_service.to_yaml, [MiqAeMethodService::MiqAeServiceService])).to eq(svc_service)
     end
 
     it 'loads invalid svc_model for objects without related ar_model' do
       yaml = svc_service.to_yaml
       service.delete
-      model_from_yaml = YAML.safe_load(yaml)
+      model_from_yaml = YAML.safe_load(yaml, [MiqAeMethodService::MiqAeServiceService])
       expect { model_from_yaml.reload }.to raise_error(
         NoMethodError,
         "undefined method `reload' for nil:NilClass"

--- a/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
@@ -122,11 +122,11 @@ describe MiqAeMethodService::MiqAeServiceModelBase do
     let(:service_model) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_InfraManager_Vm }
 
     describe '.ar_subclass_associations' do
-      it `does not return the tags association` do
+      it 'does not return the tags association' do
         expect(service_model.ar_model_associations).to_not include(:tags)
       end
 
-      it `does not include associations from superclass` do
+      it 'does not include associations from superclass' do
         expect(service_model.ar_model_associations).to_not include(service_model.superclass.ar_model_associations)
       end
     end

--- a/spec/engine/miq_ae_state_machine_retry_spec.rb
+++ b/spec/engine/miq_ae_state_machine_retry_spec.rb
@@ -280,6 +280,6 @@ describe "MiqAeStateMachineRetry" do
     expect(MiqQueue.count).to eq(2)
     q = MiqQueue.where(:state => 'ready').first
     expect(q[:server_guid]).to be_nil
-    expect(YAML.safe_load(q.args.first[:ae_state_data])).to eq(ae_state_data)
+    expect(YAML.load(q.args.first[:ae_state_data])).to eq(ae_state_data)
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1789153

Followup to ManageIQ/manageiq#19701

The prior behavior in core was to treat YAML.safe_load like YAML.load so let's change
some of these to .load for now.  We'll enumerate the list of classes where we
can.

Also, fix typo of backtick instead of quote. 