### PR TITLE
Explicitly pass a local URI for our client's DRb.start_service

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
@@ -120,7 +120,16 @@ begin
   # undefine Object#display which would be called over service#display
   DRbObject.send(:undef_method, :display)
 
-  DRb.start_service
+  # DRb.start_service with no URI can attempt to resolve your local hostname[1], which:
+  #   * is slower than just telling it to use a local address/socket
+  #   * could be wrong and in some cases, it can be a remote IP to a DNS assistance program
+  # [1] https://github.com/ruby/ruby/blob/v2_6_5/lib/drb/drb.rb#L879-L884
+  require 'tmpdir'
+  Dir::Tmpname.create("automation_client", nil) do |path|
+    DRb.start_service("drbunix://\#{path}")
+    FileUtils.chmod(0o750, path)
+  end
+
   $evmdrb = DRbObject.new_with_uri(MIQ_URI)
   raise AutomateMethodException,"Cannot create DRbObject for uri=\#{MIQ_URI}" if $evmdrb.nil?
   $evm = $evmdrb.find(MIQ_ID)

--- a/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
@@ -42,7 +42,7 @@ module MiqAeEngine
       require 'tmpdir'
       Dir::Tmpname.create("automation_engine", nil) do |path|
         self.drb_server = DRb.start_service("drbunix://#{path}", drb_front, :idconv => global_id_conv)
-        FileUtils.chmod(0o750, path)
+        FileUtils.chmod(0o700, path)
       end
     end
 
@@ -127,7 +127,7 @@ begin
   require 'tmpdir'
   Dir::Tmpname.create("automation_client", nil) do |path|
     DRb.start_service("drbunix://\#{path}")
-    FileUtils.chmod(0o750, path)
+    FileUtils.chmod(0o700, path)
   end
 
   $evmdrb = DRbObject.new_with_uri(MIQ_URI)


### PR DESCRIPTION
While testing some workspace instantiantion at home, I was seeing this in the
logs:

```
[----] E, [2020-03-12T16:35:06.554957 #39577:3ff30d01cf44] ERROR -- : <AEMethod available_resource_groups>   DRb::DRbConnError: druby://92.242.140.21:54933 - #<Errno::ETIMEDOUT: Operation timed out - connect(2) for "92.242.140.21" port 54933>
[----] E, [2020-03-12T16:35:06.556663 #39577:3ff30d01cf44] ERROR -- : <AEMethod available_resource_groups>   (drbunix:///var/folders/bf/hh6xb_k15wbfzg4tlbkzch300000gn/T/automation_engine20200312-39577-6nm7ah) /Users/joerafaniello/.rubies/ruby-2.6.5/lib/ruby/2.6.0/drb/drb.rb:744:in `rescue in block in open'
```

Note, the drbunix:///var/folders... unix socket being reported on one side but
the druby://92.242... TCP socket reporting a timeout.  Weird.

Using verizon fios dns at home, somehow DRb resolves DRb.start_service to a remote
DRb service, which I believe happens below because we're not passing a URI so we
have no hostname from this URI and it tries to resolve the local hostname:
https://github.com/ruby/ruby/blob/v2_6_5/lib/drb/drb.rb#L879-L884

```
irb(main):001:0> s = DRb.start_service
irb(main):002:0> s.uri
=> "druby://92.242.140.21:51000"
```

Note, this is the IP address of verizon's DNS assistance program, as mentioned
here:
https://askubuntu.com/questions/587895/why-is-the-ip-92-242-140-21-connecting-to-one-of-my-ports-is-it-malware#comment1583793_587954

We can avoid this entirely by explicitly telling DRb to use a local URI for our
DRb client:

```
irb(main):020:0>   Dir::Tmpname.create("automation_engine_client", nil) do |path|
irb(main):021:1*     puts DRb.start_service("drbunix://#{path}").uri
irb(main):022:1>     FileUtils.chmod(0o750, path)
irb(main):023:1>   end; nil
drbunix:///var/folders/bf/hh6xb_k15wbfzg4tlbkzch300000gn/T/automation_engine_client20200313-69238-im1kfc
```

We've seen this weird thing in the past where our server was using unix sockets
and the client was failing, trying to access a TCP DRb server.  The never merged
solution in the past was to remove the TCP socket option from the server but I
believe the problem might actually have been what you see above, in the DRb client,
which also starts a drb server to talk to the unix socket drb server.

https://github.com/ManageIQ/manageiq-automation_engine/pull/234

Thanks @agrare with helping me debug this.