### PR TITLE
Replace dynamic find and uri escape

### DIFF
--- a/app/models/miq_ae_instance_copy.rb
+++ b/app/models/miq_ae_instance_copy.rb
@@ -83,7 +83,7 @@ class MiqAeInstanceCopy
   end
 
   def create_instance
-    @dest_instance = MiqAeInstance.find_by_class_id_and_name(@dest_class.id, @target_name)
+    @dest_instance = MiqAeInstance.find_by(:class_id => @dest_class.id, :name => @target_name)
     if @dest_instance
       @dest_instance.destroy if @overwrite
       raise "Instance #{@target_name} exists in #{@target_ns_fqname} class #{@target_class_name}" unless @overwrite

--- a/app/models/miq_ae_yaml_import.rb
+++ b/app/models/miq_ae_yaml_import.rb
@@ -229,7 +229,7 @@ class MiqAeYamlImport
 
   def process_instance(class_obj, instance_yaml)
     inst_attrs   = instance_yaml.fetch_path('object', 'attributes')
-    instance_obj = MiqAeInstance.find_by_class_id_and_name(class_obj.id, inst_attrs['name']) unless class_obj.nil?
+    instance_obj = MiqAeInstance.find_by(:class_id => class_obj.id, :name => inst_attrs['name']) unless class_obj.nil?
     track_stats('instance', instance_obj)
     instance_obj ||= add_instance(class_obj, instance_yaml) unless @preview
     instance_obj

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_uri.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_uri.rb
@@ -17,7 +17,7 @@ module MiqAeEngine
       hash = {}
       query&.split('&')&.each do |a|
           k, v = a.split('=')
-          hash[URI.unescape(k)] = URI.unescape(v.to_s)
+          hash[CGI.unescape(k)] = CGI.unescape(v.to_s)
         end
       hash
     end

--- a/spec/models/miq_ae_instance_compare_values_spec.rb
+++ b/spec/models/miq_ae_instance_compare_values_spec.rb
@@ -1,9 +1,9 @@
 describe MiqAeInstanceCompareValues do
   before do
     @domain = 'SPEC_DOMAIN'
-    @namespace   = 'NS1'
-    @classname   = 'CLASS1'
-    @yaml_file   = File.join(File.dirname(__FILE__), 'miq_ae_copy_data', 'miq_ae_method_copy.yaml')
+    @namespace = 'NS1'
+    @classname = 'CLASS1'
+    @yaml_file = File.join(File.dirname(__FILE__), 'miq_ae_copy_data', 'miq_ae_method_copy.yaml')
     MiqAeDatastore.reset
     EvmSpecHelper.import_yaml_model_from_file(@yaml_file, @domain)
     @export_dir = Dir.mktmpdir
@@ -20,7 +20,7 @@ describe MiqAeInstanceCompareValues do
     end
 
     it "both instances in DB should be equivalent" do
-      inst1  = MiqAeInstance.find_by(:class_id => @class.id, :name => @first_instance)
+      inst1 = MiqAeInstance.find_by(:class_id => @class.id, :name => @first_instance)
       instance_check_status(inst1, inst1, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
     end
 
@@ -38,8 +38,8 @@ describe MiqAeInstanceCompareValues do
     end
 
     it 'both instances in DB should be compatible' do
-      inst1  = MiqAeInstance.find_by(:class_id => @class.id, :name => @first_instance)
-      inst2  = MiqAeInstance.find_by(:class_id => @class.id, :name => @second_instance)
+      inst1 = MiqAeInstance.find_by(:class_id => @class.id, :name => @first_instance)
+      inst2 = MiqAeInstance.find_by(:class_id => @class.id, :name => @second_instance)
       instance_check_status(inst1, inst2, MiqAeInstanceCompareValues::COMPATIBLE_INSTANCE)
     end
 

--- a/spec/models/miq_ae_instance_compare_values_spec.rb
+++ b/spec/models/miq_ae_instance_compare_values_spec.rb
@@ -20,13 +20,13 @@ describe MiqAeInstanceCompareValues do
     end
 
     it "both instances in DB should be equivalent" do
-      inst1  = MiqAeInstance.find_by_class_id_and_name(@class.id, @first_instance)
+      inst1  = MiqAeInstance.find_by(:class_id => @class.id, :name => @first_instance)
       instance_check_status(inst1, inst1, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
     end
 
     it "one instance in DB and other in YAML should be equivalent" do
       export_model(@domain)
-      inst1 = MiqAeInstance.find_by_class_id_and_name(@class.id, @first_instance)
+      inst1 = MiqAeInstance.find_by(:class_id => @class.id, :name => @first_instance)
       inst2 = MiqAeInstanceYaml.new(@instance1_file)
       instance_check_status(inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
     end
@@ -38,14 +38,14 @@ describe MiqAeInstanceCompareValues do
     end
 
     it 'both instances in DB should be compatible' do
-      inst1  = MiqAeInstance.find_by_class_id_and_name(@class.id, @first_instance)
-      inst2  = MiqAeInstance.find_by_class_id_and_name(@class.id, @second_instance)
+      inst1  = MiqAeInstance.find_by(:class_id => @class.id, :name => @first_instance)
+      inst2  = MiqAeInstance.find_by(:class_id => @class.id, :name => @second_instance)
       instance_check_status(inst1, inst2, MiqAeInstanceCompareValues::COMPATIBLE_INSTANCE)
     end
 
     it "one instance in DB and other in YAML should be compatible" do
       export_model(@domain)
-      inst1 = MiqAeInstance.find_by_class_id_and_name(@class.id, @first_instance)
+      inst1 = MiqAeInstance.find_by(:class_id => @class.id, :name => @first_instance)
       inst2 = MiqAeInstanceYaml.new(@instance2_file)
       instance_check_status(inst1, inst2, MiqAeInstanceCompareValues::COMPATIBLE_INSTANCE)
     end

--- a/spec/models/miq_ae_instance_copy_spec.rb
+++ b/spec/models/miq_ae_instance_copy_spec.rb
@@ -19,27 +19,27 @@ describe MiqAeInstanceCopy do
     before do
       @ns1 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@src_ns}", false)
       @class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @src_class)
-      @inst1  = MiqAeInstance.find_by_class_id_and_name(@class1.id, @src_instance)
+      @inst1  = MiqAeInstance.find_by(:class_id => @class1.id, :name => @src_instance)
     end
 
     it 'after copy both instances in DB should be congruent' do
       MiqAeInstanceCopy.new(@src_fqname).to_domain(@dest_domain)
       ns2 = MiqAeNamespace.lookup_by_fqname("#{@dest_domain}/#{@src_ns}", false)
       class2 = MiqAeClass.lookup_by_namespace_id_and_name(ns2.id, @src_class)
-      inst2  = MiqAeInstance.find_by_class_id_and_name(class2.id, @src_instance)
+      inst2  = MiqAeInstance.find_by(:class_id => class2.id, :name => @src_instance)
       validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
     end
 
     it 'with overwrite an existing instance should get updated' do
-      inst2  = MiqAeInstance.find_by_class_id_and_name(@class1.id, @dest_instance)
+      inst2  = MiqAeInstance.find_by(:class_id => @class1.id, :name => @dest_instance)
       validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::COMPATIBLE_INSTANCE)
       MiqAeInstanceCopy.new(@src_fqname).as(@dest_instance, nil, true)
-      inst2  = MiqAeInstance.find_by_class_id_and_name(@class1.id, @dest_instance)
+      inst2  = MiqAeInstance.find_by(:class_id => @class1.id, :name => @dest_instance)
       validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
     end
 
     it 'without overwrite an existing instance should raise error' do
-      inst2  = MiqAeInstance.find_by_class_id_and_name(@class1.id, @dest_instance)
+      inst2  = MiqAeInstance.find_by(:class_id => @class1.id, :name => @dest_instance)
       validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::COMPATIBLE_INSTANCE)
       expect { MiqAeInstanceCopy.new(@src_fqname).as(@dest_instance) }.to raise_error(RuntimeError)
     end
@@ -48,7 +48,7 @@ describe MiqAeInstanceCopy do
       MiqAeInstanceCopy.new(@src_fqname).as(@src_instance, @dest_ns, true)
       ns2 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@dest_ns}", false)
       class2 = MiqAeClass.lookup_by_namespace_id_and_name(ns2.id, @src_class)
-      inst2  = MiqAeInstance.find_by_class_id_and_name(class2.id, @src_instance)
+      inst2  = MiqAeInstance.find_by(:class_id => class2.id, :name => @src_instance)
       validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
     end
 
@@ -56,7 +56,7 @@ describe MiqAeInstanceCopy do
       MiqAeInstanceCopy.new(@src_fqname).to_domain(@dest_domain, @dest_ns, true)
       ns2 = MiqAeNamespace.lookup_by_fqname("#{@dest_domain}/#{@dest_ns}", false)
       class2 = MiqAeClass.lookup_by_namespace_id_and_name(ns2.id, @src_class)
-      inst2  = MiqAeInstance.find_by_class_id_and_name(class2.id, @src_instance)
+      inst2  = MiqAeInstance.find_by(:class_id => class2.id, :name => @src_instance)
       validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
     end
   end
@@ -65,7 +65,7 @@ describe MiqAeInstanceCopy do
     before do
       @ns1 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@src_ns}", false)
       @class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @src_class)
-      @inst1  = MiqAeInstance.find_by_class_id_and_name(@class1.id, @src_instance)
+      @inst1  = MiqAeInstance.find_by(:class_id => @class1.id, :name =>@src_instance)
     end
 
     it 'by default copy should fail' do
@@ -78,7 +78,7 @@ describe MiqAeInstanceCopy do
       cp.as('incompatible_one', 'NS2', true)
       ns2 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/ns2", false)
       ic_class = MiqAeClass.lookup_by_namespace_id_and_name(ns2.id, @src_class)
-      expect(MiqAeInstance.find_by_class_id_and_name(ic_class.id, 'incompatible_one')).not_to be_nil
+      expect(MiqAeInstance.find_by(:class_id => ic_class.id, :name => 'incompatible_one')).not_to be_nil
     end
   end
 

--- a/spec/models/miq_ae_instance_copy_spec.rb
+++ b/spec/models/miq_ae_instance_copy_spec.rb
@@ -31,15 +31,15 @@ describe MiqAeInstanceCopy do
     end
 
     it 'with overwrite an existing instance should get updated' do
-      inst2  = MiqAeInstance.find_by(:class_id => @class1.id, :name => @dest_instance)
+      inst2 = MiqAeInstance.find_by(:class_id => @class1.id, :name => @dest_instance)
       validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::COMPATIBLE_INSTANCE)
       MiqAeInstanceCopy.new(@src_fqname).as(@dest_instance, nil, true)
-      inst2  = MiqAeInstance.find_by(:class_id => @class1.id, :name => @dest_instance)
+      inst2 = MiqAeInstance.find_by(:class_id => @class1.id, :name => @dest_instance)
       validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::CONGRUENT_INSTANCE)
     end
 
     it 'without overwrite an existing instance should raise error' do
-      inst2  = MiqAeInstance.find_by(:class_id => @class1.id, :name => @dest_instance)
+      inst2 = MiqAeInstance.find_by(:class_id => @class1.id, :name => @dest_instance)
       validate_instance(@inst1, inst2, MiqAeInstanceCompareValues::COMPATIBLE_INSTANCE)
       expect { MiqAeInstanceCopy.new(@src_fqname).as(@dest_instance) }.to raise_error(RuntimeError)
     end
@@ -65,7 +65,7 @@ describe MiqAeInstanceCopy do
     before do
       @ns1 = MiqAeNamespace.lookup_by_fqname("#{@src_domain}/#{@src_ns}", false)
       @class1 = MiqAeClass.lookup_by_namespace_id_and_name(@ns1.id, @src_class)
-      @inst1  = MiqAeInstance.find_by(:class_id => @class1.id, :name =>@src_instance)
+      @inst1  = MiqAeInstance.find_by(:class_id => @class1.id, :name => @src_instance)
     end
 
     it 'by default copy should fail' do


### PR DESCRIPTION
Based on rubocop warnings.

Replace `URI.unescape` with `CGI.unescape` (which is used extensively in other ManageIQ repos).
Update dynamic finder calls for `MiqAeInstance.find_by_class_id_and_name`