### PR TITLE
Move show_url method up to MiqAeServiceVmOrTemplate class

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
@@ -40,9 +40,5 @@ module MiqAeMethodService
       options[:task] = task.to_s
       Vm.process_tasks(options)
     end
-
-    def show_url
-      URI.join(MiqRegion.my_region.remote_ui_url, "vm/show/#{@object.id}").to_s
-    end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm_or_template.rb
@@ -112,5 +112,9 @@ module MiqAeMethodService
     def remove_from_disk(sync = true)
       sync_or_async_ems_operation(sync, "vm_destroy")
     end
+
+    def show_url
+      URI.join(MiqRegion.my_region.remote_ui_url, "vm/show/#{@object.id}").to_s
+    end
   end
 end

--- a/spec/service_models/miq_ae_service_vm_or_template_spec.rb
+++ b/spec/service_models/miq_ae_service_vm_or_template_spec.rb
@@ -1,6 +1,13 @@
 describe MiqAeMethodService::MiqAeServiceVmOrTemplate do
   let(:vm) { FactoryBot.create(:vm_or_template, :ext_management_system => FactoryBot.create(:ext_management_system)) }
   let(:svc_vm) { MiqAeMethodService::MiqAeServiceVmOrTemplate.find(vm.id) }
+  let(:template) { FactoryBot.create(:template) }
+  let(:svc_template) { described_class.find(template.id) }
+
+  it "#show_url template" do
+    ui_url = stub_remote_ui_url
+    expect(svc_template.show_url).to eq("#{ui_url}/vm/show/#{template.id}")
+  end
 
   it "#ems_custom_set async" do
     @base_queue_options = {


### PR DESCRIPTION
As seen in https://github.com/ManageIQ/manageiq-providers-ibm_power_hmc/pull/68, template instances do not respond to `show_url` so moving the vm implementation to the common superclass.