### PR TITLE
[StateVarHash] Rely on created_at timestamp

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
@@ -35,9 +35,7 @@ module MiqAeEngine
 
     # returns `id` of new blob
     def generate_binary_blob
-      blob               = BinaryBlob.new
-      blob.resource_id   = - Time.now.utc.to_i # make it negtive so this isn't a valid ID
-      blob.resource_type = "StateVarHash"
+      blob = BinaryBlob.new
 
       blob.store_data("YAML", to_h)
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
@@ -10,8 +10,7 @@ module MiqAeEngine
     end
 
     def encode_with(coder)
-      coder[SERIALIZE_KEY] =
-        blank? ? 0 : BinaryBlob.new.tap { |bb| bb.store_data("YAML", to_h) }.id
+      coder[SERIALIZE_KEY] = blank? ? 0 : generate_binary_blob
     end
 
     def init_with(coder)
@@ -33,6 +32,17 @@ module MiqAeEngine
     end
 
     private
+
+    # returns `id` of new blob
+    def generate_binary_blob
+      blob               = BinaryBlob.new
+      blob.resource_id   = - Time.now.utc.to_i # make it negtive so this isn't a valid ID
+      blob.resource_type = "StateVarHash"
+
+      blob.store_data("YAML", to_h)
+
+      blob.id
+    end
 
     def validate_state_var_name!(name)
       if STATE_VAR_NAME_CLASSES.none? { |klass| name.kind_of?(klass) }


### PR DESCRIPTION
**Depends on:** https://github.com/ManageIQ/manageiq-schema/pull/605

**Follow up to: https://github.com/ManageIQ/manageiq-automation_engine/pull/478** (merge after)

Now that timestamps have been added to `BinaryBlob` records:

https://github.com/ManageIQ/manageiq-schema/pull/605

Don't set `resource_id` to a value that is based on `Time.now` and rely on the newly created column


Links
-----

* **Depends on:** https://github.com/ManageIQ/manageiq-schema/pull/605
* Follow up to https://github.com/ManageIQ/manageiq-automation_engine/pull/478