### PR TITLE
Support ruby 3

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -36,7 +36,7 @@ module MiqAeEngine
     end
 
     def self.miq_send_email(_obj, inputs)
-      MiqAeMethodService::MiqAeServiceMethods.send_email(inputs["to"], inputs["from"], inputs["subject"], inputs["body"], :cc => inputs["cc"], :bcc => inputs["bcc"], :content_type => inputs["content_type"])
+      MiqAeMethodService::MiqAeServiceMethods.send_email(inputs["to"], inputs["from"], inputs["subject"], inputs["body"], {:cc => inputs["cc"], :bcc => inputs["bcc"], :content_type => inputs["content_type"]})
     end
 
     def self.miq_snmp_trap_v1(_obj, inputs)

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -36,7 +36,7 @@ module MiqAeEngine
     end
 
     def self.miq_send_email(_obj, inputs)
-      MiqAeMethodService::MiqAeServiceMethods.send_email(inputs["to"], inputs["from"], inputs["subject"], inputs["body"], {:cc => inputs["cc"], :bcc => inputs["bcc"], :content_type => inputs["content_type"]})
+      MiqAeMethodService::MiqAeServiceMethods.send_email(inputs["to"], inputs["from"], inputs["subject"], inputs["body"], :cc => inputs["cc"], :bcc => inputs["bcc"], :content_type => inputs["content_type"])
     end
 
     def self.miq_snmp_trap_v1(_obj, inputs)

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -7,18 +7,29 @@ module MiqAeMethodService
 
     SYNCHRONOUS = Rails.env.test?
 
-    def self.send_email(to, from, subject, body, options = {}) # rubocop:disable Naming/MethodParameterName
+    def self.send_email(to, from, subject, body, *args, **kwargs)
+      # TODO: Remove this mess once we're on ruby 3.0+ only: go back to only kwargs.
+      # This is the only method that was expecting kwargs and one caller, execute_with_user,
+      # was changed to capture the kwargs as a hash (via **kwargs) and append them to the args
+      # and call MiqAeServiceMethods methods with those args. We now accept options hash as the last
+      # args or kwargs for any non execute_with_user callers.
+      options = if kwargs.present?
+        kwargs
+      else
+        args.last || {}
+      end
+
+      # we accept only 3 kwargs / options keys
+      options = options.slice(:cc, :bcc, :content_type)
+
       ar_method do
         meth = SYNCHRONOUS ? :deliver : :deliver_queue
-        options = {
+        options.merge!({
           :to           => to,
           :from         => from,
-          :cc           => options[:cc],
-          :bcc          => options[:bcc],
           :subject      => subject,
-          :content_type => options[:content_type],
           :body         => body
-        }
+        })
         GenericMailer.send(meth, :automation_notification, options)
         true
       end

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -144,7 +144,7 @@ module MiqAeMethodService
       # Need to add the username into the array of params
       # TODO: This code should pass a real username, similar to how the web-service
       #      passes the name of the user that logged into the web-service.
-      args.insert(1, User.lookup_by_userid("admin")) if args.kind_of?(Array)
+      args << User.lookup_by_userid("admin")
       MiqAeServiceModelBase.wrap_results(MiqProvisionVirtWorkflow.from_ws(*args))
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -7,16 +7,16 @@ module MiqAeMethodService
 
     SYNCHRONOUS = Rails.env.test?
 
-    def self.send_email(to, from, subject, body, content_type: nil, cc: nil, bcc: nil) # rubocop:disable Naming/MethodParameterName
+    def self.send_email(to, from, subject, body, options = {}) # rubocop:disable Naming/MethodParameterName
       ar_method do
         meth = SYNCHRONOUS ? :deliver : :deliver_queue
         options = {
           :to           => to,
           :from         => from,
-          :cc           => cc,
-          :bcc          => bcc,
+          :cc           => options[:cc],
+          :bcc          => options[:bcc],
           :subject      => subject,
-          :content_type => content_type,
+          :content_type => options[:content_type],
           :body         => body
         }
         GenericMailer.send(meth, :automation_notification, options)

--- a/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
@@ -49,12 +49,12 @@ describe MiqAeMethodService::MiqAeServiceMethods do
       method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:send_email, #{options[:to].inspect}, #{options[:from].inspect}, #{options[:subject].inspect}, #{options[:body].inspect}, {:bcc => #{options[:bcc].inspect}, :cc => #{options[:cc].inspect}, :content_type => #{options[:content_type].inspect}})"
       @ae_method.update(:data => method)
       stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', false)
-      expect(MiqQueue).to receive(:put).with(
+      expect(MiqQueue).to receive(:put).with({
         :class_name  => 'GenericMailer',
         :method_name => "deliver",
         :args        => [:automation_notification, options],
         :role        => "notifier"
-      ).once
+      }).once
       ae_object = invoke_ae.root(@ae_result_key)
       expect(ae_object).to be_truthy
     end

--- a/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
@@ -41,6 +41,25 @@ describe MiqAeMethodService::MiqAeServiceMethods do
       expect(ae_object).to be_truthy
     end
 
+    it "sends mail and rejects invalid inputs" do
+      method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:send_email, #{options[:to].inspect}, #{options[:from].inspect}, #{options[:subject].inspect}, #{options[:body].inspect}, :bcc => #{options[:bcc].inspect}, :cc => #{options[:cc].inspect}, :joe => 'OMG', :content_type => #{options[:content_type].inspect})"
+      @ae_method.update(:data => method)
+      stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', true)
+      expect(GenericMailer).to receive(:deliver).with(:automation_notification, options).once
+      ae_object = invoke_ae.root(@ae_result_key)
+      expect(ae_object).to be_truthy
+    end
+
+    it "sends mail synchronous with no options or kwargs" do
+      method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:send_email, #{options[:to].inspect}, #{options[:from].inspect}, #{options[:subject].inspect}, #{options[:body].inspect}, nil)"
+      @ae_method.update(:data => method)
+      stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', true)
+      lesser_options = options.except(:cc, :bcc, :content_type)
+      expect(GenericMailer).to receive(:deliver).with(:automation_notification, lesser_options).once
+      ae_object = invoke_ae.root(@ae_result_key)
+      expect(ae_object).to be_truthy
+    end
+
     it "sends mail synchronous with options hash (for backwards compatibility with ruby 2.7) - drop when we drop ruby 2.7" do
       method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:send_email, #{options[:to].inspect}, #{options[:from].inspect}, #{options[:subject].inspect}, #{options[:body].inspect}, {:bcc => #{options[:bcc].inspect}, :cc => #{options[:cc].inspect}, :content_type => #{options[:content_type].inspect}})"
       @ae_method.update(:data => method)

--- a/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
@@ -41,6 +41,15 @@ describe MiqAeMethodService::MiqAeServiceMethods do
       expect(ae_object).to be_truthy
     end
 
+    it "sends mail synchronous with options hash (for backwards compatibility with ruby 2.7) - drop when we drop ruby 2.7" do
+      method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:send_email, #{options[:to].inspect}, #{options[:from].inspect}, #{options[:subject].inspect}, #{options[:body].inspect}, {:bcc => #{options[:bcc].inspect}, :cc => #{options[:cc].inspect}, :content_type => #{options[:content_type].inspect}})"
+      @ae_method.update(:data => method)
+      stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', true)
+      expect(GenericMailer).to receive(:deliver).with(:automation_notification, options).once
+      ae_object = invoke_ae.root(@ae_result_key)
+      expect(ae_object).to be_truthy
+    end
+
     it "sends mail asynchronous" do
       miq_server = EvmSpecHelper.local_miq_server
       MiqRegion.seed
@@ -60,52 +69,102 @@ describe MiqAeMethodService::MiqAeServiceMethods do
     end
   end
 
-  it "#snmp_trap_v1" do
-    to      = "wilma@bedrock.gov"
-    from    = "fred@bedrock.gov"
-    inputs  = {:to => to, :from => from}
-    method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:snmp_trap_v1, #{inputs.inspect})"
-    @ae_method.update(:data => method)
+  context "#snmp_trap" do
+    it "_v1" do
+      to      = "wilma@bedrock.gov"
+      from    = "fred@bedrock.gov"
+      inputs  = {:to => to, :from => from}
+      method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:snmp_trap_v1, #{inputs.inspect})"
+      @ae_method.update(:data => method)
 
-    stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', true)
-    expect(MiqSnmp).to receive(:trap_v1).with(inputs).once
-    ae_object = invoke_ae.root(@ae_result_key)
-    expect(ae_object).to be_truthy
+      stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', true)
+      expect(MiqSnmp).to receive(:trap_v1).with(inputs).once
+      ae_object = invoke_ae.root(@ae_result_key)
+      expect(ae_object).to be_truthy
 
-    stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', false)
-    expect(MiqQueue).to receive(:put).with(
-      :class_name  => "MiqSnmp",
-      :method_name => "trap_v1",
-      :args        => [inputs],
-      :role        => "notifier",
-      :zone        => nil
-    ).once
-    ae_object = invoke_ae.root(@ae_result_key)
-    expect(ae_object).to be_truthy
-  end
+      stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', false)
+      expect(MiqQueue).to receive(:put).with(
+        :class_name  => "MiqSnmp",
+        :method_name => "trap_v1",
+        :args        => [inputs],
+        :role        => "notifier",
+        :zone        => nil
+      ).once
+      ae_object = invoke_ae.root(@ae_result_key)
+      expect(ae_object).to be_truthy
+    end
 
-  it "#snmp_trap_v2" do
-    to      = "wilma@bedrock.gov"
-    from    = "fred@bedrock.gov"
-    inputs  = {:to => to, :from => from}
-    method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:snmp_trap_v2, #{inputs.inspect})"
-    @ae_method.update(:data => method)
+    it "_v2" do
+      to      = "wilma@bedrock.gov"
+      from    = "fred@bedrock.gov"
+      inputs  = {:to => to, :from => from}
+      method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:snmp_trap_v2, #{inputs.inspect})"
+      @ae_method.update(:data => method)
 
-    stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', true)
-    expect(MiqSnmp).to receive(:trap_v2).with(inputs).once
-    ae_object = invoke_ae.root(@ae_result_key)
-    expect(ae_object).to be_truthy
+      stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', true)
+      expect(MiqSnmp).to receive(:trap_v2).with(inputs).once
+      ae_object = invoke_ae.root(@ae_result_key)
+      expect(ae_object).to be_truthy
 
-    stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', false)
-    expect(MiqQueue).to receive(:put).with(
-      :class_name  => "MiqSnmp",
-      :method_name => "trap_v2",
-      :args        => [inputs],
-      :role        => "notifier",
-      :zone        => nil
-    ).once
-    ae_object = invoke_ae.root(@ae_result_key)
-    expect(ae_object).to be_truthy
+      stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', false)
+      expect(MiqQueue).to receive(:put).with(
+        :class_name  => "MiqSnmp",
+        :method_name => "trap_v2",
+        :args        => [inputs],
+        :role        => "notifier",
+        :zone        => nil
+      ).once
+      ae_object = invoke_ae.root(@ae_result_key)
+      expect(ae_object).to be_truthy
+    end
+
+    it "_v1 kwargs" do
+      to      = "wilma@bedrock.gov"
+      from    = "fred@bedrock.gov"
+      inputs  = {:to => to, :from => from}
+      method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:snmp_trap_v1, **#{inputs.inspect})"
+      @ae_method.update(:data => method)
+
+      stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', true)
+      expect(MiqSnmp).to receive(:trap_v1).with(inputs).once
+      ae_object = invoke_ae.root(@ae_result_key)
+      expect(ae_object).to be_truthy
+
+      stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', false)
+      expect(MiqQueue).to receive(:put).with(
+        :class_name  => "MiqSnmp",
+        :method_name => "trap_v1",
+        :args        => [inputs],
+        :role        => "notifier",
+        :zone        => nil
+      ).once
+      ae_object = invoke_ae.root(@ae_result_key)
+      expect(ae_object).to be_truthy
+    end
+
+    it "_v2 kwargs" do
+      to      = "wilma@bedrock.gov"
+      from    = "fred@bedrock.gov"
+      inputs  = {:to => to, :from => from}
+      method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:snmp_trap_v2, **#{inputs.inspect})"
+      @ae_method.update(:data => method)
+
+      stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', true)
+      expect(MiqSnmp).to receive(:trap_v2).with(inputs).once
+      ae_object = invoke_ae.root(@ae_result_key)
+      expect(ae_object).to be_truthy
+
+      stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', false)
+      expect(MiqQueue).to receive(:put).with(
+        :class_name  => "MiqSnmp",
+        :method_name => "trap_v2",
+        :args        => [inputs],
+        :role        => "notifier",
+        :zone        => nil
+      ).once
+      ae_object = invoke_ae.root(@ae_result_key)
+      expect(ae_object).to be_truthy
+    end
   end
 
   it "#vm_templates" do
@@ -142,6 +201,20 @@ describe MiqAeMethodService::MiqAeServiceMethods do
   end
 
   it "#category_create" do
+    @ae_method.update(:data => category_create_script)
+
+    expect(invoke_ae.root(@ae_result_key)).to be_truthy
+  end
+
+  def category_create_script_kwargs
+    <<-'RUBY'
+    options = {:name => 'flintstones',
+               :description => 'testing'}
+    $evm.root['foo'] = $evm.execute(:category_create, **options)
+    RUBY
+  end
+
+  it "#category_create kwargs" do
     @ae_method.update(:data => category_create_script)
 
     expect(invoke_ae.root(@ae_result_key)).to be_truthy
@@ -255,6 +328,16 @@ describe MiqAeMethodService::MiqAeServiceMethods do
     expect(ct.entries.collect(&:name).include?('fred')).to be_truthy
   end
 
+  it "#tag_create kwargs" do
+    ct = FactoryBot.create(:classification_department_with_tags)
+    method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:tag_create, #{ct.name.inspect}, :name => 'fred', :description => 'ABC')"
+    @ae_method.update(:data => method)
+
+    expect(invoke_ae.root(@ae_result_key)).to be_truthy
+    ct.reload
+    expect(ct.entries.collect(&:name).include?('fred')).to be_truthy
+  end
+
   context "#tag_delete!" do
     let(:ct) { FactoryBot.create(:classification_department_with_tags) }
     let(:entry_name) { ct.entries.first.name }
@@ -326,6 +409,77 @@ describe MiqAeMethodService::MiqAeServiceMethods do
       @ae_method.update(:data => method)
 
       expect(invoke_ae.root(@ae_result_key)).to be false
+    end
+  end
+
+  context "#create_provision_request" do
+    let(:workspace) do
+      double("MiqAeEngine::MiqAeWorkspaceRuntime",
+             :persist_state_hash => MiqAeEngine::StateVarHash.new,
+             :ae_user            => user)
+    end
+    let(:user) { double }
+    let(:miq_ae_service) { MiqAeMethodService::MiqAeService.new(workspace) }
+    before do
+      allow(User).to receive(:lookup_by_userid).and_return(user)
+    end
+
+    it "passes arguments correctly" do
+      expect(MiqProvisionVirtWorkflow).to receive(:from_ws).with('one', 'two', user).and_return(true)
+      expect(MiqAeMethodService::MiqAeServiceModelBase).to receive(:wrap_results).and_return(true)
+      allow(workspace).to receive(:disable_rbac)
+      miq_ae_service.execute(:create_provision_request, 'one', 'two')
+    end
+
+    it "passes array arguments correctly" do
+      expect(MiqProvisionVirtWorkflow).to receive(:from_ws).with(['one', 'two'], user).and_return(true)
+      expect(MiqAeMethodService::MiqAeServiceModelBase).to receive(:wrap_results).and_return(true)
+      allow(workspace).to receive(:disable_rbac)
+      miq_ae_service.execute(:create_provision_request, %w[one two])
+    end
+
+    it "passes empty array arguments correctly" do
+      expect(MiqProvisionVirtWorkflow).to receive(:from_ws).with([], user).and_return(true)
+      expect(MiqAeMethodService::MiqAeServiceModelBase).to receive(:wrap_results).and_return(true)
+      allow(workspace).to receive(:disable_rbac)
+      miq_ae_service.execute(:create_provision_request, [])
+    end
+
+    it "passes nil argument correctly" do
+      expect(MiqProvisionVirtWorkflow).to receive(:from_ws).with(user).and_return(true)
+      expect(MiqAeMethodService::MiqAeServiceModelBase).to receive(:wrap_results).and_return(true)
+      allow(workspace).to receive(:disable_rbac)
+      miq_ae_service.execute(:create_provision_request)
+    end
+  end
+
+  context "#create_automation_request" do
+    let(:workspace) do
+      double("MiqAeEngine::MiqAeWorkspaceRuntime",
+             :persist_state_hash => MiqAeEngine::StateVarHash.new,
+             :ae_user            => user)
+    end
+    let(:user)           { double }
+    let(:admin_user)     { double }
+    let(:miq_ae_service) { MiqAeMethodService::MiqAeService.new(workspace) }
+    let(:auto_approve)   { true }
+    let(:options)        { {:test => 1} }
+
+    it "passes arguments correctly" do
+      expect(AutomationRequest).to receive(:create_request).with(options, user, auto_approve).and_return(true)
+      expect(MiqAeMethodService::MiqAeServiceModelBase).to receive(:wrap_results).and_return(true)
+      allow(workspace).to receive(:disable_rbac)
+      allow(User).to receive(:lookup_by_userid!).and_return(user)
+      miq_ae_service.execute(:create_automation_request, options, user, auto_approve)
+    end
+
+    it "passes arguments correctly from defaults" do
+      expect(AutomationRequest).to receive(:create_request).with(options, admin_user, false).and_return(true)
+      expect(MiqAeMethodService::MiqAeServiceModelBase).to receive(:wrap_results).and_return(true)
+      allow(workspace).to receive(:disable_rbac)
+      allow(User).to receive(:lookup_by_userid!).and_return(admin_user)
+
+      miq_ae_service.execute(:create_automation_request, options)
     end
   end
 

--- a/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
@@ -33,7 +33,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
     end
 
     it "sends mail synchronous" do
-      method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:send_email, #{options[:to].inspect}, #{options[:from].inspect}, #{options[:subject].inspect}, #{options[:body].inspect}, {:bcc => #{options[:bcc].inspect}, :cc => #{options[:cc].inspect}, :content_type => #{options[:content_type].inspect}})"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:send_email, #{options[:to].inspect}, #{options[:from].inspect}, #{options[:subject].inspect}, #{options[:body].inspect}, :bcc => #{options[:bcc].inspect}, :cc => #{options[:cc].inspect}, :content_type => #{options[:content_type].inspect})"
       @ae_method.update(:data => method)
       stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', true)
       expect(GenericMailer).to receive(:deliver).with(:automation_notification, options).once
@@ -46,7 +46,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
       MiqRegion.seed
       miq_server.server_roles << FactoryBot.create(:server_role, :name => 'notifier')
 
-      method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:send_email, #{options[:to].inspect}, #{options[:from].inspect}, #{options[:subject].inspect}, #{options[:body].inspect}, {:bcc => #{options[:bcc].inspect}, :cc => #{options[:cc].inspect}, :content_type => #{options[:content_type].inspect}})"
+      method = "$evm.root['#{@ae_result_key}'] = $evm.execute(:send_email, #{options[:to].inspect}, #{options[:from].inspect}, #{options[:subject].inspect}, #{options[:body].inspect}, :bcc => #{options[:bcc].inspect}, :cc => #{options[:cc].inspect}, :content_type => #{options[:content_type].inspect})"
       @ae_method.update(:data => method)
       stub_const('MiqAeMethodService::MiqAeServiceMethods::SYNCHRONOUS', false)
       expect(MiqQueue).to receive(:put).with({

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -80,7 +80,7 @@ describe MiqAeEngine do
         object_id = cluster.id
         automate_attrs = {"#{object_type}::#{object_type.underscore}" => object_id,
                           "User::user"                                => user.id}
-        expect(MiqAeEngine).to receive(:create_automation_object).with(instance_name, automate_attrs, :vmdb_object => cluster).and_return('uri')
+        expect(MiqAeEngine).to receive(:create_automation_object).with(instance_name, automate_attrs, {:vmdb_object => cluster}).and_return('uri')
         expect(call_automate(object_type, object_id)).to be_nil
       end
 
@@ -90,7 +90,7 @@ describe MiqAeEngine do
         object_id = ems.id
         automate_attrs = {"#{base_name}::#{base_name.underscore}" => object_id,
                           "User::user"                            => user.id}
-        expect(MiqAeEngine).to receive(:create_automation_object).with(instance_name, automate_attrs, :vmdb_object => ems).and_return('uri')
+        expect(MiqAeEngine).to receive(:create_automation_object).with(instance_name, automate_attrs, {:vmdb_object => ems}).and_return('uri')
         expect(call_automate(object_type, object_id)).to be_nil
       end
     end
@@ -141,7 +141,7 @@ describe MiqAeEngine do
           args[:fqclass_name] = "Factory/StateMachines/ServiceProvision_template"
           args[:user_id] = user.id
           args[:miq_group_id] = user.current_group.id
-          expect(MiqAeEngine).to receive(:create_automation_object).with("DEFAULT", attrs, :fqclass => "Factory/StateMachines/ServiceProvision_template").and_return('uri')
+          expect(MiqAeEngine).to receive(:create_automation_object).with("DEFAULT", attrs, {:fqclass => "Factory/StateMachines/ServiceProvision_template"}).and_return('uri')
           expect(MiqAeEngine.deliver(args)).to eq(@ws)
         end
       end


### PR DESCRIPTION
* rspec-mocks 3.10.3 requires "with" to be explicit with hashes vs. kwargs
* Handle ruby 2.6-3.0+ kwargs/options
  Change `execute_with_user` to capture any kwargs passed as a hash and append to args passed in and call the `MiqAeServiceMethods` method with these args but never send over the kwargs.  Therefore all `MiqAeServiceMethods` methods can be made to only accept options hashes and never kwargs.  This works with ruby 2.6-3.0+. We can change this when we drop ruby 2.
* Add tests for methods to exercise ruby 3/2 args
* Fix bug where conditional is always true, and handling nil/empty array

