### PR TITLE
Fix MiqProvisionVirtWorkflow.from_ws user argument

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_methods.rb
@@ -155,7 +155,7 @@ module MiqAeMethodService
       # Need to add the username into the array of params
       # TODO: This code should pass a real username, similar to how the web-service
       #      passes the name of the user that logged into the web-service.
-      args << User.lookup_by_userid("admin")
+      args.insert(1, User.lookup_by_userid("admin"))
       MiqAeServiceModelBase.wrap_results(MiqProvisionVirtWorkflow.from_ws(*args))
     end
 

--- a/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_methods_spec.rb
@@ -437,17 +437,22 @@ describe MiqAeMethodService::MiqAeServiceMethods do
              :persist_state_hash => MiqAeEngine::StateVarHash.new,
              :ae_user            => user)
     end
-    let(:user) { double }
-    let(:miq_ae_service) { MiqAeMethodService::MiqAeService.new(workspace) }
+    let(:user)            { double }
+    let(:miq_ae_service)  { MiqAeMethodService::MiqAeService.new(workspace) }
+    let(:version)         { "1.1" }
+    let(:template_fields) { {"name" => "App"} }
+    let(:vm_fields)       { {'vm_name' => 'CRM_APP', 'request_type' => 'template'} }
+    let(:requester)       { {'owner_email' => 'admin@asd.com'} }
+    let(:tags)            { {'crm' => 'true'} }
     before do
       allow(User).to receive(:lookup_by_userid).and_return(user)
     end
 
     it "passes arguments correctly" do
-      expect(MiqProvisionVirtWorkflow).to receive(:from_ws).with('one', 'two', user).and_return(true)
+      expect(MiqProvisionVirtWorkflow).to receive(:from_ws).with(version, user, template_fields, vm_fields, requester, tags, nil, nil, nil).and_return(true)
       expect(MiqAeMethodService::MiqAeServiceModelBase).to receive(:wrap_results).and_return(true)
       allow(workspace).to receive(:disable_rbac)
-      miq_ae_service.execute(:create_provision_request, 'one', 'two')
+      miq_ae_service.execute(:create_provision_request, version, template_fields, vm_fields, requester, tags, nil, nil, nil)
     end
 
     it "passes array arguments correctly" do
@@ -465,7 +470,7 @@ describe MiqAeMethodService::MiqAeServiceMethods do
     end
 
     it "passes nil argument correctly" do
-      expect(MiqProvisionVirtWorkflow).to receive(:from_ws).with(user).and_return(true)
+      expect(MiqProvisionVirtWorkflow).to receive(:from_ws).with(nil, user).and_return(true)
       expect(MiqAeMethodService::MiqAeServiceModelBase).to receive(:wrap_results).and_return(true)
       allow(workspace).to receive(:disable_rbac)
       miq_ae_service.execute(:create_provision_request)


### PR DESCRIPTION
The `user` argument to MiqProvisionVirtWorkflow.from_ws must be the second positional argument not the last.  This was causing failures when calling `user.userid` when `user` was actually the `template_fields` hash payload.

I used the example from the docs for the args https://www.manageiq.org/docs/reference/latest/scripting_actions/#inline-method-to-create-a-provision-request