### PR TITLE
[WIP] Use AS::Dependencies interlock with classic autoloader

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -145,7 +145,7 @@ module MiqAeEngine
     def self.run_ruby_method(code, miq_request_id)
       ActiveRecord::Base.connection_pool.release_connection unless Rails.env.test?
       with_automation_env do
-        ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+        AsDependenciesInterlock.permit_concurrent_loads do
           run_method(Gem.ruby, miq_request_id) do |stdin|
             stdin.puts(code)
           end


### PR DESCRIPTION
Hide the details about inspecting the autoloader by using the core method which will use the interlock with classic and no interlock for zeitwerk.

Depends on: https://github.com/ManageIQ/manageiq/pull/22539
Related: https://github.com/ManageIQ/manageiq/issues/22000