### PR TITLE
Fix issue where delivery failures return 'true'

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -126,6 +126,7 @@ module MiqAeEngine
       message = "Error delivering #{ManageIQ::Password.sanitize_string(automate_attrs.inspect)} for object [#{object_name}] with state [#{state}] to Automate: #{err.message}"
       miq_task&.error(MiqTask::MESSAGE_TASK_COMPLETED_UNSUCCESSFULLY)
       _log.error(message)
+      return nil
     ensure
       vmdb_object.after_ae_delivery(ae_result.to_s.downcase) if vmdb_object.respond_to?(:after_ae_delivery)
       if miq_task && miq_task.state == MiqTask::STATE_ACTIVE


### PR DESCRIPTION
This method is expected to return nil on failures, otherwise the
workspace itself, however when there is an error, _log.error will return
true, which becomes the return value of this method.