### PR TITLE
fix failing automation manager spec 

### DIFF
--- a/spec/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager_spec.rb
@@ -1,11 +1,11 @@
 describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager do
   let(:provider) { FactoryBot.create(:provider_ansible_tower) }
-  let(:automation_manager) { FactoryBot.create(:automation_manager_ansible_tower, :provider => provider) }
+  let!(:automation_manager) { FactoryBot.create(:automation_manager_ansible_tower, :provider => provider) }
 
   it "get the service model" do
-    automation_manager
     svc = described_class.find(automation_manager.id)
 
-    expect(svc.name).to eq(automation_manager.name)
+    ems = ExtManagementSystem.find(automation_manager.ext_management_system.id)
+    expect(svc.name).to eq(ems.name)
   end
 end


### PR DESCRIPTION
fixes the build: 

```
Failures:
  1) MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager get the service model
     Failure/Error: expect(svc.name).to eq(automation_manager.name)
       expected: "ems_0000000000313 Automation Manager"
            got: "provider_0000000000004 Automation Manager"
       (compared using ==)
     # ./spec/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager_spec.rb:9:in `block (2 levels) in <top (required)>'
```

somewhere between https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/229 and https://github.com/ManageIQ/manageiq-providers-ansible_tower/commit/3a7a8bc9cf85df020c40252189544a7e1591eee3 is where this broke