### PR TITLE
require logger to avoid autoload during rails boot

### DIFF
--- a/lib/manageiq/automation_engine/engine.rb
+++ b/lib/manageiq/automation_engine/engine.rb
@@ -17,6 +17,8 @@ module ManageIQ
       end
 
       def self.init_loggers
+        # This require avoids autoload during rails boot
+        require 'manageiq/automation_engine/logger'
         $miq_ae_logger ||= Vmdb::Loggers.create_logger("automation.log", ManageIQ::AutomationEngine::Logger)
       end
 


### PR DESCRIPTION
Rails 7 doesn't want us to autoload during rails boot so we can avoid this by requiring the file.  Autoload assumes it should be reloaded on code change in dev mode, which doesn't make sense for code that's loaded once at boot.