### PR TITLE
Permit yaml safe_load of aliases in automate ruby methods

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
@@ -110,6 +110,14 @@ begin
   require 'drb'
   require 'yaml'
 
+  YAML.singleton_class.prepend(
+    Module.new do
+      def safe_load(yaml, aliases: false, **kwargs)
+        super(yaml, aliases: true, **kwargs)
+      end
+    end
+  )
+
   Time.zone = 'UTC'
 
   MIQ_OK    = 0

--- a/spec/engine/miq_ae_method_spec.rb
+++ b/spec/engine/miq_ae_method_spec.rb
@@ -47,6 +47,38 @@ describe MiqAeEngine::MiqAeMethod do
       end
     end
 
+    context "with a script that tries to YAML.load with aliases" do
+      let(:script) do
+        <<-RUBY
+          YAML.load("---\na: &a\n  b: true  \n\ndevelopment:\n  <<: *a\n  c: false\n\n")
+        RUBY
+      end
+
+      it "logs and returns the correct exit status" do
+        allow($miq_ae_logger).to receive(:info).and_call_original
+        expect($miq_ae_logger).to receive(:info).with("Method exited with rc=MIQ_OK", :resource_id => 123).at_least(:once)
+        expect($miq_ae_logger).to_not receive(:error)
+
+        expect(subject).to eq(0)
+      end
+    end
+
+    context "with a script that tries to YAML.safe_load with aliases" do
+      let(:script) do
+        <<-RUBY
+          YAML.safe_load("---\na: &a\n  b: true  \n\ndevelopment:\n  <<: *a\n  c: false\n\n")
+        RUBY
+      end
+
+      it "logs and returns the correct exit status" do
+        allow($miq_ae_logger).to receive(:info).and_call_original
+        expect($miq_ae_logger).to receive(:info).with("Method exited with rc=MIQ_OK", :resource_id => 123).at_least(:once)
+        expect($miq_ae_logger).to_not receive(:error)
+
+        expect(subject).to eq(0)
+      end
+    end
+
     context "with a script that raises" do
       let(:script) do
         <<-RUBY


### PR DESCRIPTION
Psych 4 defaults to safe_load, which defaults to not permitting aliases or classes not in an approved list.

This is similar to what we do in the core application here: https://github.com/ManageIQ/manageiq/blob/46c992aaee664ea79713020e60c0342f703a8bc6/lib/extensions/yaml_load_aliases.rb#L9

The difference is we don't want to pull in application models/classes as permitted classes, at least until we know why we need them. Also, automate's ruby invocation is somewhat isolated from the application and doesn't really pull much into the remote ruby process beyond active support and some minor changes.

We're instead, just extending YAML.safe_load to permit aliases in this change. We can add more later or find a better way to share code if that is needed.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
