### PR TITLE
MiqAeNamespace should use ancestry instead of acts_as_tree.

### DIFF
--- a/app/models/miq_ae_domain.rb
+++ b/app/models/miq_ae_domain.rb
@@ -8,8 +8,8 @@ class MiqAeDomain < MiqAeNamespace
   EDITABLE_PROPERTIES_FOR_REMOTES = [:priority, :enabled].freeze
   AUTH_KEYS = %w[userid password].freeze
 
-  default_scope { where(:parent_id => nil).where(arel_table[:name].not_eq("$")) }
-  validates_inclusion_of :parent_id, :in => [nil], :message => 'should be nil for Domain'
+  default_scope { roots.where(arel_table[:name].not_eq("$")) }
+  validates :ancestry, :inclusion => {:in => [nil], :message => 'should be nil for Domain'}
 
   validates_presence_of :tenant, :message => "object is needed to own the domain"
   after_destroy :squeeze_priorities
@@ -207,7 +207,7 @@ class MiqAeDomain < MiqAeNamespace
   end
 
   def about_class
-    ns = MiqAeNamespace.where(:parent_id => id).find_by("lower(name) = ?", "system")
+    ns = children.find_by("lower(name) = ?", "system")
     MiqAeClass.where(:namespace_id => ns.id).find_by("lower(name) = ?", "about") if ns
   end
 


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq-schema/pull/455
Blocks https://github.com/ManageIQ/manageiq/pull/19824
Cross Repo Tests: ManageIQ/manageiq-cross_repo-tests#66

https://github.com/ManageIQ/manageiq-automation_engine/issues/409

@miq-bot add_label performance