### PR TITLE
Require 'logger' in ae_engine dynamic_preamble

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/drb_remote_invoker.rb
@@ -102,6 +102,7 @@ end
 begin
   require 'date'
   require 'rubygems'
+  require 'logger'
   $:.unshift("#{Gem.loaded_specs['activesupport'].full_gem_path}/lib")
   require 'active_support/all'
   require 'socket'


### PR DESCRIPTION
I noticed that when concurrent-ruby 3.5 was installed locally, ae methods would fail

```
[----] I, [2025-02-12T14:36:51.937615#789267:f3c8c]  INFO -- automation: Updated namespace [Infrastructure/VM/Provisioning/Profile/vm_dialog_name_prefix  ManageIQ/Infrastructure/VM/Provisioning]
[----] I, [2025-02-12T14:36:51.938889#789267:f3c8c]  INFO -- automation: Invoking [inline] method [/ManageIQ/Infrastructure/VM/Provisioning/Profile/vm_dialog_name_prefix] with inputs [{}]
[----] I, [2025-02-12T14:36:51.940359#789267:f3c8c]  INFO -- automation: <AEMethod [/ManageIQ/Infrastructure/VM/Provisioning/Profile/vm_dialog_name_prefix]> Starting 
[----] E, [2025-02-12T14:36:52.163973#789267:f5b7c] ERROR -- automation: Method STDERR: The following error occurred during inline method preamble evaluation:
[----] E, [2025-02-12T14:36:52.164225#789267:f5b7c] ERROR -- automation: Method STDERR: NameError: uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
[----] E, [2025-02-12T14:36:52.164460#789267:f5b7c] ERROR -- automation: Method STDERR: /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:12:in `<module:LoggerThreadSafeLevel>'
[----] E, [2025-02-12T14:36:52.164681#789267:f5b7c] ERROR -- automation: Method STDERR: /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
[----] E, [2025-02-12T14:36:52.164907#789267:f5b7c] ERROR -- automation: Method STDERR: /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:8:in `<top (required)>'
[----] E, [2025-02-12T14:36:52.165078#789267:f5b7c] ERROR -- automation: Method STDERR: <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.165228#789267:f5b7c] ERROR -- automation: Method STDERR: <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.165392#789267:f5b7c] ERROR -- automation: Method STDERR: /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support/logger_silence.rb:5:in `<top (required)>'
[----] E, [2025-02-12T14:36:52.165530#789267:f5b7c] ERROR -- automation: Method STDERR: <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.165668#789267:f5b7c] ERROR -- automation: Method STDERR: <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.165802#789267:f5b7c] ERROR -- automation: Method STDERR: /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support/logger.rb:3:in `<top (required)>'
[----] E, [2025-02-12T14:36:52.165935#789267:f5b7c] ERROR -- automation: Method STDERR: <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.166120#789267:f5b7c] ERROR -- automation: Method STDERR: <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.166292#789267:f5b7c] ERROR -- automation: Method STDERR: /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support.rb:29:in `<top (required)>'
[----] E, [2025-02-12T14:36:52.166456#789267:f5b7c] ERROR -- automation: Method STDERR: <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.166629#789267:f5b7c] ERROR -- automation: Method STDERR: <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.166769#789267:f5b7c] ERROR -- automation: Method STDERR: /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support/all.rb:3:in `<top (required)>'
[----] E, [2025-02-12T14:36:52.166929#789267:f5b7c] ERROR -- automation: Method STDERR: <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.167097#789267:f5b7c] ERROR -- automation: Method STDERR: <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.167270#789267:f5b7c] ERROR -- automation: Method STDERR: -:18:in `<main>'
[----] E, [2025-02-12T14:36:52.167440#789267:f5b7c] ERROR -- automation: Method STDERR: /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:12:in `<module:LoggerThreadSafeLevel>': uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)
[----] E, [2025-02-12T14:36:52.167606#789267:f5b7c] ERROR -- automation: Method STDERR: 
[----] E, [2025-02-12T14:36:52.167769#789267:f5b7c] ERROR -- automation: Method STDERR: Logger::Severity.constants.each do |severity|
[----] E, [2025-02-12T14:36:52.167932#789267:f5b7c] ERROR -- automation: Method STDERR: ^^^^^^
[----] E, [2025-02-12T14:36:52.168144#789267:f5b7c] ERROR -- automation: Method STDERR: from /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
[----] E, [2025-02-12T14:36:52.168299#789267:f5b7c] ERROR -- automation: Method STDERR: from /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:8:in `<top (required)>'
[----] E, [2025-02-12T14:36:52.168453#789267:f5b7c] ERROR -- automation: Method STDERR: from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.168599#789267:f5b7c] ERROR -- automation: Method STDERR: from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.168756#789267:f5b7c] ERROR -- automation: Method STDERR: from /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support/logger_silence.rb:5:in `<top (required)>'
[----] E, [2025-02-12T14:36:52.168912#789267:f5b7c] ERROR -- automation: Method STDERR: from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.169058#789267:f5b7c] ERROR -- automation: Method STDERR: from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.169209#789267:f5b7c] ERROR -- automation: Method STDERR: from /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support/logger.rb:3:in `<top (required)>'
[----] E, [2025-02-12T14:36:52.169382#789267:f5b7c] ERROR -- automation: Method STDERR: from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.169550#789267:f5b7c] ERROR -- automation: Method STDERR: from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.169731#789267:f5b7c] ERROR -- automation: Method STDERR: from /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support.rb:29:in `<top (required)>'
[----] E, [2025-02-12T14:36:52.169911#789267:f5b7c] ERROR -- automation: Method STDERR: from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.170077#789267:f5b7c] ERROR -- automation: Method STDERR: from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.170241#789267:f5b7c] ERROR -- automation: Method STDERR: from /home/grare/adam/.gem/ruby/3.3.0/gems/activesupport-7.0.8.7/lib/active_support/all.rb:3:in `<top (required)>'
[----] E, [2025-02-12T14:36:52.170428#789267:f5b7c] ERROR -- automation: Method STDERR: from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.170591#789267:f5b7c] ERROR -- automation: Method STDERR: from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
[----] E, [2025-02-12T14:36:52.170751#789267:f5b7c] ERROR -- automation: Method STDERR: from -:18:in `<main>'
[----] I, [2025-02-12T14:36:52.171183#789267:f3c8c]  INFO -- automation: <AEMethod [/ManageIQ/Infrastructure/VM/Provisioning/Profile/vm_dialog_name_prefix]> Ending
[----] E, [2025-02-12T14:36:52.171846#789267:f3c8c] ERROR -- automation: Aborting instantiation (unknown method return code) because [Method exited with rc=Unknown RC: [1]]
[----] E, [2025-02-12T14:36:52.171981#789267:f3c8c] ERROR -- automation: Aborting instantiation (unknown method return code) because [Method exited with rc=Unknown RC: [1]]
[----] E, [2025-02-12T14:36:52.172101#789267:f3c8c] ERROR -- automation: Aborting instantiation (unknown method return code) because [Method exited with rc=Unknown RC: [1]]
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
