### PR TITLE
[WIP] Domain name caching

### DIFF
--- a/app/models/miq_ae_datastore.rb
+++ b/app/models/miq_ae_datastore.rb
@@ -121,6 +121,7 @@ module MiqAeDatastore
   def self.reset
     _log.info("Clearing datastore")
     [MiqAeClass, MiqAeField, MiqAeInstance, MiqAeNamespace, MiqAeMethod, MiqAeValue].each(&:delete_all)
+    MiqAeDomain.clear_domain_cache
   end
 
   def self.reset_default_namespace

--- a/app/models/miq_ae_domain.rb
+++ b/app/models/miq_ae_domain.rb
@@ -10,7 +10,7 @@ class MiqAeDomain < MiqAeNamespace
   EDITABLE_PROPERTIES_FOR_REMOTES = [:priority, :enabled].freeze
   AUTH_KEYS = %w[userid password].freeze
 
-  default_scope { roots.where(arel_table[:name].not_eq("$")) }
+  default_scope { roots.where.not(:name => "$") }
   validates :ancestry, :inclusion => {:in => [nil], :message => 'should be nil for Domain'}
 
   validates_presence_of :tenant, :message => "object is needed to own the domain"
@@ -247,7 +247,7 @@ class MiqAeDomain < MiqAeNamespace
   end
 
   def about_class
-    MiqAeClass.where(:domain => self).find_by(MiqAeClass.arel_table[:relative_path].lower.eq("system/about"))
+    MiqAeClass.where(:domain => self).find_by(:lower_relative_path => "system/about")
   end
 
   def self.reset_priority_of_system_domains

--- a/app/models/miq_ae_domain.rb
+++ b/app/models/miq_ae_domain.rb
@@ -1,4 +1,6 @@
 class MiqAeDomain < MiqAeNamespace
+  include RelativePathMixin
+
   SYSTEM_SOURCE = "system".freeze
   REMOTE_SOURCE = "remote".freeze
   USER_SOURCE   = "user".freeze
@@ -19,6 +21,8 @@ class MiqAeDomain < MiqAeNamespace
   belongs_to :tenant
   belongs_to :git_repository, :dependent => :destroy
   validates_inclusion_of :source, :in => VALID_SOURCES
+
+  alias_attribute :domain_name, :name
 
   EXPORT_EXCLUDE_KEYS = [/^id$/, /^(?!tenant).*_id$/, /^created_on/, /^updated_on/,
                          /^updated_by/, /^reserved$/, /^commit_message/,

--- a/app/models/miq_ae_domain.rb
+++ b/app/models/miq_ae_domain.rb
@@ -11,6 +11,7 @@ class MiqAeDomain < MiqAeNamespace
   AUTH_KEYS = %w[userid password].freeze
 
   default_scope { roots.where.not(:name => "$") }
+  scope :all_domains, -> { unscoped.roots }
   validates :ancestry, :inclusion => {:in => [nil], :message => 'should be nil for Domain'}
 
   validates_presence_of :tenant, :message => "object is needed to own the domain"
@@ -38,14 +39,14 @@ class MiqAeDomain < MiqAeNamespace
 
     load_domain_cache
     name = name.downcase
-    @domain_names[name] ||= MiqAeDomain.unscoped.roots.where(:lower_name => name).pluck(:id).first
+    @domain_names[name] ||= all_domains.where(:lower_name => name).pluck(:id).first
   end
 
   def self.id_to_name(domain_id)
     return if domain_id.nil?
 
     load_domain_cache
-    @domain_ids[domain_id] ||= MiqAeDomain.unscoped.roots.where(:id => domain_id).pluck(:name).first
+    @domain_ids[domain_id] ||= all_domains.where(:id => domain_id).pluck(:name).first
   end
 
   delegate :clear_domain_cache, :to => self
@@ -54,7 +55,7 @@ class MiqAeDomain < MiqAeNamespace
   end
 
   def self.load_domain_cache
-    @domain_ids ||= Hash[*MiqAeDomain.unscoped.roots.pluck(:id, :name).flatten]
+    @domain_ids ||= Hash[*all_domains.pluck(:id, :name).flatten]
     @domain_names ||= @domain_ids.invert.transform_keys { |key| key.to_s.downcase }
   end
 

--- a/app/models/miq_ae_yaml_import.rb
+++ b/app/models/miq_ae_yaml_import.rb
@@ -224,7 +224,7 @@ class MiqAeYamlImport
 
   def existing_class_object(ns_obj, class_yaml)
     class_attrs = class_yaml.fetch_path('object', 'attributes')
-    class_obj = MiqAeClass.lookup_by_namespace_id_and_name(ns_obj.id, class_attrs['name']) unless ns_obj.nil?
+    class_obj = MiqAeClass.lookup_by_namespace_and_name(ns_obj.fqname, class_attrs['name']) unless ns_obj.nil?
     track_stats('class', class_obj)
     class_obj
   end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
@@ -9,8 +9,13 @@ module MiqAeEngine
       $miq_ae_logger.info("Prepend namespace [#{@prepend_namespace}] during domain search")
     end
 
-    def ae_user=(obj)
-      @ae_user = obj
+    def ae_user=(user)
+      @ae_user = user
+      @sorted_domain_ids = nil
+    end
+
+    def sorted_domain_ids
+      @sorted_domain_ids ||= @ae_user.current_tenant.enabled_domains.pluck(:id)
     end
 
     def get_alternate_domain(scheme, uri, namespace, klass, instance)
@@ -45,7 +50,7 @@ module MiqAeEngine
     def get_matching_domain(namespace, klass, instance, method)
       relative_path = instance ? "#{namespace}/#{klass}/#{instance}" : "#{namespace}/#{klass}/#{method}"
       klass = instance ? ::MiqAeInstance : ::MiqAeMethod
-      match = klass.find_best_match_by(@ae_user, relative_path)
+      match = klass.find_best_match_by(sorted_domain_ids, relative_path)
       match.namespace[1..-1] if match
     end
   end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -170,7 +170,7 @@ module MiqAeEngine
       Benchmark.current_realtime[:fetch_instance_count] += 1
       Benchmark.realtime_block(:fetch_instance_time) do
         @workspace.datastore(@class_fqname.downcase.to_sym, iname.downcase) do
-          MiqAeInstance.where(:class_id => @aec.id).find_by(MiqAeInstance.arel_table[:name].lower.eq(iname.downcase))
+          MiqAeInstance.where(:class_id => @aec.id).find_by(:lower_name => iname.downcase)
         end
       end.first
     end

--- a/spec/models/miq_ae_domain_spec.rb
+++ b/spec/models/miq_ae_domain_spec.rb
@@ -474,4 +474,21 @@ describe MiqAeDomain do
       end
     end
   end
+
+  context "#clear_cache" do
+    it "changes name after saves" do
+      d = FactoryBot.create(:miq_ae_domain)
+      expect(MiqAeDomain.id_to_name(d.id)).to eq(d.name)
+      d.update(:name => "#{d.name}2")
+      expect(MiqAeDomain.id_to_name(d.id)).to eq(d.name)
+    end
+
+    it "changes name after saves" do
+      d = FactoryBot.create(:miq_ae_domain)
+      d_id = d.id
+      expect(MiqAeDomain.id_to_name(d.id)).to eq(d.name)
+      d.destroy
+      expect(MiqAeDomain.id_to_name(d_id)).to be_nil
+    end
+  end
 end

--- a/spec/models/miq_ae_domain_spec.rb
+++ b/spec/models/miq_ae_domain_spec.rb
@@ -491,4 +491,22 @@ describe MiqAeDomain do
       expect(MiqAeDomain.id_to_name(d_id)).to be_nil
     end
   end
+
+  context ".default_scope" do
+    it "skips dollar domains" do
+      a = FactoryBot.create(:miq_ae_domain)
+      FactoryBot.create(:miq_ae_domain, :name => "$")
+
+      expect(MiqAeDomain.all).to eq([a])
+    end
+  end
+
+  context ".default_scope" do
+    it "returns dollar domains" do
+      a = FactoryBot.create(:miq_ae_domain)
+      b = FactoryBot.create(:miq_ae_domain, :name => "$")
+
+      expect(MiqAeDomain.all_domains).to match_array([a, b])
+    end
+  end
 end


### PR DESCRIPTION
Reduce the domain lookups.

Automate has reduced the number of namespace lookups, but it has greatly increased the number of domain name lookups.

- introduces domain name cache
- simplifies lower name/path lookups (performance is the same)

links:

- linked: https://github.com/ManageIQ/manageiq/pull/20187
- followup to: https://github.com/ManageIQ/manageiq-automation_engine/pull/439
- https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/127

|         ms |       bytes |   objects |query |    qry ms |     rows |`comments`
|        ---:|         ---:|       ---:|  ---:|       ---:|      ---:| ---
|  102,018.6 | 20,011,589* | 3,550,475 |1,399 |   1,828.3 |    7,277 |`before-ancestry`
|   97,108.4 | 29,799,493* | 2,130,528 |  762 |   1,064.1 |    1,053 |`before PR`
|  102,689.6 | 20,088,885* | 1,927,497 |  695 |     914.2 |      944 |`after PR`
|  0         | 33%       | 46%       | 10%  |   9%     |      10% |`PR savings`
|  0         | 0           | 46%       | 50%  |   50%     |      87% |`overall savings`

\* Memory usage does not reflect 1,580,960 freed objects.
\* Memory usage does not reflect 783,419 freed objects.
\* Memory usage does not reflect 676,182 freed objects.