### PR TITLE
 Test queue_name for ems_ops methods

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-cloud_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-cloud_manager.rb
@@ -1,5 +1,8 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_CloudManager < MiqAeServiceManageIQ_Providers_BaseManager
+    require_relative "mixins/miq_ae_service_ems_operations_mixin"
+    include MiqAeServiceEmsOperationsMixin
+
     expose :cloud_networks,         :association => true
     expose :public_networks,        :association => true
     expose :private_networks,       :association => true

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-network_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-network_manager.rb
@@ -1,8 +1,10 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_NetworkManager < MiqAeServiceExtManagementSystem
-  end
+    require_relative "mixins/miq_ae_service_ems_operations_mixin"
+    include MiqAeServiceEmsOperationsMixin
 
-  def create_network_router(create_options, options = {})
-    sync_or_async_ems_operation(options[:sync], "create_network_router", [create_options])
+    def create_network_router(create_options, options = {})
+      sync_or_async_ems_operation(options[:sync], "create_network_router", [create_options])
+    end
   end
 end

--- a/spec/service_models/miq_ae_service_ems_cluster_spec.rb
+++ b/spec/service_models/miq_ae_service_ems_cluster_spec.rb
@@ -1,10 +1,30 @@
 describe MiqAeMethodService::MiqAeServiceEmsCluster do
-  let(:cluster) { FactoryBot.create(:ems_cluster) }
+  let(:cluster) { FactoryBot.create(:ems_cluster, :ext_management_system => FactoryBot.create(:ext_management_system)) }
+  let(:host) { FactoryBot.create(:host) }
   let(:svc_cluster) { MiqAeMethodService::MiqAeServiceEmsCluster.find(cluster.id) }
 
   it "#show_url" do
     ui_url = stub_remote_ui_url
 
     expect(svc_cluster.show_url).to eq("#{ui_url}/ems_cluster/show/#{cluster.id}")
+  end
+
+  it "#backup_create async" do
+    @base_queue_options = {
+      :class_name  => cluster.class.name,
+      :instance_id => cluster.id,
+      :zone        => cluster.my_zone,
+      :role        => 'ems_operations',
+      :queue_name  => cluster.queue_name_for_ems_operations,
+      :task_id     => nil
+    }
+    svc_cluster.register_host(host)
+
+    expect(MiqQueue.last).to have_attributes(
+      @base_queue_options.merge(
+        :method_name => 'register_host',
+        :args        => [host.id]
+      )
+    )
   end
 end

--- a/spec/service_models/miq_ae_service_ems_folder_spec.rb
+++ b/spec/service_models/miq_ae_service_ems_folder_spec.rb
@@ -1,0 +1,24 @@
+describe MiqAeMethodService::MiqAeServiceEmsFolder do
+  let(:folder) { FactoryBot.create(:ems_folder, :ext_management_system => FactoryBot.create(:ext_management_system)) }
+  let(:host) { FactoryBot.create(:host) }
+  let(:svc_folder) { MiqAeMethodService::MiqAeServiceEmsFolder.find(folder.id) }
+
+  it "#register_host async" do
+    @base_queue_options = {
+      :class_name  => folder.class.name,
+      :instance_id => folder.id,
+      :zone        => folder.my_zone,
+      :role        => 'ems_operations',
+      :queue_name  => folder.queue_name_for_ems_operations,
+      :task_id     => nil
+    }
+    svc_folder.register_host(host)
+
+    expect(MiqQueue.last).to have_attributes(
+      @base_queue_options.merge(
+        :method_name => 'register_host',
+        :args        => [host.id]
+      )
+    )
+  end
+end

--- a/spec/service_models/miq_ae_service_manageiq-providers-cloud_manager_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-cloud_manager_spec.rb
@@ -1,4 +1,7 @@
 describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_CloudManager do
+  let(:cloud_manager) { FactoryBot.create(:ems_openstack) }
+  let(:svc_cloud_manager) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_CloudManager.find(cloud_manager.id) }
+
   it "#availability_zones" do
     expect(described_class.instance_methods).to include(:availability_zones)
   end
@@ -41,5 +44,24 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_CloudManager do
 
   it "#host_aggregates" do
     expect(described_class.instance_methods).to include(:host_aggregates)
+  end
+
+  it "#create_cloud_tenant async" do
+    @base_queue_options = {
+      :class_name  => cloud_manager.class.name,
+      :instance_id => cloud_manager.id,
+      :zone        => cloud_manager.my_zone,
+      :role        => 'ems_operations',
+      :queue_name  => cloud_manager.queue_name_for_ems_operations,
+      :task_id     => nil
+    }
+    svc_cloud_manager.create_cloud_tenant("thing")
+
+    expect(MiqQueue.last).to have_attributes(
+      @base_queue_options.merge(
+        :method_name => 'create_cloud_tenant',
+        :args        => ["thing"]
+      )
+    )
   end
 end

--- a/spec/service_models/miq_ae_service_manageiq-providers-network_manager_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-network_manager_spec.rb
@@ -1,0 +1,24 @@
+describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_NetworkManager do
+  let(:ems) { FactoryBot.create(:ems_cloud) }
+  let(:network_manager) { ems.network_manager }
+  let(:svc_network_manager) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_NetworkManager.find(network_manager.id) }
+
+  it "#create_network_router async" do
+    @base_queue_options = {
+      :class_name  => network_manager.class.name,
+      :instance_id => network_manager.id,
+      :zone        => network_manager.my_zone,
+      :role        => 'ems_operations',
+      :queue_name  => network_manager.queue_name_for_ems_operations,
+      :task_id     => nil
+    }
+    svc_network_manager.create_network_router("thing")
+
+    expect(MiqQueue.last).to have_attributes(
+      @base_queue_options.merge(
+        :method_name => 'create_network_router',
+        :args        => ["thing"]
+      )
+    )
+  end
+end

--- a/spec/service_models/miq_ae_service_manageiq-providers-vmware_infra_manager-host_esx_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-vmware_infra_manager-host_esx_spec.rb
@@ -1,0 +1,23 @@
+describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_HostEsx do
+  let(:host) { FactoryBot.create(:host_vmware_esx, :ext_management_system => FactoryBot.create(:ext_management_system)) }
+  let(:svc_host) { MiqAeMethodService::MiqAeServiceManageIQ_Providers_Vmware_InfraManager_HostEsx.find(host.id) }
+
+  it "#shutdown async" do
+    @base_queue_options = {
+      :class_name  => host.class.name,
+      :instance_id => host.id,
+      :zone        => host.my_zone,
+      :role        => 'ems_operations',
+      :queue_name  => host.queue_name_for_ems_operations,
+      :task_id     => nil
+    }
+    svc_host.shutdown
+
+    expect(MiqQueue.last).to have_attributes(
+      @base_queue_options.merge(
+        :method_name => 'vim_shutdown',
+        :args        => [false]
+      )
+    )
+  end
+end

--- a/spec/service_models/miq_ae_service_vm_or_template_spec.rb
+++ b/spec/service_models/miq_ae_service_vm_or_template_spec.rb
@@ -1,0 +1,23 @@
+describe MiqAeMethodService::MiqAeServiceVmOrTemplate do
+  let(:vm) { FactoryBot.create(:vm_or_template, :ext_management_system => FactoryBot.create(:ext_management_system)) }
+  let(:svc_vm) { MiqAeMethodService::MiqAeServiceVmOrTemplate.find(vm.id) }
+
+  it "#ems_custom_set async" do
+    @base_queue_options = {
+      :class_name  => vm.class.name,
+      :instance_id => vm.id,
+      :zone        => vm.my_zone,
+      :role        => 'ems_operations',
+      :queue_name  => vm.queue_name_for_ems_operations,
+      :task_id     => nil
+    }
+    svc_vm.ems_custom_set("thing", "thing2")
+
+    expect(MiqQueue.last).to have_attributes(
+      @base_queue_options.merge(
+        :method_name => 'set_custom_field',
+        :args        => ["thing", "thing2"]
+      )
+    )
+  end
+end


### PR DESCRIPTION
Per https://github.com/ManageIQ/manageiq-automation_engine/issues/426
Follow up to https://github.com/ManageIQ/manageiq-automation_engine/pull/419#issuecomment-584287073

- [x]     ems_cluster.rb
- [x]     ems_folder.rb
- [x]     host.rb
- [x]     manageiq-providers-cloud_manager.rb
- [x]     manageiq-providers-network_manager.rb
- [x]     manageiq-providers-vmware-infra_manager-host_esx.rb
- [x]     vm_or_template.rb


 ~~it depends on https://github.com/ManageIQ/manageiq/pull/19850~~