### PR TITLE
Remove the to_xml call from miq_ae_engine

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -310,9 +310,7 @@ module MiqAeEngine
 
     uri = create_automation_object(uri, attr, options) if attr
     options[:uri] = uri
-    MiqAeWorkspaceRuntime.instantiate(uri, user_obj, :readonly => readonly).tap do |ws|
-      $miq_ae_logger.debug { ws.to_expanded_xml }
-    end
+    MiqAeWorkspaceRuntime.instantiate(uri, user_obj, :readonly => readonly)
   end
 
   def self.ae_user_object(options = {})


### PR DESCRIPTION
Per needinfo on https://bugzilla.redhat.com/show_bug.cgi?id=1805451 I was asked to remove the call to_xml as it's old and unused now. 

@miq-bot assign @tinaafitz 

We I guess have a plan to remove the rest of them sometime soon but for now this should be sufficient for the bz. 