### PR TITLE
Fix YAML.load error with serialized StateVarHash

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb
@@ -163,7 +163,7 @@ module MiqAeEngine
       $miq_ae_logger.info("Instantiating [#{ManageIQ::Password.sanitize_string(uri)}]", :resource_id => miq_request_id) if root.nil?
 
       if (ae_state_data = args.delete('ae_state_data'))
-        @persist_state_hash.merge!(YAML.load(ae_state_data))
+        @persist_state_hash.merge!(YAML.safe_load(ae_state_data, :permitted_classes => [MiqAeEngine::StateVarHash]))
       end
 
       if (ae_state_previous = args.delete('ae_state_previous'))

--- a/spec/miq_ae_engine_spec.rb
+++ b/spec/miq_ae_engine_spec.rb
@@ -924,7 +924,7 @@ describe MiqAeEngine do
     end
 
     it "fetches value from state_var" do
-      ae_state_data = {:my_id => 45}.to_yaml
+      ae_state_data = MiqAeEngine::StateVarHash.new(:my_id => 45).to_yaml
       workspace = MiqAeEngine.instantiate("/A/C/BARNEY/FRED?ae_state_data=#{ae_state_data}", user)
       expect(workspace.root['field1']).to eq("45")
       expect(workspace.root['field2']).to eq('Bamm Bamm Rubble')


### PR DESCRIPTION
Fixes Psych error loading `MiqAeEngine::StateVarHash` 

`[Psych::DisallowedClass]: Tried to load unspecified class: MiqAeEngine::StateVarHash`

```
[----] E, [2025-05-01T13:19:47.306216#918739:8afc] ERROR -- evm: Q-task_id([r34_vm_retire_task_47]) MIQ(MiqQueue#deliver) Message id: [9104], Error: [Tried to load unspecified class: MiqAeEngine::StateVarHash]
[----] E, [2025-05-01T13:19:47.306435#918739:8afc] ERROR -- evm: Q-task_id([r34_vm_retire_task_47]) [Psych::DisallowedClass]: Tried to load unspecified class: MiqAeEngine::StateVarHash  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2025-05-01T13:19:47.306595#918739:8afc] ERROR -- evm: Q-task_id([r34_vm_retire_task_47]) /home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych/class_loader.rb:99:in `find'
/home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych/class_loader.rb:28:in `load'
/home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych/visitors/to_ruby.rb:426:in `resolve_class'
/home/grare/adam/src/manageiq/manageiq/config/initializers/yaml_autoloader.rb:15:in `resolve_class'
/home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych/visitors/to_ruby.rb:215:in `visit_Psych_Nodes_Mapping'
/home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych/visitors/visitor.rb:30:in `visit'
/home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych/visitors/visitor.rb:6:in `accept'
/home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych/visitors/to_ruby.rb:35:in `accept'
/home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych/visitors/to_ruby.rb:320:in `visit_Psych_Nodes_Document'
/home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych/visitors/visitor.rb:30:in `visit'
/home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych/visitors/visitor.rb:6:in `accept'
/home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych/visitors/to_ruby.rb:35:in `accept'
/home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych.rb:334:in `safe_load'
/home/grare/adam/src/manageiq/manageiq/lib/extensions/yaml_load_aliases.rb:9:in `safe_load'
/home/grare/adam/.gem/ruby/3.3.0/gems/psych-4.0.6/lib/psych.rb:369:in `load'
/home/grare/adam/src/manageiq/manageiq-automation_engine/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb:166:in `instantiate'
/home/grare/adam/src/manageiq/manageiq-automation_engine/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb:54:in `instantiate_with_user'
/home/grare/adam/src/manageiq/manageiq-automation_engine/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb:48:in `block in instantiate'
/home/grare/adam/src/manageiq/manageiq/app/models/user.rb:383:in `with_user'
/home/grare/adam/src/manageiq/manageiq-automation_engine/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_workspace_runtime.rb:48:in `instantiate'
/home/grare/adam/src/manageiq/manageiq-automation_engine/lib/miq_automation_engine/engine/miq_ae_engine.rb:328:in `resolve_automation_object'
/home/grare/adam/src/manageiq/manageiq-automation_engine/lib/miq_automation_engine/engine/miq_ae_engine.rb:106:in `deliver'
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
