### PR TITLE
permit_concurrent_loads is not needed with zeitwerk autoloader

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_method.rb
@@ -145,10 +145,8 @@ module MiqAeEngine
     def self.run_ruby_method(code, miq_request_id)
       ActiveRecord::Base.connection_pool.release_connection unless Rails.env.test?
       with_automation_env do
-        ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-          run_method(Gem.ruby, miq_request_id) do |stdin|
-            stdin.puts(code)
-          end
+        run_method(Gem.ruby, miq_request_id) do |stdin|
+          stdin.puts(code)
         end
       end
     end


### PR DESCRIPTION
This was only needed for classic autoloader.  The core "freedom" patch made zeitwerk autoloader bypass the interlock anyway, so now that we're only supporting zeitwerk, this is no longer needed.

Co-dependency:
https://github.com/ManageIQ/manageiq/pull/22801

Part of the rails 7 upgrade: https://github.com/ManageIQ/manageiq/issues/22052