### PR TITLE
[WIP] Fix warnings raised by URI 1.0.1

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -20,7 +20,7 @@ module MiqAeEngine
     BASE_CLASS        = 'object'.freeze
     BASE_OBJECT       = [BASE_NAMESPACE, BASE_CLASS].join(PATH_SEPARATOR)
     RE_METHOD_CALL    = /^[\s]*([\.\/\w]+)[\s]*(?:\((.*)\))?[\s]*$/.freeze
-    RE_URI_ESCAPE     = Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")
+    RE_URI_ESCAPE     = Regexp.new("[^#{URI::RFC2396_Parser::PATTERN::UNRESERVED}]")
     RE_SUBST          = /\$\{([^}]+)\}/.freeze
     RE_COLLECT_ARRAY  = /^[\s]*(?:([\.\/\w]+)[\s]*=[\s]*)?\[(.*)\](?:\.([^.]+))?/.freeze
     RE_COLLECT_HASH   = /^[\s]*(?:([\.\/\w]+)[\s]*=[\s]*)?\{(.*)\}(?:\.([^.]*))*/.freeze

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -859,8 +859,7 @@ describe MiqAeEngine do
       expect(test_class_name).to receive(:constantize).and_return(test_class)
       expect(test_class).to receive(:find_by!).with(any_args).and_return(test_class_instance)
       allow(MiqAeEngine).to receive(:create_automation_attribute_key)
-      expect($log).to receive(:error)
-        .with("Error delivering {\"User::user\"=>#{user.id}, nil=>nil} for object \[TestClass.\] with state \[\] to Automate: bad URI(is not URI?): \"_ wrong_uri _\"")
+      expect($log).to receive(:error).with(/Error delivering.+_ wrong_uri _/)
       MiqAeEngine.deliver(options)
     end
 


### PR DESCRIPTION
WIP:  
- [ ] Depends on URI 1.0.1+ https://github.com/ManageIQ/manageiq/pull/23261
- [ ] [cross repo test](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/928)

Correct error message validation to be less brittle to underlying changes in URI's message format.

Related to:
https://www.github.com/ruby/uri/issues/125
https://github.com/ManageIQ/manageiq/pull/23260

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
