### PR TITLE
Const get

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb
@@ -122,7 +122,9 @@ module MiqAeMethodService
     def self.create_service_model(ar_model)
       file_path = model_to_file_path(ar_model)
       if File.exist?(file_path)
-        require file_path
+        # class reloading in development causes require to no-op when it should load
+        # since we will never require this file, using load is not a big loss
+        load file_path
         model_name_from_active_record_model(ar_model).safe_constantize
       else
         dynamic_service_model_creation(ar_model, service_model_superclass(ar_model))


### PR DESCRIPTION
### Before

When development reloads classes, `MiqAeService` models run into an issue.

1. reference an unknown automate service model.
2. calls `MiqAeMethodService.const_missing`
3. `MiqAeServiceModelBase.create_service_model_from_name`
4. `MiqAeServiceModelBase.create_service_model`
5. if file containing service model is found `require file_name` *HERE*
6. reference same service model
7. since we required file, it is found and all is well

If rails reloads a class, it unloads the service models, but since the file is still marked as required, the `require` does nothing.
So the workflow changes as follows:

5. the file was already required, so `requre` is a no-op
6. reference same constant (still unknown) - step 1
7. calls `MiqAeMethodService.const_missing`
8. infinite loop

To display the dialog for provisioning a Vm, automate is called inline in the webserver, so the webserver starts crashing with stack overflow errors.

```
irb(main):001:0> MiqAeMethodService::MiqAeServiceVm
=> MiqAeMethodService::MiqAeServiceVm
irb(main):002:0> reload!
Reloading...
=> true
irb(main):003:0> MiqAeMethodService::MiqAeServiceVm
/Users/kbrock/.gem/ruby/3.0.6/gems/activesupport-6.1.7.6/lib/active_support/core_ext/string/inflections.rb:87:in `safe_constantize': stack level too deep (SystemStackError)
	from manageiq-automation_engine/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb:159:in `service_model_name_to_model'
	from manageiq-automation_engine/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service_model_base.rb:117:in `create_service_model_from_name'

```

### After

```
irb(main):001:0> MiqAeMethodService::MiqAeServiceVm
=> MiqAeMethodService::MiqAeServiceVm
irb(main):002:0> reload!
Reloading...
=> true
irb(main):003:0> MiqAeMethodService::MiqAeServiceVm
=> MiqAeMethodService::MiqAeServiceVm
irb(main):004:0> quit
```

