### PR TITLE
[StateVarHash] Use .secret_filter

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
@@ -23,7 +23,7 @@ module MiqAeEngine
         binary_blob.destroy
 
         $miq_ae_logger.info("Reloading state var data: ")
-        VMDBLogger.log_hashes($miq_ae_logger, blob_hash, :filter => Vmdb::Settings::PASSWORD_FIELDS)
+        VMDBLogger.log_hashes($miq_ae_logger, blob_hash, :filter => Vmdb::Settings.secret_filter)
         update(blob_hash)
       else
         $miq_ae_logger.warn("Failed to load BinaryBlob with ID [#{coder[SERIALIZE_KEY]}] for #{self.class.name}")


### PR DESCRIPTION
`.secret_filter` allows for user customized attribute keys to be filtered out, so leverage that here, as `PASSWORD_FIELDS` is still combined with that value (even if none exists).