### PR TITLE
Fix tests for manageiq-password 1.0 upgrade

### DIFF
--- a/spec/models/miq_ae_password_spec.rb
+++ b/spec/models/miq_ae_password_spec.rb
@@ -26,8 +26,12 @@ describe MiqAePassword do
       expect(described_class.decrypt(ManageIQ::Password.encrypt(plaintext))).to eq(plaintext)
     end
 
-    it "throws understandable error" do
-      expect { described_class.decrypt("v1:{something}") }.to raise_error(ManageIQ::Password::PasswordError)
+    it "throws error for plaintext password" do
+      expect { described_class.decrypt("passw0rd") }.to raise_error(ManageIQ::Password::PasswordError)
+    end
+
+    it "throws error for undecryptable strings" do
+      expect { described_class.decrypt("v2:{something}") }.to raise_error(ManageIQ::Password::PasswordError)
     end
   end
 


### PR DESCRIPTION
This change, along with ManageIQ/manageiq-password#26 will handle the
changes for the 1.0 upgrade of manageiq-password

Depends on ManageIQ/manageiq-password#26 and subsequent patch release.