### PR TITLE
comment the supports feature code

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm.rb
@@ -5,7 +5,9 @@ module MiqAeMethodService
     expose :resize_revert,  :override_return => nil
 
     expose :supports_resize?
+    # @return [boolean] (not using supports)
     expose :validate_resize_confirm
+    # @return [boolean] (not using supports)
     expose :validate_resize_revert
 
     expose :associate_floating_ip,    :override_return => nil
@@ -22,6 +24,9 @@ module MiqAeMethodService
       sync_or_async_ems_operation(options[:sync], "detach_volume", [volume_id])
     end
 
+    # this implents the AvailabilityMixin interface
+    # for backwards compatibility in customer scripts
+    # prefer using supports_resize? method instead
     def validate_resize
       {:available => supports_resize?, :message => unsupported_reason(:resize)}
     end


### PR DESCRIPTION
We have `validate_resize` for backwards compatibility.
It feels safer to just implement this rather than ask the customer
to find this method and update it.

the 2 validate methods look like they are implementing the AvailabilityMixin
but they are just a boolean method instead