### PR TITLE
Use :provider_embedded_ansible factory

### DIFF
--- a/spec/miq_ae_playbook_method_spec.rb
+++ b/spec/miq_ae_playbook_method_spec.rb
@@ -9,7 +9,8 @@ describe MiqAeEngine::MiqAePlaybookMethod do
     let(:method_name) { "Freddy Kreuger" }
     let(:method_key) { "FreddyKreuger_ansible_method_task_id" }
     let(:miq_task) { FactoryBot.create(:miq_task) }
-    let(:manager)  { FactoryBot.create(:embedded_automation_manager_ansible) }
+    let(:provider) { FactoryBot.create(:provider_embedded_ansible) }
+    let(:manager)  { provider.automation_manager }
     let(:playbook) { FactoryBot.create(:embedded_playbook, :manager => manager, :name => 'playbook_test.yml') }
     let(:stack_job) { FactoryBot.create(:embedded_ansible_job, :miq_task => miq_task) }
     let(:resolved_hosts) { "1.1.1.94" }

--- a/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -676,7 +676,8 @@ describe MiqAeDatastore do
 
   context "import and export with playbook method type" do
     let(:miq_ae_class) { MiqAeClass.first }
-    let(:manager)      { FactoryBot.create(:embedded_automation_manager_ansible) }
+    let(:provider)     { FactoryBot.create(:provider_embedded_ansible) }
+    let(:manager)      { provider.automation_manager }
     let(:repo)         { FactoryBot.create(:embedded_ansible_configuration_script_source) }
     let(:playbook)     { FactoryBot.create(:embedded_playbook, :manager => manager) }
     let(:cred)         { FactoryBot.create(:embedded_ansible_credential, :manager => manager, :name => 'cred') }


### PR DESCRIPTION
This will be changed in ManageIQ/manageiq#20816 and make the solo manager unable to be created as a factory.