### PR TITLE
Fix issue where newer Psych fails to load the script_info

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
@@ -171,7 +171,7 @@ class Exception
   end
 
   def get_file_info(line)
-    script_info = YAML.load(SCRIPT_INFO_YAML)
+    script_info = YAML.safe_load(SCRIPT_INFO_YAML, permitted_classes: [Range])
     script_info.each do |fqname, range|
       return fqname, line - range.begin if range.cover?(line)
     end


### PR DESCRIPTION
The script_info is constructed to give metadata about the script provided by the user. One of the fields uses a Range [^1] to denote the start and end lines of the code. The script_info is passed as a yaml payload to the external executor, but newer version of Psych do not permit Range objects by default, so it fails to deserialize.

This commit allows that specific class and ensure we use safe_load for backward compatibility.

Without this change, we get the following errors when running miq_ae_method_spec.rb:

```
  1) MiqAeEngine::MiqAeMethod.invoke_inline_ruby (private) with a script that raises logs the error with file and line numbers changed in the stacktrace, and raises an exception
     Failure/Error: expect($miq_ae_logger).to receive(:error).with("Method STDERR: /my/automate/method:2:in `<main>': unhandled exception").at_least(:once)

       #<ManageIQ::Loggers::Base:0x00007fe01d743f10 @level=1, @progname="automation", @default_formatter=#<Logger::Formatter:0x00007fe01d743df8 @datetime_format=nil>, @formatter=#<ManageIQ::Loggers::Base::Formatter:0x00007fe01d743cb8 @datetime_format=nil>, @logdev=#<Logger::LogDevice:0x00007fe01d743da8 @shift_period_suffix="%Y%m%d", @shift_size=1048576, @shift_age=0, @filename=#<Pathname:/Users/jfrey/dev/manageiq/log/automation.log>, @dev=#<File:/Users/jfrey/dev/manageiq/log/automation.log>, @binmode=false, @mon_data=#<Monitor:0x00007fe01d743d80>, @mon_data_owner_object_id=39840>, @write_lock=#<Thread::Mutex:0x00007fe01d743c90>, @local_levels={}> received :error with unexpected arguments
         expected: ("Method STDERR: /my/automate/method:2:in `<main>': unhandled exception")
              got: ("<AEMethod /my/automate/method> The following error occurred during method evaluation:") (1 time)
                   ("<AEMethod /my/automate/method>   RuntimeError: ") (1 time)
                   ("Method STDERR: -: Tried to load unspecified class: Range (Psych::DisallowedClass)") (1 time)
     # ./spec/engine/miq_ae_method_spec.rb:56:in `block (4 levels) in <main>'
     # /Users/jfrey/.gem/ruby/2.7.6/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <main>'

  2) MiqAeEngine::MiqAeMethod.invoke_inline_ruby (private) with a script that raises in a nested method logs the error with file and line numbers changed in the stacktrace, and raises an exception
     Failure/Error: expect($miq_ae_logger).to receive(:error).with("Method STDERR: /my/automate/method:2:in `my_method': unhandled exception").at_least(:once)

       #<ManageIQ::Loggers::Base:0x00007fe01d743f10 @level=1, @progname="automation", @default_formatter=#<Logger::Formatter:0x00007fe01d743df8 @datetime_format=nil>, @formatter=#<ManageIQ::Loggers::Base::Formatter:0x00007fe01d743cb8 @datetime_format=nil>, @logdev=#<Logger::LogDevice:0x00007fe01d743da8 @shift_period_suffix="%Y%m%d", @shift_size=1048576, @shift_age=0, @filename=#<Pathname:/Users/jfrey/dev/manageiq/log/automation.log>, @dev=#<File:/Users/jfrey/dev/manageiq/log/automation.log>, @binmode=false, @mon_data=#<Monitor:0x00007fe01d743d80>, @mon_data_owner_object_id=39840>, @write_lock=#<Thread::Mutex:0x00007fe01d743c90>, @local_levels={}> received :error with unexpected arguments
         expected: ("Method STDERR: /my/automate/method:2:in `my_method': unhandled exception")
              got: ("<AEMethod /my/automate/method> The following error occurred during method evaluation:") (1 time)
                   ("<AEMethod /my/automate/method>   RuntimeError: ") (1 time)
                   ("Method STDERR: -: Tried to load unspecified class: Range (Psych::DisallowedClass)") (1 time)
     # ./spec/engine/miq_ae_method_spec.rb:76:in `block (4 levels) in <main>'
     # /Users/jfrey/.gem/ruby/2.7.6/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <main>'

  3) MiqAeEngine::MiqAeMethod.invoke_inline_ruby (private) embed other methods into a method exception can log stack trace in embedded methods
     Failure/Error: expect($miq_ae_logger).to receive(:error).with("<AEMethod /my/automate/method>   /Shared/Methods/RaiseException:8:in `some_method'").at_least(:once)

       #<ManageIQ::Loggers::Base:0x00007fe01d743f10 @level=1, @progname="automation", @default_formatter=#<Logger::Formatter:0x00007fe01d743df8 @datetime_format=nil>, @formatter=#<ManageIQ::Loggers::Base::Formatter:0x00007fe01d743cb8 @datetime_format=nil>, @logdev=#<Logger::LogDevice:0x00007fe01d743da8 @shift_period_suffix="%Y%m%d", @shift_size=1048576, @shift_age=0, @filename=#<Pathname:/Users/jfrey/dev/manageiq/log/automation.log>, @dev=#<File:/Users/jfrey/dev/manageiq/log/automation.log>, @binmode=false, @mon_data=#<Monitor:0x00007fe01d743d80>, @mon_data_owner_object_id=39840>, @write_lock=#<Thread::Mutex:0x00007fe01d743c90>, @local_levels={}> received :error with unexpected arguments
         expected: ("<AEMethod /my/automate/method>   /Shared/Methods/RaiseException:8:in `some_method'")
              got: ("<AEMethod /my/automate/method> The following error occurred during method evaluation:") (1 time)
                   ("<AEMethod /my/automate/method>   RuntimeError: ") (1 time)
                   ("Method STDERR: -: Tried to load unspecified class: Range (Psych::DisallowedClass)") (1 time)
     # ./spec/engine/miq_ae_method_spec.rb:360:in `block (5 levels) in <main>'
     # /Users/jfrey/.gem/ruby/2.7.6/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <main>'
```

[^1]: https://github.com/ManageIQ/manageiq-automation_engine/blob/77dbf078519c6b5da34c66da54bf51d1643182c5/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb#L270

@jrafanie Please review. cc @agrare 