### PR TITLE
Fix oops backtick instead of quotes.

### DIFF
--- a/spec/miq_ae_service_model_spec.rb
+++ b/spec/miq_ae_service_model_spec.rb
@@ -101,11 +101,11 @@ describe MiqAeMethodService::MiqAeServiceVm do
   end
 
   describe 'missing methods' do
-    it `recognize missing methods name which starts with normalize_` do
+    it 'recognize missing methods name which starts with normalize_' do
       expect(@ae_vm.respond_to?(:normalized_tags)).to be true
     end
 
-    it `does not recognize arbitraray missing methods name which starts with normalize_` do
+    it 'does not recognize arbitraray missing methods name which starts with normalize_' do
       expect(@ae_vm.respond_to?(:normalized_not_exist_method)).to be false
     end
   end


### PR DESCRIPTION
Fixes 2 errors seen in the output in the travis log:
No such file or directory - recognize
No such file or directory - does

cc @gmcculloug @astrozzc 