### PR TITLE
remove unused to_xml

### DIFF
--- a/spec/miq_ae_collect_spec.rb
+++ b/spec/miq_ae_collect_spec.rb
@@ -16,7 +16,6 @@ describe "MiqAeCollect" do
     ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO#get_months", @user)
     expect(ws).not_to be_nil
 
-    # puts ws.to_xml
     months = ws.root("months")
     expect(months).not_to be_nil
     expect(months.class.to_s).to eq("Hash")
@@ -34,7 +33,6 @@ describe "MiqAeCollect" do
   it "collects weekdays" do
     ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO#get_weekdays", @user)
     expect(ws).not_to be_nil
-    # puts ws.to_xml
     weekdays = ws.root("weekdays")
     expect(weekdays).not_to be_nil
     expect(weekdays.class.to_s).to eq("Hash")
@@ -51,7 +49,6 @@ describe "MiqAeCollect" do
 
     ws = MiqAeEngine.instantiate("/TEST/COLLECT/INFO#get_weekdays", @user)
     expect(ws).not_to be_nil
-    # puts ws.to_xml
     weekdays = ws.root("weekdays")
     expect(weekdays).not_to be_nil
     expect(weekdays.class.to_s).to eq("Array")

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -556,8 +556,6 @@ describe MiqAeEngine do
     expect(ws.roots.length).to eq(4)
     expect(ws.roots[3].attributes["attr1"]).to eq("frank")
 
-    # puts ws.to_expanded_xml()
-
     ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test_password", user)
     expect(ws).not_to be_nil
     roots = ws.roots
@@ -565,7 +563,6 @@ describe MiqAeEngine do
     expect(roots).to be_a_kind_of(Array)
     expect(roots.length).to eq(1)
     expect(MiqAePassword.decrypt_if_password(roots.first.attributes["password"])).to eq("secret")
-    # puts ws.to_expanded_xml()
   end
 
   it "follows relationships properly" do

--- a/spec/miq_ae_method_spec.rb
+++ b/spec/miq_ae_method_spec.rb
@@ -54,7 +54,6 @@ describe MiqAeMethod do
       expect(ws).not_to be_nil
       ws = MiqAeEngine.instantiate("/EVM/SYSTEM/TEST/FOO/test_inline", @user)
       expect(ws).not_to be_nil
-      # puts ws.to_expanded_xml()
     end
 
     it "properly processes instance methods via relationship via no inheritance" do

--- a/spec/miq_ae_state_machine_spec.rb
+++ b/spec/miq_ae_state_machine_spec.rb
@@ -21,7 +21,6 @@ describe "MiqAeStateMachine" do
     expect(ws.root['ae_result']).to eq('ok')
     expect(ws.root['ae_state']).to eq('final')
 
-    # puts ws.to_xml
     #     puts "Old Provision Technique took #{t1 - t0} seconds"
   end
 
@@ -36,7 +35,6 @@ describe "MiqAeStateMachine" do
     expect(ws).not_to be_nil
     expect(ws.root['ae_result']).to eq('ok')
     expect(ws.root['ae_state']).to eq('')
-    # puts ws.to_xml
     #     puts "New Provision Technique took #{t1 - t0} seconds"
   end
 
@@ -52,7 +50,6 @@ describe "MiqAeStateMachine" do
     expect(ws).not_to be_nil
     expect(ws.root['ae_result']).to eq('error')
     expect(ws.root['ae_state']).to eq('ProvisionCheck')
-    # puts ws.to_xml
   end
 
   it "raises exception properly during a provision request" do
@@ -68,7 +65,6 @@ describe "MiqAeStateMachine" do
     expect(ws).not_to be_nil
     expect(ws.root['ae_result']).to eq('error')
     expect(ws.root['ae_state']).to eq('ProvisionCheck')
-    # puts ws.to_xml
   end
 
   it "properly overrides class values with instance values, when they are present" do
@@ -84,7 +80,6 @@ describe "MiqAeStateMachine" do
     # t1 = Time.now
 
     expect(ws).not_to be_nil
-    # puts ws.to_xml
     # puts "New Provision (with instance override) Technique took #{t1 - t0} seconds"
   end
 


### PR DESCRIPTION

my earlier pr was biting off more than i can chew at once
so maybe i can get away with smaller steps
we're not using any of these calls and if we're going to remove to_xml anytime this would be an okay start