### PR TITLE
Move $miq_ae_logger initialization and configuration into plugin

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,3 @@
+---
+:log:
+  :level_automation: info

--- a/lib/manageiq/automation_engine/engine.rb
+++ b/lib/manageiq/automation_engine/engine.rb
@@ -15,6 +15,14 @@ module ManageIQ
       def self.plugin_name
         _('Automation Engine')
       end
+
+      def self.init_loggers
+        $miq_ae_logger ||= Vmdb::Loggers.create_logger("automation.log")
+      end
+
+      def self.apply_logger_config(config)
+        Vmdb::Loggers.apply_config_value(config, $miq_ae_logger, :level_automation)
+      end
     end
   end
 end


### PR DESCRIPTION
@agrare Please review.

From what I can tell the only callers of this left are in ui-classic ([here](https://github.com/search?q=org%3AManageIQ+miq_ae_logger+-repo%3AManageIQ%2Fmanageiq-automation_engine&type=code)), which I'm wondering if we can hide behind something like a `ManageIQ::AutomationEngine.logger`