### PR TITLE
fix deprecation warning about updating display to visible

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service.rb
@@ -87,9 +87,9 @@ module MiqAeMethodService
       ar_method { @object.update_attribute(:description, new_description) }
     end
 
-    def display=(display)
+    def visible=(visible)
       ar_method do
-        @object.display = display
+        @object.visible = visible
         @object.save
       end
     end

--- a/spec/service_models/miq_ae_service_service_spec.rb
+++ b/spec/service_models/miq_ae_service_service_spec.rb
@@ -51,17 +51,17 @@ describe MiqAeMethodService::MiqAeServiceService do
     expect(@service.description).to eq('new_test_description')
   end
 
-  context "#display=" do
+  context "#visible=" do
     it "updates the display visibility" do
-      @service.display = true
+      @service.visible = true
       @service.save
 
-      method = "$evm.root['service'].display = false"
+      method = "$evm.root['service'].visible = false"
       @ae_method.update(:data => method)
       invoke_ae
 
       @service.reload
-      expect(@service.display).to be_falsey
+      expect(@service.visible).to be_falsey
     end
   end
 


### PR DESCRIPTION
`DEPRECATION WARNING: display= is deprecated and will be removed from ManageIQ L-release (visible=) (called from block (3 levels) in <top (required)> at /home/travis/build/ManageIQ/manageiq-automation_engine/spec/service_models/miq_ae_service_service_spec.rb:56)`

it's failing because the repo's red, https://github.com/ManageIQ/manageiq-automation_engine/pull/448 fixes the failure