### PR TITLE
[README.md] Fix URI diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Here is a grammar for a URI:
 
 Here is a typical example:
 
-    foo://example.com:8042/over/there?name=ferret#nose
-    \_/   \______________/\_________/ \_________/ \__/
-    |           |            |            |        |
-  scheme     authority       path        query   fragment
+    foo://example.com:8042/over/there?name=ferret#mouth
+    \_/   \______________/\_________/ \_________/ \___/
+     |           |             |           |        |
+    scheme   authority        path       query   fragment
 
 
 The Automation Engine supports two schemes (currently):


### PR DESCRIPTION
Makes sure the `scheme, authority, ...` line is tabbed in by 4 spaces so that the markdown processor treats it as a code block.

Also, re-adjusted some of the alignment of a few of the example words and brackets so it lines up nicer.