### PR TITLE
Use Ansible Workflow/Job Template Common Parent Class

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_ansible_template_method.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_ansible_template_method.rb
@@ -1,6 +1,6 @@
 module MiqAeEngine
   class MiqAeAnsibleTemplateMethod < MiqAeAnsibleMethodBase
-    TEMPLATE_CLASS = ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript
+    TEMPLATE_CLASS = ManageIQ::Providers::AutomationManager::ConfigurationScript
 
     private
 


### PR DESCRIPTION
Previously Ansible AE methods were using the `::ExternalAutomationManager::ConfigurationScript` class however this is not a parent class for workflow templates `::ConfigurationWorkflow`, and so the AE method would fail on the call https://github.com/ManageIQ/manageiq-automation_engine/blob/master/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_ansible_template_method.rb#L14 when using workflow templates

@miq-bot assign @agrare 
@miq-bot add_label bug, radjabov/yes?
@miq-bot add_reviewer @agrare 