### PR TITLE
The `#refresh_ems` method now calls `.queue_refresh`

### DIFF
--- a/spec/service_models/miq_ae_service_orchestration_stack_spec.rb
+++ b/spec/service_models/miq_ae_service_orchestration_stack_spec.rb
@@ -37,7 +37,7 @@ describe MiqAeMethodService::MiqAeServiceOrchestrationStack do
     before { stack.update(:ext_management_system => FactoryBot.create(:ext_management_system)) }
 
     it "calls a refresh on OrchestrationStack object" do
-      expect(stack.class).to receive(:refresh_ems).with(stack.ext_management_system.id, stack.ems_ref)
+      expect(stack.class).to receive(:queue_refresh).with(stack.ext_management_system.id, stack.ems_ref)
       service_stack.refresh
     end
 


### PR DESCRIPTION
We're switching from `refresh_ems` to `queue_refresh` for consistency with other queue methods.  This means that the `instance#refresh_ems` method calls `Class.queue_refresh` not `Class.refresh_ems`.