### PR TITLE
Fix automation array values

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -234,14 +234,6 @@ module MiqAeEngine
     args = create_automation_attributes(hash)
     return args if args.kind_of?(String)
 
-    # result_array = []
-    # args.keys.each do |k|
-    #   args[k].each do |item|
-    #     result_array.push(item.id)
-    #   end
-    # end
-    # result_string = result_array.join("\x1F")
-
     args.collect { |a| a.join("=") }.join("&")
   end
 
@@ -270,7 +262,6 @@ module MiqAeEngine
   end
 
   def self.create_automation_attribute_array_value(value)
-    # value
     value.collect do |obj|
       obj.kind_of?(ActiveRecord::Base) ? obj.id.to_s : obj.to_s
     end

--- a/lib/miq_automation_engine/engine/miq_ae_engine.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine.rb
@@ -212,7 +212,7 @@ module MiqAeEngine
 
   def self.create_automation_attribute_key(object, attr_name = nil)
     klass_name = create_automation_attribute_class_name(object)
-    return klass_name.to_s if automation_attribute_is_array?(klass_name)
+    return klass_name.to_s if automation_attribute_is_array?(klass_name, object)
 
     attr_name ||= create_automation_attribute_name(object)
     "#{klass_name}::#{attr_name}"
@@ -222,13 +222,25 @@ module MiqAeEngine
     object.id
   end
 
-  def self.automation_attribute_is_array?(attr)
-    attr.to_s.downcase.starts_with?("array::")
+  def self.automation_attribute_is_array?(attr, object = nil)
+    if !object.nil? && !object.kind_of?(String) && object.has_attribute?(:options) && !object.options.nil? && !object.options[:dialog].nil?
+      object[:options][:dialog][attr].kind_of?(Array)
+    else
+      attr.to_s.downcase.starts_with?("array::")
+    end
   end
 
   def self.create_automation_attributes_string(hash)
     args = create_automation_attributes(hash)
     return args if args.kind_of?(String)
+
+    # result_array = []
+    # args.keys.each do |k|
+    #   args[k].each do |item|
+    #     result_array.push(item.id)
+    #   end
+    # end
+    # result_string = result_array.join("\x1F")
 
     args.collect { |a| a.join("=") }.join("&")
   end
@@ -254,13 +266,14 @@ module MiqAeEngine
   end
 
   def self.create_automation_attribute_array_key(key)
-    "Array::#{key}"
+    key
   end
 
   def self.create_automation_attribute_array_value(value)
+    # value
     value.collect do |obj|
-      obj.kind_of?(ActiveRecord::Base) ? "#{obj.class.name}::#{obj.id}" : obj.to_s
-    end.join("\x1F")
+      obj.kind_of?(ActiveRecord::Base) ? obj.id.to_s : obj.to_s
+    end
   end
 
   def self.set_automation_attributes_from_objects(objects, attrs_hash)
@@ -311,9 +324,20 @@ module MiqAeEngine
     ae_attrs["MiqRequest::miq_request"] = vmdb_object.id if vmdb_object.kind_of?(MiqRequest)
     ae_attrs['vmdb_object_type'] = create_automation_attribute_name(vmdb_object) unless vmdb_object.nil?
 
-    array_objects = ae_attrs.keys.find_all { |key| automation_attribute_is_array?(key) }
-    array_objects.each do |o|
-      ae_attrs[o] = ae_attrs[o].first if ae_attrs[o].kind_of?(Array)
+    # Sends array attributes to the miq_ae_object as strings with \x1F between each array item.
+    array_objects = ae_attrs.keys.find_all { |key| ae_attrs[key].kind_of?(Array) }
+    array_objects.each do |array_object|
+      # Each array attribute is tagged with Array:: before the attribute key unless it already starts with Array::
+      array_attr_key = array_object
+      if !array_object.starts_with?("Array::")
+        array_attr_key = "Array::#{array_object}"
+      end
+      ae_attrs[array_attr_key] = ae_attrs[array_object].collect do |obj|
+        obj.kind_of?(ActiveRecord::Base) ? "#{obj.class.name}::#{obj.id}" : obj.to_s
+      end.join("\x1F")
+      if !array_object.starts_with?("Array::")
+        ae_attrs.delete(array_object)
+      end
     end
     ae_attrs
   end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -253,7 +253,7 @@ module MiqAeEngine
     end
 
     def process_args_as_attributes(args = {})
-      args.keys.each { |k| attribute_is_array?(args, k) ? process_args_array(args, k) : process_args_attribute(args, k) }
+      args.keys.each { |k| attribute_is_array?(k) ? process_args_array(args, k) : process_args_attribute(args, k) }
       @attributes.merge!(args)
     end
 
@@ -264,7 +264,7 @@ module MiqAeEngine
       args[key.downcase] = load_array_objects_from_string(value)
     end
 
-    def attribute_is_array?(object, attr)
+    def attribute_is_array?(attr)
       attr.to_s.downcase.starts_with?("array::")
     end
 

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -253,7 +253,7 @@ module MiqAeEngine
     end
 
     def process_args_as_attributes(args = {})
-      args.keys.each { |k| MiqAeEngine.automation_attribute_is_array?(k) ? process_args_array(args, k) : process_args_attribute(args, k) }
+      args.keys.each { |k| attribute_is_array?(args, k) ? process_args_array(args, k) : process_args_attribute(args, k) }
       @attributes.merge!(args)
     end
 
@@ -262,6 +262,10 @@ module MiqAeEngine
       key = args_key.split(CLASS_SEPARATOR).last
       value = args.delete(args_key)
       args[key.downcase] = load_array_objects_from_string(value)
+    end
+
+    def attribute_is_array?(object, attr)
+      attr.to_s.downcase.starts_with?("array::")
     end
 
     def process_args_attribute(args, args_key)

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -293,7 +293,7 @@ describe MiqAeEngine do
       FactoryBot.create(:host)
       hash       = {"hosts" => Host.all}
       attrs      = {"Array::my_hosts" => hash["hosts"].collect { |h| "Host::#{h.id}" }}
-      result_str = "Array%3A%3Amy_hosts=" + hash["hosts"].collect { |h| "Host%3A%3A#{h.id}" }.join("%1F") # After URL encoding the separator "\x1F" is converted to %1F
+      result_str = "Array%3A%3Amy_hosts=#{hash["hosts"].collect { |h| "Host%3A%3A#{h.id}" }.join("%1F")}" # After URL encoding the separator "\x1F" is converted to %1F
       extras = "MiqServer%3A%3Amiq_server=#{miq_server_id}"
       uri = "/System/Process/AUTOMATION?#{result_str}&#{extras}&object_name=AUTOMATION"
       expect(MiqAeEngine.create_automation_object("AUTOMATION", attrs)).to eq(uri)


### PR DESCRIPTION
Fixed automation array values for multi select drop downs in Order Service Forms.

When ordering from a Service Catalog for an Ansible Playbook Catalog Item there is a bug with multi-select dropdown values not being correctly sent to the Ansible Playbook.

An example order service form with a multi-select dropdown:
<img width="1056" alt="Screenshot 2024-04-22 at 3 38 28 PM" src="https://github.com/ManageIQ/manageiq-automation_engine/assets/32444791/61b3a3ff-21bc-48ec-be19-1f20484a9a44">

Before:
When viewing the Ansible Playbook output in the Services / My Services Screen for the Service you order will look like this. `test1` is the multi-select dropdown value and it outputs "VARIABLE IS NOT DEFINED!". `test2` is just a single select dropdown used for reference.
<img width="1408" alt="Screenshot 2024-04-22 at 3 38 11 PM" src="https://github.com/ManageIQ/manageiq-automation_engine/assets/32444791/324f92ed-bd93-470c-9167-fd86479eafb4">

This is due to the field being with "Array::" on its key value causing the Ansible Playbook output to not be able to find that variable. When the "Array::" tag is removed from the key it then displays the Array as a String with `\u001f` separating the Array items.
<img width="1407" alt="Screenshot 2024-04-22 at 3 47 51 PM" src="https://github.com/ManageIQ/manageiq-automation_engine/assets/32444791/b3f80a2c-3461-4132-a2bf-c8dd859921c3">


After:
By removing the "Array::" tag from the variable key as well as converting the value being sent to the Ansible Playbook from a String to an Array we receive the Array in the Playbook and see it on the Playbook output correctly. This allows us to send Arrays to the Ansible Playbook and view it correctly on the output screen as individual items instead of as a String.
<img width="1387" alt="Screenshot 2024-04-22 at 3 30 43 PM" src="https://github.com/ManageIQ/manageiq-automation_engine/assets/32444791/60b096a9-b0ec-4f7b-94bc-f31968482f31">
