### PR TITLE
Fix logger when wrapped in a container/journald logger

### DIFF
--- a/lib/manageiq/automation_engine/logger.rb
+++ b/lib/manageiq/automation_engine/logger.rb
@@ -1,11 +1,13 @@
 module ManageIQ
   module AutomationEngine
     class Logger < ManageIQ::Loggers::Base
-      def add(severity, message = nil, progname = nil, resource_id: nil)
-        # Copied from Logger#add
+      private def add_to_db(severity, message = nil, progname = nil, resource_id: nil)
+        return [severity, message, progname] unless resource_id
+
+        # Adapted from Logger#add
         severity ||= UNKNOWN
-        if @logdev.nil? or severity < level
-          return true
+        if severity < level
+          return [severity, message, progname]
         end
         if progname.nil?
           progname = @progname
@@ -21,31 +23,37 @@ module ManageIQ
 
         RequestLog.create(:message => message, :severity => format_severity(severity), :resource_id => resource_id) if resource_id
 
-        super(severity, message, progname)
+        [severity, message, progname]
       end
 
       def info(progname = nil, resource_id: nil, &block)
-        add(INFO, nil, progname, resource_id: resource_id, &block)
+        severity, message, progname = add_to_db(INFO, nil, progname, resource_id: resource_id, &block)
+        add(severity, message, progname, &block)
       end
 
       def debug(progname = nil, resource_id: nil, &block)
-        add(DEBUG, nil, progname, resource_id: resource_id, &block)
+        severity, message, progname = add_to_db(DEBUG, nil, progname, resource_id: resource_id, &block)
+        add(severity, message, progname, &block)
       end
 
       def warn(progname = nil, resource_id: nil, &block)
-        add(WARN, nil, progname, resource_id: resource_id, &block)
+        severity, message, progname = add_to_db(WARN, nil, progname, resource_id: resource_id, &block)
+        add(severity, message, progname, &block)
       end
 
       def error(progname = nil, resource_id: nil, &block)
-        add(ERROR, nil, progname, resource_id: resource_id, &block)
+        severity, message, progname = add_to_db(ERROR, nil, progname, resource_id: resource_id, &block)
+        add(severity, message, progname, &block)
       end
 
       def fatal(progname = nil, resource_id: nil, &block)
-        add(FATAL, nil, progname, resource_id: resource_id, &block)
+        severity, message, progname = add_to_db(FATAL, nil, progname, resource_id: resource_id, &block)
+        add(severity, message, progname, &block)
       end
 
       def unknown(progname = nil, resource_id: nil, &block)
-        add(UNKNOWN, nil, progname, resource_id: resource_id, &block)
+        severity, message, progname = add_to_db(UNKNOWN, nil, progname, resource_id: resource_id, &block)
+        add(severity, message, progname, &block)
       end
     end
   end


### PR DESCRIPTION
The wrapped container/journald logger from core uses ActiveSupport::Logger.broadcast and then changes the underlying logger to have a nil logdev. This has the effect of writing to the wrapped logger and avoiding writing to the underlying file. However, in the case of this automation logger, we still want to write to the database, so we still need that underlying logger to execute the database part, but not the file part.

There is an added complication that ActiveSupport::Logger.broadcast fronts the `add` method, but doesn't support kwargs. Prior to this commit, we used kwargs to pass around the request_id, however, the broadcast would ignore those, instead sending them as a fourth paramater to the container loggers add method, which doesn't known about that extra parameter. To fix that issue, this commit instead creates a new method responsible for writing to the db, and then info, debug, etc will call that first before calling the original add method with the expected number of parameters.

@jrafanie Please review.