### PR TITLE
Add a method to resize a VMware VM Disk

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm.rb
@@ -16,6 +16,10 @@ module MiqAeMethodService
       sync_or_async_ems_operation(options[:sync], "remove_disk", [disk_name, options])
     end
 
+    def resize_disk(disk_name, disk_size_mb, options = {})
+      sync_or_async_ems_operation(options[:sync], "resize_disk", [disk_name, disk_size_mb, options])
+    end
+
     def move_into_folder(folder, options = {})
       raise ArgumentError, "must be kind of MiqAeServiceEmsFolder" unless folder.kind_of?(MiqAeMethodService::MiqAeServiceEmsFolder)
 

--- a/spec/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-vmware-infra_manager-vm_spec.rb
@@ -1,5 +1,5 @@
 describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm do
-  let(:vm)             { FactoryBot.create(:vm_vmware) }
+  let(:vm)             { FactoryBot.create(:vm_vmware, :ext_management_system => FactoryBot.create(:ems_vmware)) }
   let(:folder)         { FactoryBot.create(:ems_folder) }
   let(:service_vm)     { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_Vm.find(vm.id) }
   let(:service_folder) { MiqAeMethodService::MiqAeServiceEmsFolder.find(folder.id) }
@@ -64,6 +64,17 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_
       @base_queue_options.merge(
         :method_name => 'vm_destroy',
         :args        => [])
+    )
+  end
+
+  it "#resize_disk" do
+    service_vm.resize_disk("disk_1", 1024)
+
+    expect(MiqQueue.first).to have_attributes(
+      @base_queue_options.merge(
+        :method_name => "resize_disk",
+        :args        => ["disk_1", 1024, {}]
+      )
     )
   end
 end


### PR DESCRIPTION
This adds a method which will resize a VMware VM's disk to a new larger
size specified in megabytes.

Fixes https://github.com/ManageIQ/manageiq-providers-vmware/issues/524

Depends on: ~~https://github.com/ManageIQ/manageiq-providers-vmware/pull/525~~