### PR TITLE
drop supports_ methods

### DIFF
--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm.rb
@@ -4,7 +4,6 @@ module MiqAeMethodService
     expose :resize_confirm, :override_return => nil
     expose :resize_revert,  :override_return => nil
 
-    expose :supports_resize?
     # @return [boolean] (not using supports)
     expose :validate_resize_confirm
     # @return [boolean] (not using supports)
@@ -24,11 +23,17 @@ module MiqAeMethodService
       sync_or_async_ems_operation(options[:sync], "detach_volume", [volume_id])
     end
 
+    # backwards compatible
+    def supports_resize?
+      object_send(:supports?, :resize)
+    end
+
     # this implents the AvailabilityMixin interface
     # for backwards compatibility in customer scripts
-    # prefer using supports_resize? method instead
+    # prefer using supports?(:resize) method instead
     def validate_resize
-      {:available => supports_resize?, :message => unsupported_reason(:resize)}
+      reason = object_send(:unsupported_reason, :resize)
+      {:available => !reason, :message => reason}
     end
   end
 end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ovirt-infra_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-ovirt-infra_manager.rb
@@ -1,6 +1,5 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_Ovirt_InfraManager < MiqAeServiceEmsInfra
-    expose :supports_vm_import?
     expose :submit_import_vm
     expose :submit_configure_imported_vm_networks
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_manageiq-providers-redhat-infra_manager.rb
@@ -1,6 +1,5 @@
 module MiqAeMethodService
   class MiqAeServiceManageIQ_Providers_Redhat_InfraManager < MiqAeServiceManageIQ_Providers_Ovirt_InfraManager
-    expose :supports_vm_import?
     expose :submit_import_vm
     expose :submit_configure_imported_vm_networks
   end

--- a/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
+++ b/lib/miq_automation_engine/service_models/miq_ae_service_vm.rb
@@ -34,7 +34,7 @@ module MiqAeMethodService
     end
 
     def snapshot_operation(task, options = {})
-      raise "#{task} operation not supported for #{self.class.name}" unless object_send(:supports_snapshots?)
+      raise "#{task} operation not supported for #{self.class.name}" unless object_send(:supports?, :snapshots)
 
       options[:ids]  = [id]
       options[:task] = task.to_s

--- a/spec/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm_spec.rb
+++ b/spec/service_models/miq_ae_service_manageiq-providers-openstack-cloud_manager-vm_spec.rb
@@ -34,4 +34,12 @@ describe MiqAeMethodService::MiqAeServiceManageIQ_Providers_Openstack_CloudManag
       )
     )
   end
+
+  it "#validate_resize" do
+    expect(service_vm.validate_resize).to eq({:available => true, :message => nil})
+  end
+
+  it "#supports_resize?" do
+    expect(service_vm.supports_resize?).to eq(true)
+  end
 end


### PR DESCRIPTION
part of:
- [ ] https://github.com/ManageIQ/manageiq/pull/22883

Goal is to remove exposed methods that no longer exist.
Defining them where possible to keep backwards compatibility

- drop v2v vm_import (no longer a thing)
- backwards support for supports_resize

