### PR TITLE
Wrap all automate logger calls to process the request_id

### DIFF
--- a/lib/manageiq/automation_engine/engine.rb
+++ b/lib/manageiq/automation_engine/engine.rb
@@ -19,7 +19,7 @@ module ManageIQ
       def self.init_loggers
         # This require avoids autoload during rails boot
         require 'manageiq/automation_engine/logger'
-        $miq_ae_logger ||= Vmdb::Loggers.create_logger("automation.log", ManageIQ::AutomationEngine::Logger)
+        $miq_ae_logger ||= ManageIQ::AutomationEngine::Logger.create_log_wrapper
       end
 
       def self.apply_logger_config(config)

--- a/lib/manageiq/automation_engine/logger.rb
+++ b/lib/manageiq/automation_engine/logger.rb
@@ -1,6 +1,20 @@
 module ManageIQ
   module AutomationEngine
     class Logger < ManageIQ::Loggers::Base
+      attr_reader :automation_log_wrapper
+
+      def initialize(*args, automation_log_wrapper:, **kwargs)
+        @automation_log_wrapper = automation_log_wrapper
+        super(*args, **kwargs)
+      end
+
+      def self.create_log_wrapper(io = File::NULL)
+        # We modify the interface of logger methods such as info/warn/etc. to allow the keyword argument
+        # resource_id. Therefore, we need to wrap all client logger calls to these methods to process the resource_id,
+        # cut the request_log entry and forward the remaining arguments to the logger.
+        new(io, :progname => "automation", :automation_log_wrapper => Vmdb::Loggers.create_logger("automation.log"))
+      end
+
       private def add_to_db(severity, message = nil, progname = nil, resource_id: nil)
         return [severity, message, progname] unless resource_id
 
@@ -28,31 +42,37 @@ module ManageIQ
 
       def info(progname = nil, resource_id: nil, &block)
         severity, message, progname = add_to_db(INFO, nil, progname, resource_id: resource_id, &block)
+        automation_log_wrapper.add(severity, message, progname, &block)
         add(severity, message, progname, &block)
       end
 
       def debug(progname = nil, resource_id: nil, &block)
         severity, message, progname = add_to_db(DEBUG, nil, progname, resource_id: resource_id, &block)
+        automation_log_wrapper.add(severity, message, progname, &block)
         add(severity, message, progname, &block)
       end
 
       def warn(progname = nil, resource_id: nil, &block)
         severity, message, progname = add_to_db(WARN, nil, progname, resource_id: resource_id, &block)
+        automation_log_wrapper.add(severity, message, progname, &block)
         add(severity, message, progname, &block)
       end
 
       def error(progname = nil, resource_id: nil, &block)
         severity, message, progname = add_to_db(ERROR, nil, progname, resource_id: resource_id, &block)
+        automation_log_wrapper.add(severity, message, progname, &block)
         add(severity, message, progname, &block)
       end
 
       def fatal(progname = nil, resource_id: nil, &block)
         severity, message, progname = add_to_db(FATAL, nil, progname, resource_id: resource_id, &block)
+        automation_log_wrapper.add(severity, message, progname, &block)
         add(severity, message, progname, &block)
       end
 
       def unknown(progname = nil, resource_id: nil, &block)
         severity, message, progname = add_to_db(UNKNOWN, nil, progname, resource_id: resource_id, &block)
+        automation_log_wrapper.add(severity, message, progname, &block)
         add(severity, message, progname, &block)
       end
     end


### PR DESCRIPTION
Rails 7.1 changed how the broadcast logger works to provide a public API.
https://www.github.com/rails/rails/pull/48615

Our automation logger was subclassing Logger with new behavior and
different method signatures to cut a record in the request_log for
each automation log message, namely by accepting a request_id keyword argument.

So, we intercept all calls to the broadcast logger or a traditional logger to allow
this request_id keyword argument. We process this kwarg and forwarding them along
the rest of the arguments to the broadcast logger/logger.

[Rails 7.1 cross repo](https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/937)