### PR TITLE
Fix ruby 2.7 failures

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
@@ -137,8 +137,8 @@ begin
   MIQ_ARGS = $evm.inputs
 
   # Setup stdout and stderr to go through the logger on the MiqAeService instance ($evm)
-  silence_warnings { STDOUT = $stdout = $evm.stdout ; nil}
-  silence_warnings { STDERR = $stderr = $evm.stderr ; nil}
+  silence_warnings { STDOUT.close; STDOUT = $stdout = $evm.stdout ; nil}
+  silence_warnings { STDERR.close; STDERR = $stderr = $evm.stderr ; nil}
 
 rescue Exception => err
   STDERR.puts('The following error occurred during inline method preamble evaluation:')

--- a/spec/engine/miq_ae_method_spec.rb
+++ b/spec/engine/miq_ae_method_spec.rb
@@ -74,7 +74,7 @@ describe MiqAeEngine::MiqAeMethod do
       it "logs the error with file and line numbers changed in the stacktrace, and raises an exception" do
         allow($miq_ae_logger).to receive(:error).and_call_original
         expect($miq_ae_logger).to receive(:error).with("Method STDERR: /my/automate/method:2:in `my_method': unhandled exception").at_least(:once)
-        expect($miq_ae_logger).to receive(:error).with("Method STDERR: \tfrom /my/automate/method:6:in `<main>'").at_least(:once)
+        expect($miq_ae_logger).to receive(:error).with("Method STDERR: from /my/automate/method:6:in `<main>'").at_least(:once)
 
         expect { subject }.to raise_error(MiqAeException::UnknownMethodRc)
       end


### PR DESCRIPTION
This pull request was tested as part of a cross repo, [here](https://travis-ci.com/github/ManageIQ/manageiq-cross_repo-tests/builds/216566458) along with a [core change to allow ruby 2.7](https://github.com/ManageIQ/manageiq/pull/21023).

Part of https://github.com/ManageIQ/manageiq/issues/19678