### PR TITLE
Support for AWX service provision

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_script.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_script.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_ConfigurationScript < MiqAeServiceManageIQ_Providers_ExternalAutomationManager_ConfigurationScript
+  class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_ConfigurationScript < MiqAeServiceManageIQ_Providers_Awx_AutomationManager_ConfigurationScript
     expose :run
 
     def create_job(args)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_workflow.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_workflow.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_ConfigurationWorkflow < MiqAeServiceManageIQ_Providers_ExternalAutomationManager_ConfigurationScript
+  class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_ConfigurationWorkflow < MiqAeServiceManageIQ_Providers_Awx_AutomationManager_ConfigurationWorkflow
     expose :run
 
     def create_job(args)

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-job.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-job.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_Job < MiqAeServiceManageIQ_Providers_ExternalAutomationManager_OrchestrationStack
+  class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_Job < MiqAeServiceManageIQ_Providers_Awx_AutomationManager_Job
     expose :refresh_ems
     expose :raw_stdout
 

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-template_runner.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-template_runner.rb
@@ -1,5 +1,5 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_TemplateRunner < MiqAeServiceJob
+  class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_TemplateRunner < MiqAeServiceManageIQ_Providers_Awx_AutomationManager_TemplateRunner
     expose :signal
     expose :wait_on_ansible_job
 

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-awx-automation_manager-configuration_script.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-awx-automation_manager-configuration_script.rb
@@ -1,0 +1,9 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Awx_AutomationManager_ConfigurationScript < MiqAeServiceManageIQ_Providers_ExternalAutomationManager_ConfigurationScript
+    expose :run
+
+    def create_job(args)
+      ar_method { wrap_results(ManageIQ::Providers::Awx::AutomationManager::Job.create_job(@object, args)) }
+    end
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-awx-automation_manager-configuration_workflow.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-awx-automation_manager-configuration_workflow.rb
@@ -1,0 +1,9 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Awx_AutomationManager_ConfigurationWorkflow < MiqAeServiceManageIQ_Providers_ExternalAutomationManager_ConfigurationScript
+    expose :run
+
+    def create_job(args)
+      ar_method { wrap_results(ManageIQ::Providers::Awx::AutomationManager::WorkflowJob.create_job(@object, args)) }
+    end
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-awx-automation_manager-job.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-awx-automation_manager-job.rb
@@ -1,10 +1,11 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_WorkflowJob < MiqAeServiceManageIQ_Providers_Awx_AutomationManager_WorkflowJob
+  class MiqAeServiceManageIQ_Providers_Awx_AutomationManager_Job < MiqAeServiceManageIQ_Providers_ExternalAutomationManager_OrchestrationStack
     expose :refresh_ems
+    expose :raw_stdout
 
     def self.create_job(template, args = {})
       template_object = ConfigurationScript.find_by(:id => template.id)
-      klass = ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob
+      klass = ManageIQ::Providers::Awx::AutomationManager::Job
       wrap_results(klass.create_job(template_object, args))
     end
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-awx-automation_manager-template_runner.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-awx-automation_manager-template_runner.rb
@@ -1,0 +1,10 @@
+module MiqAeMethodService
+  class MiqAeServiceManageIQ_Providers_Awx_AutomationManager_TemplateRunner < MiqAeServiceJob
+    expose :signal
+    expose :wait_on_ansible_job
+
+    def self.create_job(args)
+      wrap_results(ManageIQ::Providers::Awx::AutomationManager::TemplateRunner.create_job(args))
+    end
+  end
+end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-awx-automation_manager-workflow_job.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-awx-automation_manager-workflow_job.rb
@@ -1,10 +1,10 @@
 module MiqAeMethodService
-  class MiqAeServiceManageIQ_Providers_AnsibleTower_AutomationManager_WorkflowJob < MiqAeServiceManageIQ_Providers_Awx_AutomationManager_WorkflowJob
+  class MiqAeServiceManageIQ_Providers_Awx_AutomationManager_WorkflowJob < MiqAeServiceManageIQ_Providers_ExternalAutomationManager_OrchestrationStack
     expose :refresh_ems
 
     def self.create_job(template, args = {})
       template_object = ConfigurationScript.find_by(:id => template.id)
-      klass = ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob
+      klass = ManageIQ::Providers::Awx::AutomationManager::WorkflowJob
       wrap_results(klass.create_job(template_object, args))
     end
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_service_awx.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_service_awx.rb
@@ -1,0 +1,11 @@
+module MiqAeMethodService
+  class MiqAeServiceServiceAwx < MiqAeServiceService
+    require_relative "mixins/miq_ae_service_service_ansible_tower_mixin"
+    include MiqAeServiceServiceAnsibleTowerMixin
+
+    expose :launch_job
+    expose :job
+    expose :job_options
+    expose :job_options=
+  end
+end

--- a/spec/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_workflow_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-ansible_tower-automation_manager-configuration_workflow_spec.rb
@@ -8,7 +8,7 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_AnsibleTower_Automat
   end
 
   it "#create_job" do
-    workflow_template = FactoryBot.create(:configuration_workflow)
+    workflow_template = FactoryBot.create(:ansible_configuration_workflow)
     svc_workflow_template = described_class.find(workflow_template.id)
     expect(ManageIQ::Providers::AnsibleTower::AutomationManager::WorkflowJob).to receive(:create_job)
 


### PR DESCRIPTION
- these classes are necessary in order to successfully provision an AWX service from the catalog

Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/282
- [x] Approval and transfer of https://github.com/nasark/manageiq-providers-awx

@miq-bot assign @agrare 
@miq-bot add_labels enhancement