### PR TITLE
Remove direct reference to VMDBLogger

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash.rb
@@ -22,7 +22,7 @@ module MiqAeEngine
         binary_blob.destroy
 
         $miq_ae_logger.info("Reloading state var data: ")
-        VMDBLogger.log_hashes($miq_ae_logger, blob_hash, :filter => Vmdb::Settings.secret_filter)
+        $miq_ae_logger.log_hashes(blob_hash, :filter => Vmdb::Settings.secret_filter)
         update(blob_hash)
       else
         $miq_ae_logger.warn("Failed to load BinaryBlob with ID [#{coder[SERIALIZE_KEY]}] for #{self.class.name}")


### PR DESCRIPTION
@agrare Please review.  This will use log_hashes from ManageIQ::Loggers, which gets us away from VMDBLogger.