### PR TITLE
Use Rbac.filtered for MiqAeExpressionMethod

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_expression_method.rb
@@ -12,9 +12,7 @@ module MiqAeEngine
     end
 
     def run
-      @search_objects = Rbac.search(:filter         => MiqExpression.new(@exp),
-                                    :class          => @exp_object,
-                                    :results_format => :objects).first
+      @search_objects = Rbac.filtered(@exp_object, :filter => MiqExpression.new(@exp))
       @search_objects.empty? ? error_handler : set_result
     end
 


### PR DESCRIPTION
We were only using the search results of the return set anyway, and :results_format is no longer a valid parameter

The main reason for changing this is to ensure :skip_counts is set so we can avoid that extra processing


The tests did seem to exercise this method.