### PR TITLE
Allow StateVarHash to YAML.load from runtime instantiate

### DIFF
--- a/spec/engine/miq_ae_state_machine_retry_spec.rb
+++ b/spec/engine/miq_ae_state_machine_retry_spec.rb
@@ -183,7 +183,7 @@ describe "MiqAeStateMachineRetry" do
   end
 
   it "check persistent hash" do
-    ActiveRecord::Base.yaml_column_permitted_classes << "MiqAeEngine::StateVarHash"
+    YamlPermittedClasses.app_yaml_permitted_classes |= [MiqAeEngine::StateVarHash]
     setup_model(method_script_state_var)
     expected = MiqAeEngine::StateVarHash.new('three' => 3, 'one' => 1, 'two' => 2, 'gravy' => 'train')
     send_ae_request_via_queue(@automate_args)


### PR DESCRIPTION
Previously, we allowed it to be permitted in serialized columns, but this test also requires it be permitted from miq_ae_workspace_runtime.rb instantiate.

Like https://github.com/ManageIQ/manageiq-providers-vmware/pull/892, this depends on:

- [ ] https://github.com/ManageIQ/manageiq/pull/22698
- [ ] https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/835