### PR TITLE
Improve automate query performance.

### DIFF
--- a/app/models/miq_ae_browser.rb
+++ b/app/models/miq_ae_browser.rb
@@ -143,8 +143,7 @@ class MiqAeBrowser
       if klass_name == "MiqAeInstance"
         true
       else
-        prefix = klass_name == "MiqAeDomain" ? "MiqAeNamespace" : klass_name
-        @waypoint_ids.include?("#{prefix}::#{obj.id}")
+        @waypoint_ids.include?("#{klass_name}::#{obj.id}")
       end
     end
   end

--- a/app/models/miq_ae_datastore.rb
+++ b/app/models/miq_ae_datastore.rb
@@ -148,7 +148,7 @@ module MiqAeDatastore
   end
 
   def self.seed_default_namespace
-    default_ns   = MiqAeNamespace.create!(:name => DEFAULT_OBJECT_NAMESPACE)
+    default_ns   = MiqAeDomain.create!(:name => DEFAULT_OBJECT_NAMESPACE, :tenant => Tenant.root_tenant)
     object_class = default_ns.ae_classes.create!(:name => 'Object')
 
     default_method_options = {:language => 'ruby', :scope => 'instance', :location => 'builtin'}

--- a/app/models/miq_ae_datastore/xml_import.rb
+++ b/app/models/miq_ae_datastore/xml_import.rb
@@ -7,7 +7,7 @@ module MiqAeDatastore
       methods   = input.delete("MiqAeMethod")
 
       # Create the AEClass
-      aec = MiqAeClass.new(input)
+      aec = MiqAeClass.create(input)
 
       Benchmark.realtime_block(:process_class_schema_time) do
         # Find or Create the AEFields

--- a/app/models/miq_ae_domain.rb
+++ b/app/models/miq_ae_domain.rb
@@ -166,7 +166,11 @@ class MiqAeDomain < MiqAeNamespace
   def display_name
     return self[:display_name] unless git_enabled?
 
-    "#{domain_name} (#{ref})"
+    "#{name} (#{ref})"
+  end
+
+  def fqname
+    "/#{name}"
   end
 
   def destroy_queue(user = User.current_user)
@@ -212,8 +216,7 @@ class MiqAeDomain < MiqAeNamespace
   end
 
   def about_class
-    ns = children.find_by("lower(name) = ?", "system")
-    MiqAeClass.where(:namespace_id => ns.id).find_by("lower(name) = ?", "about") if ns
+    MiqAeClass.where(:domain => self).find_by(MiqAeClass.arel_table[:relative_path].lower.eq("system/about"))
   end
 
   def self.reset_priority_of_system_domains

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
@@ -1,9 +1,6 @@
 module MiqAeEngine
   class MiqAeDomainSearch
     def initialize
-      @fqns_id_cache       = {}
-      @fqns_id_class_cache = {}
-      @partial_ns          = []
       @prepend_namespace   = nil
     end
 
@@ -13,23 +10,19 @@ module MiqAeEngine
     end
 
     def ae_user=(obj)
-      @sorted_domains ||= obj.current_tenant.enabled_domains.collect(&:name) # rubocop:disable Naming/MemoizedInstanceVariableName
+      @ae_user = obj
     end
 
     def get_alternate_domain(scheme, uri, namespace, klass, instance)
       return namespace if namespace.nil? || klass.nil?
       return namespace if scheme != "miqaedb"
-      return namespace if @fqns_id_cache.key?(namespace)
 
       search(uri, namespace, klass, instance, nil)
     end
 
     def get_alternate_domain_method(scheme, uri, namespace, klass, method)
       return namespace if namespace.nil? || klass.nil?
-
       return namespace if scheme != "miqaedb"
-
-      return namespace if @fqns_id_cache.key?(namespace)
 
       search(uri, namespace, klass, nil, method)
     end
@@ -37,82 +30,23 @@ module MiqAeEngine
     private
 
     def search(uri, namespace, klass, instance, method)
-      unless @partial_ns.include?(namespace)
-        fqns = MiqAeNamespace.lookup_by_fqname(namespace, false)
-        if fqns && !fqns.domain?
-          @fqns_id_cache[namespace] = fqns.id
-          return namespace
-        end
-      end
-      @partial_ns << namespace unless @partial_ns.include?(namespace)
       updated_ns = find_first_fq_domain(uri, "#{@prepend_namespace}/#{namespace}", klass, instance, method) if @prepend_namespace
       updated_ns ||= find_first_fq_domain(uri, namespace, klass, instance, method)
       updated_ns || namespace
     end
 
     def find_first_fq_domain(uri, namespace, klass, instance, method)
-      # Check if the namespace, klass and instance exist if it does
-      # swap out the namespace
-      parts = namespace.split('/')
-      parts.unshift("")
-      matching_domain = get_matching_domain(parts, klass, instance, method)
-      matching_domain ||= get_matching_domain(parts, klass, MiqAeObject::MISSING_INSTANCE, method)
-      updated_ns = nil
-      if matching_domain
-        parts[0]   = matching_domain
-        updated_ns = parts.join('/')
-        $miq_ae_logger.info("Updated namespace [#{ManageIQ::Password.sanitize_string(uri)}  #{updated_ns}]")
-      end
-      updated_ns
+      matching_ns = get_matching_domain(namespace, klass, instance, method)
+      matching_ns ||= get_matching_domain(namespace, klass, MiqAeObject::MISSING_INSTANCE, method)
+      $miq_ae_logger.info("Updated namespace [#{ManageIQ::Password.sanitize_string(uri)}  #{matching_ns}]") if matching_ns
+      matching_ns
     end
 
-    def get_matching_domain(ns_parts, klass, instance, method)
-      @sorted_domains.detect do |domain|
-        ns_parts[0] = domain
-        ns_id       = find_fqns_id(ns_parts)
-        cls_id      = find_class_id(klass, ns_id) if ns_id
-        get_matching(cls_id, instance, method) if cls_id
-      end
-    end
-
-    def get_matching(cls_id, instance, method)
-      instance ? find_instance_id(instance, cls_id) : find_method_id(method, cls_id)
-    end
-
-    def find_fqns_id(fqns_parts)
-      fqname = fqns_parts.join('/')
-      return @fqns_id_cache[fqname] if @fqns_id_cache.key?(fqname)
-
-      ns = MiqAeNamespace.lookup_by_fqname(fqname, false)
-      @fqns_id_cache[fqname] = ns.id if ns
-    end
-
-    def find_class_id(class_name, ns_id)
-      return nil if class_name.nil? || ns_id.nil?
-
-      key_name = "#{class_name}#{ns_id}"
-      return @fqns_id_class_cache[key_name] if @fqns_id_class_cache.key?(key_name)
-
-      class_filter = MiqAeClass.arel_table[:name].lower.matches(class_name.downcase)
-      ae_class = MiqAeClass.where(class_filter).where(:namespace_id => ns_id)
-      @fqns_id_class_cache[key_name] = ae_class.first.id if ae_class.any?
-    end
-
-    def find_instance_id(instance_name, class_id)
-      return nil if instance_name.nil? || class_id.nil?
-
-      instance_name = ::ActiveRecordQueryParts.glob_to_sql_like(instance_name.dup).downcase
-      ae_instance_filter = MiqAeInstance.arel_table[:name].lower.matches(instance_name)
-      ae_instances = MiqAeInstance.where(ae_instance_filter).where(:class_id => class_id)
-      ae_instances.first.try(:id)
-    end
-
-    def find_method_id(method_name, class_id)
-      return nil if method_name.nil? || class_id.nil?
-
-      ae_method_filter = ::MiqAeMethod.arel_table[:name].lower.matches(method_name)
-      ae_methods = ::MiqAeMethod.where(ae_method_filter).where(:class_id => class_id)
-      ae_methods.first.try(:id)
+    def get_matching_domain(namespace, klass, instance, method)
+      relative_path = instance ? "#{namespace}/#{klass}/#{instance}" : "#{namespace}/#{klass}/#{method}"
+      klass = instance ? ::MiqAeInstance : ::MiqAeMethod
+      match = klass.find_best_match_by(@ae_user, relative_path)
+      match.namespace[1..-1] if match
     end
   end
 end

--- a/spec/engine/miq_ae_state_machine_multi_spec.rb
+++ b/spec/engine/miq_ae_state_machine_multi_spec.rb
@@ -2,6 +2,7 @@ describe "MultipleStateMachineSteps" do
   include Spec::Support::AutomationHelper
 
   before do
+    Tenant.seed
     MiqAeDatastore.reset_default_namespace
     @instance1           = 'instance1'
     @instance2           = 'instance2'

--- a/spec/miq_ae_object_spec.rb
+++ b/spec/miq_ae_object_spec.rb
@@ -4,6 +4,7 @@ describe MiqAeEngine::MiqAeObject do
   before do
     MiqAeDatastore.reset
     @domain = 'SPEC_DOMAIN'
+    FactoryBot.create(:miq_ae_domain, :name => @domain)
     @user = FactoryBot.create(:user_with_group)
     @model_data_dir = File.join(File.dirname(__FILE__), "data")
     EvmSpecHelper.import_yaml_model(File.join(@model_data_dir, "miq_ae_object_spec1"), @domain)

--- a/spec/miq_ae_state_missing_relation_spec.rb
+++ b/spec/miq_ae_state_missing_relation_spec.rb
@@ -1,5 +1,6 @@
 describe "MiqAeStateMachine" do
   before do
+    Tenant.seed
     MiqAeDatastore.reset_default_namespace
     @user             = FactoryBot.create(:user_with_group)
     @domain           = 'FLINTSTONE'


### PR DESCRIPTION
Columns `domain_id`  and `relative_path` are added into` MiqAeNamespace`, `MiqAeClass`, `MiqAeInstance` and `MiqAeMethod`.

Depends on https://github.com/ManageIQ/manageiq/pull/20050
Depends on https://github.com/ManageIQ/manageiq-schema/pull/465

cross repo tests: ManageIQ/manageiq-cross_repo-tests#112

Fixes https://github.com/ManageIQ/manageiq-automation_engine/issues/410