### PR TITLE
[StateVarHash] Prevent purging

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
@@ -10,8 +10,7 @@ module MiqAeEngine
     end
 
     def encode_with(coder)
-      coder[SERIALIZE_KEY] =
-        blank? ? 0 : BinaryBlob.new.tap { |bb| bb.store_data("YAML", to_h) }.id
+      coder[SERIALIZE_KEY] = blank? ? 0 : generate_binary_blob
     end
 
     def init_with(coder)
@@ -33,6 +32,17 @@ module MiqAeEngine
     end
 
     private
+
+    # returns `id` of new blob
+    def generate_binary_blob
+      blob               = BinaryBlob.new
+      blob.resource_id   = - Time.now.utc.to_i # make it negtive so this isn't a valid ID
+      blob.resource_type = "StateVarHash"
+
+      blob.store_data("YAML", to_h)
+
+      blob.id
+    end
 
     def validate_state_var_name!(name)
       if STATE_VAR_NAME_CLASSES.none? { |klass| name.kind_of?(klass) }


### PR DESCRIPTION
The `BinaryBlob` of the `StateVarHash` is purged via the following `ActiveRecord` query:

```ruby
where(:resource => nil)
```

Which simply checks if the `resource_id` is `nil`.  Since the `BinaryBlob` is destroyed when it is accessed in `init_with`, this on it's own will prevent it from being purged pre-maturely.  However, adding a pseudo negative ID based on Time it can be purged based on date to avoid bloat without adding a `created_at` column but still avoid a bloat of `BinaryBlob` records from failed automate jobs.



Links
-----

* Fixes:
  - https://github.com/ManageIQ/manageiq/issues/21351
* #405