### PR TITLE
Add queue_name for ems_operations methods

### DIFF
--- a/lib/miq_automation_engine/service_models/mixins/miq_ae_service_ems_operations_mixin.rb
+++ b/lib/miq_automation_engine/service_models/mixins/miq_ae_service_ems_operations_mixin.rb
@@ -11,6 +11,7 @@ module MiqAeServiceEmsOperationsMixin
         :args        => args,
         :zone        => @object.my_zone,
         :role        => "ems_operations",
+        :queue_name  => @object.queue_name_for_ems_operations,
         :task_id     => nil               # Clear task_id to allow running asynchronously under current worker process
       }
 

--- a/spec/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-cloud_volume_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-cloud_volume_spec.rb
@@ -1,18 +1,18 @@
 describe MiqAeMethodService::MiqAeServiceUser do
-  let(:cloud_volume)         { FactoryBot.create(:cloud_volume_openstack) }
+  let(:cloud_volume)         do
+    FactoryBot.create(:cloud_volume_openstack, :ext_management_system => FactoryBot.create(:ems_openstack))
+  end
   let(:service_cloud_volume) do
     MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManager_CloudVolume.find(cloud_volume.id)
   end
 
   before do
-    zone = FactoryBot.create(:zone)
-    allow_any_instance_of(CloudVolume).to receive(:my_zone).and_return(zone.name)
-    allow(MiqServer).to receive(:my_zone).and_return(zone.name)
     @base_queue_options = {
       :class_name  => cloud_volume.class.name,
       :instance_id => cloud_volume.id,
-      :zone        => zone.name,
+      :zone        => cloud_volume.ext_management_system.my_zone,
       :role        => 'ems_operations',
+      :queue_name  => cloud_volume.queue_name_for_ems_operations,
       :task_id     => nil
     }
   end
@@ -20,7 +20,7 @@ describe MiqAeMethodService::MiqAeServiceUser do
   it "#backup_create async" do
     service_cloud_volume.backup_create('test backup', false)
 
-    expect(MiqQueue.first).to have_attributes(
+    expect(MiqQueue.last).to have_attributes(
       @base_queue_options.merge(
         :method_name => 'backup_create',
         :args        => [{:name => "test backup", :incremental => false}])
@@ -30,7 +30,7 @@ describe MiqAeMethodService::MiqAeServiceUser do
   it "#backup_restore async" do
     service_cloud_volume.backup_restore('1234')
 
-    expect(MiqQueue.first).to have_attributes(
+    expect(MiqQueue.last).to have_attributes(
       @base_queue_options.merge(
         :method_name => 'backup_restore',
         :args        => ["1234"])

--- a/spec/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-cloud_volume_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-cloud_volume_spec.rb
@@ -10,7 +10,7 @@ describe MiqAeMethodService::MiqAeServiceUser do
     @base_queue_options = {
       :class_name  => cloud_volume.class.name,
       :instance_id => cloud_volume.id,
-      :zone        => cloud_volume.ext_management_system.my_zone,
+      :zone        => cloud_volume.my_zone,
       :role        => 'ems_operations',
       :queue_name  => cloud_volume.queue_name_for_ems_operations,
       :task_id     => nil

--- a/spec/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager-vm_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager-vm_spec.rb
@@ -1,15 +1,14 @@
 describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Redhat_InfraManager_Vm do
-  let(:vm)         { FactoryBot.create(:vm_redhat) }
+  let(:vm)         { FactoryBot.create(:vm_redhat, :ext_management_system => FactoryBot.create(:ems_redhat)) }
   let(:service_vm) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Redhat_InfraManager_Vm.find(vm.id) }
 
   before do
-    zone = FactoryBot.create(:zone)
-    allow(MiqServer).to receive(:my_zone).and_return(zone.name)
     @base_queue_options = {
       :class_name  => vm.class.name,
       :instance_id => vm.id,
-      :zone        => zone.name,
+      :zone        => vm.my_zone,
       :role        => 'ems_operations',
+      :queue_name  => vm.queue_name_for_ems_operations,
       :task_id     => nil
     }
   end

--- a/spec/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
@@ -1,18 +1,16 @@
 describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm do
-  let(:vm)             { FactoryBot.create(:vm_vmware) }
+  let(:vm)             { FactoryBot.create(:vm_vmware, :ext_management_system => FactoryBot.create(:ems_vmware)) }
   let(:folder)         { FactoryBot.create(:ems_folder) }
   let(:service_vm)     { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(vm.id) }
   let(:service_folder) { MiqAeMethodService::MiqAeServiceEmsFolder.find(folder.id) }
 
   before do
-    zone = FactoryBot.create(:zone)
-    allow_any_instance_of(Vm).to receive(:my_zone).and_return(zone.name)
-    allow(MiqServer).to receive(:my_zone).and_return(zone.name)
     @base_queue_options = {
       :class_name  => vm.class.name,
       :instance_id => vm.id,
-      :zone        => zone.name,
+      :zone        => vm.my_zone,
       :role        => 'ems_operations',
+      :queue_name  => vm.queue_name_for_ems_operations,
       :task_id     => nil
     }
   end


### PR DESCRIPTION
Add a queue_name to the MiqQueue message when queueing for the ems_operations role

Depends on: https://github.com/ManageIQ/manageiq/pull/19815

https://github.com/ManageIQ/manageiq-providers-vmware/issues/484