### PR TITLE
Adds a rescue to find_miq_request_id

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -100,6 +100,10 @@ module MiqAeEngine
           root.attributes[root.attributes['vmdb_object_type']].object.miq_request_id
         end
       end
+    rescue => err
+      $miq_ae_logger.error("Failed to find miq_request_id, in root.attributes: #{root.attributes.keys}")
+      $miq_ae_logger.error(err)
+      nil
     end
 
     def rbac_enabled?

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -272,7 +272,7 @@ module MiqAeMethodService
 
     def self.find_miq_request_id(object)
       if !defined?(object.type).nil?
-        if object.type.to_s.match?("RequestEvent")
+        if object.type.to_s.include?("RequestEvent")
           return object.target_id
         elsif object.type.to_s.include?("Request")
           return object.id


### PR DESCRIPTION
Adds a rescue to `find_miq_request_id` as a precaution in case the method fails unexpectedly. This ensures that in a worst case scenario, nil is returned, which means the log won't be saved to the database but still sent to the automation logger.

Also changed `object.type.to_s.match?` to `object.type.to_s.include?` for consistency.