### PR TITLE
add expose check_connection to generic service

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_generic.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_generic.rb
@@ -7,5 +7,6 @@ module MiqAeMethodService
     expose :check_refreshed
     expose :postprocess
     expose :on_error
+    expose :check_connection
   end
 end


### PR DESCRIPTION
We need to expose `check_connection`, see the rest of the related changes on https://github.com/ManageIQ/manageiq/pull/20773. 

@miq-bot add_label ivanchuk/yes

part of https://bugzilla.redhat.com/show_bug.cgi?id=1835226 fix 