### PR TITLE
Remove prepend_namespace

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_builtin_method.rb
@@ -56,8 +56,6 @@ module MiqAeEngine
       ATTRIBUTE_LIST.detect { |attr| provider_category = category_for_key(obj, attr) }
       $miq_ae_logger.info("Setting provider_category to: #{provider_category}", :resource_id => obj.workspace.find_miq_request_id)
       obj.workspace.root["ae_provider_category"] = provider_category || UNKNOWN
-
-      prepend_vendor(obj)
     end
 
     def self.miq_parse_automation_request(obj, _inputs)
@@ -218,16 +216,6 @@ module MiqAeEngine
       end
     end
     private_class_method :category_for_key
-
-    def self.prepend_vendor(obj)
-      vendor = nil
-      ATTRIBUTE_LIST.detect { |attr| vendor = detect_vendor(obj.workspace.root[attr], attr) }
-      if vendor
-        $miq_ae_logger.info("Setting prepend_namespace to: #{vendor}", :resource_id => obj.workspace.find_miq_request_id)
-        obj.workspace.prepend_namespace = vendor.downcase
-      end
-    end
-    private_class_method :prepend_vendor
 
     def self.detect_vendor(src_obj, attr)
       return unless src_obj

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_domain_search.rb
@@ -1,12 +1,6 @@
 module MiqAeEngine
   class MiqAeDomainSearch
     def initialize
-      @prepend_namespace   = nil
-    end
-
-    def prepend_namespace=(namespace)
-      @prepend_namespace = namespace.chomp('/').sub(%r{^/}, '')
-      $miq_ae_logger.info("Prepend namespace [#{@prepend_namespace}] during domain search")
     end
 
     def ae_user=(obj)

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -26,8 +26,6 @@ module MiqAeEngine
       initialize_obj_entries
     end
 
-    delegate :prepend_namespace=, :to => :@dom_search
-
     def readonly?
       @readonly
     end

--- a/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_method_service/miq_ae_service.rb
@@ -123,10 +123,6 @@ module MiqAeMethodService
       service_object.root_service.delete_service_vars_option(name)
     end
 
-    def prepend_namespace=(namespace)
-      @workspace.prepend_namespace = namespace
-    end
-
     def instantiate(uri)
       obj = @workspace.instantiate(uri, @workspace.ae_user, @workspace.current_object)
       return nil if obj.nil?

--- a/spec/miq_ae_domain_search_spec.rb
+++ b/spec/miq_ae_domain_search_spec.rb
@@ -49,20 +49,4 @@ describe MiqAeEngine::MiqAeDomainSearch do
     ns = search.get_alternate_domain_method('miqaedb', '/FRED/WILMA/OBELIX', 'FRED', 'WILMA', 'OBELIX')
     expect(ns).to eq('BARNEY/FRED')
   end
-
-  it "#get_alternate_domain with vendor" do
-    create_vendor_ae_instances
-    search.ae_user = user
-    search.prepend_namespace = "/AMAZON/"
-    ns = search.get_alternate_domain('miqaedb', '/TEST/PROV/ONE', 'TEST', 'PROV', 'ONE')
-    expect(ns).to eq('AMAZON/AMAZON/TEST')
-  end
-
-  it "#get_alternate_domain_method with vendor" do
-    create_vendor_ae_methods
-    search.ae_user = user
-    search.prepend_namespace = "/OPENSTACK/"
-    ns = search.get_alternate_domain_method('miqaedb', '/TEST/WILMA/OBELIX', 'TEST', 'WILMA', 'OBELIX')
-    expect(ns).to eq('OPENSTACK/OPENSTACK/TEST')
-  end
 end

--- a/spec/miq_ae_service_spec.rb
+++ b/spec/miq_ae_service_spec.rb
@@ -221,20 +221,6 @@ describe MiqAeMethodService::MiqAeService do
 end
 
 describe MiqAeMethodService::MiqAeService do
-  context "#prepend_namespace=" do
-    let(:options) { {} }
-    let(:workspace) { double("MiqAeEngine::MiqAeWorkspaceRuntime", :root => options) }
-    let(:miq_ae_service) { described_class.new(workspace) }
-    let(:ns) { "fred" }
-
-    it "set namespace" do
-      allow(workspace).to receive(:disable_rbac)
-      allow(workspace).to receive(:persist_state_hash).and_return(MiqAeEngine::StateVarHash.new)
-      expect(workspace).to receive(:prepend_namespace=).with(ns)
-
-      miq_ae_service.prepend_namespace = ns
-    end
-  end
   context "create notifications" do
     before do
       NotificationType.seed


### PR DESCRIPTION
We do not use `prepend_namespace`
The feature is causing us to double the number of queries when looking up objects

@Fryguy you mentioned that we are not using this.
It was an extension mechanism added by tina that seems to not be leveraged.

I just put this into a PR so I didn't have to have a local branch and have to remember where I saw this issue.