### PR TITLE
Handle a nil svc in DrbRemoteInvoker#with_server

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
@@ -12,9 +12,12 @@ module MiqAeEngine
       setup if num_methods.zero?
       self.num_methods += 1
       svc = MiqAeMethodService::MiqAeService.new(@workspace, inputs)
-      yield build_method_content(bodies, method_name, svc.object_id, script_info)
+      begin
+        yield build_method_content(bodies, method_name, svc.object_id, script_info)
+      ensure
+        svc.destroy # Reset inputs to empty to avoid storing object references
+      end
     ensure
-      svc.destroy # Reset inputs to empty to avoid storing object references
       self.num_methods -= 1
       teardown if num_methods.zero?
     end


### PR DESCRIPTION
The `ensure` section of the `DrbRemoteInvoker#with_server` method does not handle an exception raised before `svc` is set and thus can call `nil.destroy`.