### PR TITLE
Bug with handling of Arrays in Automate #480

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -246,7 +246,7 @@ module MiqAeEngine
   def self.create_automation_attribute_array_value(value)
     value.collect do |obj|
       obj.kind_of?(ActiveRecord::Base) ? "#{obj.class.name}::#{obj.id}" : obj.to_s
-    end.join(",")
+    end.join("\x1F")
   end
 
   def self.set_automation_attributes_from_objects(objects, attrs_hash)

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -277,7 +277,7 @@ module MiqAeEngine
     end
 
     def load_array_objects_from_string(objects_str)
-      objects_str.split(',').collect do |element|
+      objects_str.split("\x1F").collect do |element|
         if element.include?(CLASS_SEPARATOR)
           klass, str_value = element.split(CLASS_SEPARATOR)
           MiqAeObject.convert_value_based_on_datatype(str_value.strip, klass.strip)

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -375,8 +375,8 @@ describe MiqAeEngine do
 
     it "with an array of Vms" do
       hash          = {"vms" => Vm.all}
-      result_str    = "Array::vms=" + hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join(",")
-      result_arr    = hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join(",")
+      result_str    = "Array::vms=#{hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join("\x1F")}"
+      result_arr    = hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join("\x1F")
       result        = MiqAeEngine.create_automation_attributes(hash)
       expect(MiqAeEngine.create_automation_attributes_string(hash)).to eq(result_str)
       expect(result["Array::vms"]).to eq(result_arr)
@@ -384,8 +384,8 @@ describe MiqAeEngine do
 
     it "with an array containing a single Vm" do
       hash          = {"vms" => [Vm.first]}
-      result_str    = "Array::vms=" + hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join(",")
-      result_arr    = hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join(",")
+      result_str    = "Array::vms=#{hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join("\x1F")}"
+      result_arr    = hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join("\x1F")
       result        = MiqAeEngine.create_automation_attributes(hash)
       expect(MiqAeEngine.create_automation_attributes_string(hash)).to eq(result_str)
       expect(result["Array::vms"]).to eq(result_arr)
@@ -406,8 +406,8 @@ describe MiqAeEngine do
 
     it "with an array of Hosts" do
       hash          = {"hosts" => Host.all}
-      result_str    = "Array::hosts=" + hash["hosts"].collect { |h| "Host::#{h.id}" }.join(",")
-      result_arr    = hash["hosts"].collect { |h| "Host::#{h.id}" }.join(",")
+      result_str    = "Array::hosts=#{hash["hosts"].collect { |h| "Host::#{h.id}" }.join("\x1F")}"
+      result_arr    = hash["hosts"].collect { |h| "Host::#{h.id}" }.join("\x1F")
       result        = MiqAeEngine.create_automation_attributes(hash)
       expect(MiqAeEngine.create_automation_attributes_string(hash)).to eq(result_str)
       expect(result["Array::hosts"]).to eq(result_arr)
@@ -415,11 +415,11 @@ describe MiqAeEngine do
 
     it "with multiple arrays" do
       hash            = {"vms" => Vm.all}
-      vm_result_str   = "Array::vms=" + hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join(",")
-      vm_result_arr   = hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join(",")
+      vm_result_str   = "Array::vms=#{hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join("\x1F")}"
+      vm_result_arr   = hash["vms"].collect { |v| "ManageIQ::Providers::Vmware::InfraManager::Vm::#{v.id}" }.join("\x1F")
       hash["hosts"]   = Host.all
-      host_result_str = "Array::hosts=" + hash["hosts"].collect { |h| "Host::#{h.id}" }.join(",")
-      host_result_arr = hash["hosts"].collect { |h| "Host::#{h.id}" }.join(",")
+      host_result_str = "Array::hosts=#{hash["hosts"].collect { |h| "Host::#{h.id}" }.join("\x1F")}"
+      host_result_arr = hash["hosts"].collect { |h| "Host::#{h.id}" }.join("\x1F")
       result          = MiqAeEngine.create_automation_attributes(hash)
       expect(result["Array::vms"]).to eq(vm_result_arr)
       expect(result["Array::hosts"]).to eq(host_result_arr)
@@ -777,7 +777,7 @@ describe MiqAeEngine do
     ems = FactoryBot.create(:ems_vmware)
 
     EvmSpecHelper.import_yaml_model(File.join(model_data_dir, "miq_ae_engine_spec5"), domain)
-    ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?Array::my_objects=Vm::#{vm1.id},ExtManagementSystem::#{ems.id},Vm::#{vm2.id}", user)
+    ws = MiqAeEngine.instantiate("/EVM/AUTOMATE/test1?Array::my_objects=Vm::#{vm1.id}\x1FExtManagementSystem::#{ems.id}\x1FVm::#{vm2.id}", user)
     my_objects_array = ws.root("my_objects")
     expect(my_objects_array.length).to eq(3)
     my_objects_array.each { |o| o.kind_of?(MiqAeMethodService::MiqAeServiceModelBase) }


### PR DESCRIPTION
This PR aims to fix the issue - https://github.com/ManageIQ/manageiq-automation_engine/issues/480

**backport:** also include https://github.com/ManageIQ/manageiq/pull/21520

After the change- 
![Screenshot 2021-10-13 at 6 42 34 PM](https://user-images.githubusercontent.com/16753936/137139942-9624ce11-0dc1-46e2-979c-0facf6ea5524.png)

After spending lots of hours on regex to match the scenarios of wrapping special characters around the option values, I came to sense. I realized that array elements could be stored and retrieved with this small change without worrying about the special characters.
