### PR TITLE
Psych4 support

### DIFF
--- a/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
+++ b/spec/engine/miq_ae_method_service/miq_ae_service_model_base_spec.rb
@@ -104,13 +104,13 @@ describe MiqAeMethodService::MiqAeServiceModelBase do
     end
 
     it 'loads object from yaml' do
-      expect(YAML.safe_load(svc_service.to_yaml, [MiqAeMethodService::MiqAeServiceService])).to eq(svc_service)
+      expect(YAML.safe_load(svc_service.to_yaml, :permitted_classes => [MiqAeMethodService::MiqAeServiceService])).to eq(svc_service)
     end
 
     it 'loads invalid svc_model for objects without related ar_model' do
       yaml = svc_service.to_yaml
       service.delete
-      model_from_yaml = YAML.safe_load(yaml, [MiqAeMethodService::MiqAeServiceService])
+      model_from_yaml = YAML.safe_load(yaml, :permitted_classes => [MiqAeMethodService::MiqAeServiceService])
       expect(model_from_yaml.class).to eq(svc_service.class)
       expect(model_from_yaml.record_exists?).to eq(false)
     end

--- a/spec/engine/miq_ae_state_machine_retry_spec.rb
+++ b/spec/engine/miq_ae_state_machine_retry_spec.rb
@@ -280,6 +280,6 @@ describe "MiqAeStateMachineRetry" do
     expect(MiqQueue.count).to eq(2)
     q = MiqQueue.where(:state => 'ready').first
     expect(q[:server_guid]).to be_nil
-    expect(YAML.safe_load(q.args.first[:ae_state_data], [MiqAeEngine::StateVarHash])).to eq(ae_state_data)
+    expect(YAML.safe_load(q.args.first[:ae_state_data], :permitted_classes => [MiqAeEngine::StateVarHash])).to eq(ae_state_data)
   end
 end

--- a/spec/engine/miq_ae_state_machine_retry_spec.rb
+++ b/spec/engine/miq_ae_state_machine_retry_spec.rb
@@ -183,6 +183,7 @@ describe "MiqAeStateMachineRetry" do
   end
 
   it "check persistent hash" do
+    ActiveRecord::Base.yaml_column_permitted_classes << "MiqAeEngine::StateVarHash"
     setup_model(method_script_state_var)
     expected = MiqAeEngine::StateVarHash.new('three' => 3, 'one' => 1, 'two' => 2, 'gravy' => 'train')
     send_ae_request_via_queue(@automate_args)

--- a/spec/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash_spec.rb
+++ b/spec/lib/miq_automation_engine/engine/miq_ae_engine/state_var_hash_spec.rb
@@ -11,7 +11,7 @@ describe MiqAeEngine::StateVarHash do
     it 'should return an empty hash struct without calling BinaryBlob find' do
       expect(BinaryBlob).to_not receive(:find_by)
 
-      new_start_var_hash = YAML.safe_load(blank_yaml_string, [MiqAeEngine::StateVarHash])
+      new_start_var_hash = YAML.safe_load(blank_yaml_string, :permitted_classes => [MiqAeEngine::StateVarHash])
 
       expect(new_start_var_hash).to be_a(MiqAeEngine::StateVarHash)
       expect(new_start_var_hash).to be_blank
@@ -33,7 +33,7 @@ describe MiqAeEngine::StateVarHash do
       yaml_out = YAML.dump(state_var_hash)
       expect(BinaryBlob.count).to be(1)
 
-      YAML.safe_load(yaml_out, [MiqAeEngine::StateVarHash])
+      YAML.safe_load(yaml_out, :permitted_classes => [MiqAeEngine::StateVarHash])
       expect(BinaryBlob.count).to be_zero
     end
 
@@ -41,7 +41,7 @@ describe MiqAeEngine::StateVarHash do
       expect($miq_ae_logger).to receive(:info).with(/Reloading state var data/).and_call_original
       expect($miq_ae_logger).to receive(:info).with(/\n---/).and_call_original
 
-      new_start_var_hash = YAML.safe_load(YAML.dump(state_var_hash), [MiqAeEngine::StateVarHash])
+      new_start_var_hash = YAML.safe_load(YAML.dump(state_var_hash), :permitted_classes => [MiqAeEngine::StateVarHash])
 
       expect(new_start_var_hash).to eq(state_var_hash)
       expect(new_start_var_hash.object_id).to_not eq(start_var_hash.object_id)
@@ -53,7 +53,7 @@ describe MiqAeEngine::StateVarHash do
       expect($miq_ae_logger).to receive(:info).with(/Reloading state var data/).and_call_original
       expect($miq_ae_logger).to receive(:info).with(/\n---\nusername: foo\npassword: \[FILTERED\]/).and_call_original
 
-      new_start_var_hash = YAML.safe_load(YAML.dump(svh_with_user_pass), [MiqAeEngine::StateVarHash])
+      new_start_var_hash = YAML.safe_load(YAML.dump(svh_with_user_pass), :permitted_classes => [MiqAeEngine::StateVarHash])
 
       expect(new_start_var_hash).to eq(svh_with_user_pass)
       expect(new_start_var_hash.object_id).to_not eq(svh_with_user_pass.object_id)
@@ -65,7 +65,7 @@ describe MiqAeEngine::StateVarHash do
 
       expect($miq_ae_logger).to receive(:warn).with(/Failed to load BinaryBlob with ID/).and_call_original
 
-      restored_state_var = YAML.safe_load(yaml_out, [MiqAeEngine::StateVarHash])
+      restored_state_var = YAML.safe_load(yaml_out, :permitted_classes => [MiqAeEngine::StateVarHash])
       expect(restored_state_var).to eq({})
     end
   end


### PR DESCRIPTION
* Update safe_load calls to work with psych 3/4

  ```
  Keep compatibility with psych 3.1+ since permitted_classes and aliases were
  added as keyword arguments to safe_load.

  Note, psych 4 changed the interface to drop support with positional arguments for the 
  permitted_classes.
  Now, we must explicitly specify them using kwargs.
  ```

Part of https://github.com/ManageIQ/manageiq/issues/22696