### PR TITLE
Change options accessing syntax in spec 

### DIFF
--- a/spec/service_models/miq_ae_service_miq_provision_spec.rb
+++ b/spec/service_models/miq_ae_service_miq_provision_spec.rb
@@ -87,9 +87,9 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
     method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].register_automate_callback(:first_time_out, 'do_something_great')"
     @ae_method.update(:data => method)
     expect(invoke_ae.root(@ae_result_key)).to be_truthy
-    expect(@miq_provision[:options][:callbacks]).to be_nil
+    expect(@miq_provision.options[:callbacks]).to be_nil
     @miq_provision.reload
-    callback_hash = @miq_provision[:options][:callbacks]
+    callback_hash = @miq_provision.options[:callbacks]
     expect(callback_hash.count).to eq(1)
     expect(callback_hash[:first_time_out]).to eq('do_something_great')
   end
@@ -97,13 +97,13 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
   it "#register_automate_callback - with previous callbacks" do
     method   = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].register_automate_callback(:first_time_out, 'do_something_great')"
     @ae_method.update(:data => method)
-    expect(@miq_provision[:options][:callbacks]).to be_nil
+    expect(@miq_provision.options[:callbacks]).to be_nil
     opts = @miq_provision.options.dup
     opts[:callbacks] = {:next_time_around => 'do_something_better_yet'}
     @miq_provision.update(:options => opts)
     expect(invoke_ae.root(@ae_result_key)).to be_truthy
     @miq_provision.reload
-    callback_hash = @miq_provision[:options][:callbacks]
+    callback_hash = @miq_provision.options[:callbacks]
     expect(callback_hash.count).to eq(2)
     expect(callback_hash[:first_time_out]).to eq('do_something_great')
     expect(callback_hash[:next_time_around]).to eq('do_something_better_yet')
@@ -113,9 +113,9 @@ describe MiqAeMethodService::MiqAeServiceMiqProvision do
     method = "$evm.root['#{@ae_result_key}'] = $evm.root['miq_provision'].set_vm_notes('homer')"
     @ae_method.update(:data => method)
     expect(invoke_ae.root(@ae_result_key)).to be_truthy
-    expect(@miq_provision[:options][:vm_notes]).to be_nil
+    expect(@miq_provision.options[:vm_notes]).to be_nil
     @miq_provision.reload
-    expect(@miq_provision[:options][:vm_notes]).to eq('homer')
+    expect(@miq_provision.options[:vm_notes]).to eq('homer')
   end
 
   it "#target_type" do


### PR DESCRIPTION
`@miq_provision[:options]` should use `@miq_provision.options` syntax

per https://github.com/ManageIQ/manageiq-automation_engine/pull/416#discussion_r376386419