### PR TITLE
Guard against hitting const_missing from within const_missing

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service.rb
@@ -1,5 +1,7 @@
 module MiqAeMethodService
   def self.const_missing(name)
+    super unless defined?(MiqAeServiceModelBase)
+
     MiqAeServiceModelBase.create_service_model_from_name(name) || super
   end
 end


### PR DESCRIPTION
If MiqAeServiceModelBase is not yet defined, we could hit const_missing
recursively, leading to a stack level too deep.

Fixes https://github.com/ManageIQ/manageiq/issues/19618