### PR TITLE
Avoid Fixnum

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -190,7 +190,7 @@ module MiqAeEngine
       case value.class.to_s
       when 'MiqAePassword'            then xml.Password(OPAQUE_PASSWORD)
       when 'String'                   then xml.String(value)
-      when 'Fixnum'                   then xml.Fixnum(value)
+      when 'Fixnum', 'Integer'        then xml.Integer(value)
       when 'Symbol'                   then xml.Symbol(value.to_s)
       when 'TrueClass', 'FalseClass'  then xml.Boolean(value.to_s)
       when /MiqAeMethodService::(.*)/ then xml.tag!($1.gsub(/::/, '-'), :object_id => value.object_id, :id => value.id)
@@ -490,7 +490,7 @@ module MiqAeEngine
       return false                                           if datatype == 'FalseClass'
       return Time.parse(value).getlocal                      if 'time'.casecmp?(datatype)
       return value.to_sym                                    if 'symbol'.casecmp?(datatype)
-      return value.to_i                                      if 'integer'.casecmp?(datatype) || datatype == 'Fixnum'
+      return value.to_i                                      if 'integer'.casecmp?(datatype) || 'fixnum'.casecmp?(datatype)
       return value.to_f                                      if 'float'.casecmp?(datatype)
       return value.gsub(/[\[\]]/, '').strip.split(/\s*,\s*/) if datatype == 'array' && value.class == String
       return decrypt_password(value) if datatype == 'password'

--- a/manageiq-automation_engine.gemspec
+++ b/manageiq-automation_engine.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubyzip", "~>2.0.0"
+  spec.add_dependency "drb"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/spec/miq_ae_object_spec.rb
+++ b/spec/miq_ae_object_spec.rb
@@ -329,7 +329,7 @@ describe MiqAeEngine::MiqAeObject do
 
   context "integer" do
     it "returns value to_i" do
-      %w[Integer integer Fixnum].each { |type| expect(described_class.convert_value_based_on_datatype("45", type)).to eq(45) }
+      %w[Integer integer].each { |type| expect(described_class.convert_value_based_on_datatype("45", type)).to eq(45) }
     end
   end
 


### PR DESCRIPTION
`Fixnum` has been deprecated for a while, it has finally been dropped.

I am not totally sure of the implications here.
This will essentially change the wire protocol.

In theory, we could leave the code as-is.
The references to `Fixnum` are not ruby, but rather just in xml. and we are using `value.to_i` locally.

But grep wise, would be nice for `grep Fixnum` to come back empty.
Which is a non-trivial statement.
Very hard to manage a migration when there are false positives all around.