### PR TITLE
Remove unused refresh_new_target builtin method

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -123,10 +123,6 @@ module MiqAeEngine
       event_object_from_workspace(obj).refresh(inputs['target'], true)
     end
 
-    def self.miq_event_action_refresh_new_target(obj, _inputs)
-      event_object_from_workspace(obj).refresh_new_target
-    end
-
     def self.miq_event_action_policy(obj, inputs)
       event_object_from_workspace(obj).policy(inputs['target'], inputs['policy_event'], inputs['param'])
     end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_ems_event.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_ems_event.rb
@@ -8,10 +8,6 @@ module MiqAeMethodService
       ar_method { @object.refresh(*targets, sync) } unless targets.blank?
     end
 
-    def refresh_new_target
-      ar_method { @object.refresh_new_target }
-    end
-
     def policy(target_str, policy_event, param)
       ar_method { @object.policy(target_str, policy_event, param) }
     end


### PR DESCRIPTION
The refresh_new_target method is deprecated and only has one user (RHV).  Once that is deleted we can remove this method.

Depends:
- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/515
- [x] https://github.com/ManageIQ/manageiq-content/pull/666