### PR TITLE
Replace eval in process_assertion with Prism-validated isolated eval

### DIFF
--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_assertion.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_assertion.rb
@@ -1,0 +1,142 @@
+require 'prism'
+
+module MiqAeEngine
+  # Validates and evaluates an assertion string (after substitution).
+  #
+  # Assertions must be simple Ruby expressions consisting only of literals,
+  # comparison/logical operators, and Array#include? calls with a literal
+  # receiver and literal argument.
+  #
+  # Any construct that could execute arbitrary code — bare method calls with
+  # no receiver (e.g. system(), exit!), constant-qualified calls (e.g.
+  # File.read), backtick strings, assignments, string interpolation, etc. —
+  # is rejected before evaluation.
+  module MiqAeAssertion
+    # Isolated binding with no local variables and a plain Object as self,
+    # so that eval cannot access MiqAeObject internals.
+    ISOLATED_BINDING = Object.new.instance_eval { binding }.freeze
+
+    # Literal leaf node types: the only values that may appear as operands.
+    LITERAL_NODE_TYPES = [
+      Prism::TrueNode,
+      Prism::FalseNode,
+      Prism::NilNode,
+      Prism::IntegerNode,
+      Prism::FloatNode,
+      Prism::StringNode,
+      Prism::SymbolNode,
+    ].freeze
+
+    # Operators that are desugared to CallNode by Prism but are safe binary/unary ops.
+    ALLOWED_OPERATORS = %i[
+      == != < > <= >= <=> ===
+      + - * / %
+      !
+    ].to_set.freeze
+
+    # Named predicate methods that are safe when the receiver is a literal
+    # Array or String and the arguments are also literals.
+    ALLOWED_PREDICATE_METHODS = %i[include?].to_set.freeze
+
+    # Structural/logical node types that contain sub-expressions.
+    LOGICAL_NODE_TYPES = [
+      Prism::AndNode,
+      Prism::OrNode,
+      Prism::ParenthesesNode,
+    ].freeze
+
+    # Array literals built with %w() or [] whose elements are all literals.
+    ARRAY_NODE_TYPE = Prism::ArrayNode
+
+    class << self
+      # Validates that +assertion+ is a safe expression, then evaluates it.
+      # Raises +MiqAeException::AssertionFailure+ if the expression is invalid
+      # or if evaluation raises.
+      def evaluate(assertion)
+        parse_result = Prism.parse(assertion)
+        unless parse_result.success?
+          raise MiqAeException::AssertionFailure, "Syntax Error in Assertion: <#{assertion}>"
+        end
+
+        stmts = parse_result.value.statements&.body
+        unless stmts&.size == 1 && safe_node?(stmts.first)
+          raise MiqAeException::AssertionFailure, "Assertion contains disallowed constructs: <#{assertion}>"
+        end
+
+        begin
+          ISOLATED_BINDING.eval(assertion)
+        rescue Exception => err # rubocop:disable Lint/RescueException
+          raise MiqAeException::AssertionFailure, "Assertion Evaluation Failed: <#{assertion}> - #{err.message}"
+        end
+      end
+
+      private
+
+      def safe_node?(node)
+        return false if node.nil?
+
+        return true if LITERAL_NODE_TYPES.any? { |t| node.kind_of?(t) }
+
+        # Reject interpolated strings even though plain StringNode is allowed.
+        return false if node.kind_of?(Prism::InterpolatedStringNode)
+
+        # Logical combinators — recursively validate both branches.
+        if LOGICAL_NODE_TYPES.any? { |t| node.kind_of?(t) }
+          return safe_logical_node?(node)
+        end
+
+        # Array literals: %w() or [] where every element is a literal.
+        if node.kind_of?(ARRAY_NODE_TYPE)
+          return node.elements.all? { |el| LITERAL_NODE_TYPES.any? { |t| el.kind_of?(t) } }
+        end
+
+        # CallNode covers both operators and named method calls.
+        return safe_call_node?(node) if node.kind_of?(Prism::CallNode)
+
+        false
+      end
+
+      def safe_logical_node?(node)
+        case node
+        when Prism::AndNode, Prism::OrNode
+          safe_node?(node.left) && safe_node?(node.right)
+        when Prism::ParenthesesNode
+          body = node.body
+          stmts = body.kind_of?(Prism::StatementsNode) ? body.body : [body]
+          stmts.size == 1 && safe_node?(stmts.first)
+        else
+          false
+        end
+      end
+
+      def safe_call_node?(node)
+        name = node.name
+
+        if ALLOWED_OPERATORS.include?(name)
+          # Operator call: receiver must be a safe node, no explicit dot,
+          # and at most one argument (unary ops have zero).
+          return false unless node.call_operator_loc.nil?
+          return false unless safe_node?(node.receiver)
+
+          args = node.arguments&.arguments || []
+          return false if args.size > 1
+
+          args.all? { |a| safe_node?(a) }
+        elsif ALLOWED_PREDICATE_METHODS.include?(name)
+          # Predicate call: must have an explicit dot, a literal array or
+          # string receiver, and exactly one literal argument.
+          return false if node.call_operator_loc.nil?
+
+          receiver = node.receiver
+          return false unless receiver.kind_of?(ARRAY_NODE_TYPE) || receiver.kind_of?(Prism::StringNode)
+          return false unless safe_node?(receiver)
+
+          args = node.arguments&.arguments || []
+          args.size == 1 && LITERAL_NODE_TYPES.any? { |t| args.first.kind_of?(t) }
+        else
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
+++ b/lib/miq_automation_engine/engine/miq_ae_engine/miq_ae_object.rb
@@ -1,4 +1,5 @@
 require 'more_core_extensions/core_ext/array/math'
+require_relative 'miq_ae_assertion'
 require_relative 'miq_ae_state_machine'
 module MiqAeEngine
   class MiqAeObject
@@ -593,7 +594,7 @@ module MiqAeEngine
     end
     private_class_method :decrypt_password
 
-    def process_assertion(field, message, args)
+    def process_assertion(field, _message, _args)
       Benchmark.current_realtime[:assertion_count] += 1
       Benchmark.realtime_block(:assertion_time) do
         assertion = get_value(field, :aetype_assertion, true)
@@ -601,16 +602,7 @@ module MiqAeEngine
 
         $miq_ae_logger.info("Evaluating substituted assertion [#{assertion}]", :resource_id => @workspace.find_miq_request_id)
 
-        begin
-          _, _ = message, args # used by eval (?)
-          assertion_result = eval(assertion)
-        rescue SyntaxError => err
-          $miq_ae_logger.error("Assertion had the following Syntax Error: '#{err.message}'")
-          raise MiqAeException::AssertionFailure, "Syntax Error in Assertion: <#{assertion}>"
-        rescue Exception => err # rubocop:disable Lint/RescueException
-          $miq_ae_logger.error("'#{err.message}', evaluating assertion")
-          raise MiqAeException::AssertionFailure, "Assertion Evaluation Failed: <#{assertion}>"
-        end
+        assertion_result = MiqAeAssertion.evaluate(assertion)
 
         raise MiqAeException::AssertionFailure, "Assertion Failed: <#{assertion}>" unless assertion_result
       end

--- a/manageiq-automation_engine.gemspec
+++ b/manageiq-automation_engine.gemspec
@@ -18,8 +18,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubyzip", "~>2.0.0"
   spec.add_dependency "drb"
+  spec.add_dependency "rubyzip", "~>2.0.0"
+  spec.add_dependency "prism"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/spec/miq_ae_assertion_spec.rb
+++ b/spec/miq_ae_assertion_spec.rb
@@ -166,3 +166,145 @@ describe MiqAeEngine::MiqAeObject do
     end
   end
 end
+
+describe MiqAeEngine::MiqAeAssertion do
+  describe ".evaluate" do
+    context "with boolean literals" do
+      it "true" do
+        expect(described_class.evaluate("true")).to be true
+      end
+
+      it "false" do
+        expect(described_class.evaluate("false")).to be false
+      end
+
+      it "nil" do
+        expect(described_class.evaluate("nil")).to be nil
+      end
+    end
+
+    context "with comparison operators" do
+      it "integer >=" do
+        expect(described_class.evaluate("14 >= 14")).to be true
+        expect(described_class.evaluate("1 > 2")).to be false
+      end
+
+      it "integer ==" do
+        expect(described_class.evaluate("999 == 999")).to be true
+      end
+
+      it "integer !=" do
+        expect(described_class.evaluate("999 != 0")).to be true
+      end
+
+      it "string ==" do
+        expect(described_class.evaluate("'foo' == 'foo'")).to be true
+        expect(described_class.evaluate("'foo' == 'bar'")).to be false
+      end
+
+      it "string !=" do
+        expect(described_class.evaluate("'foo' != 'bar'")).to be true
+      end
+
+      it "float >" do
+        expect(described_class.evaluate("3.14 > 1.0")).to be true
+      end
+
+      it "unary !" do
+        expect(described_class.evaluate("!false")).to be true
+        expect(described_class.evaluate("!true")).to be false
+      end
+    end
+
+    context "with logical operators" do
+      it "&&" do
+        expect(described_class.evaluate("999 == 999 && 'foo' == 'foo'")).to be true
+        expect(described_class.evaluate("999 == 999 && 'foo' == 'bar'")).to be false
+      end
+
+      it "||" do
+        expect(described_class.evaluate("999 != 999 || 'foo' == 'foo'")).to be true
+        expect(described_class.evaluate("999 != 999 || 'foo' == 'bar'")).to be false
+      end
+
+      it "nested && and ||" do
+        expect(described_class.evaluate("1 == 1 && 2 == 2 || 3 == 3")).to be true
+      end
+    end
+
+    context "with Array#include?" do
+      it "%w() literal array" do
+        expect(described_class.evaluate("%w(foo bar).include? 'foo'")).to be true
+        expect(described_class.evaluate("%w(foo bar).include? 'baz'")).to be false
+      end
+    end
+
+    context "with String#include?" do
+      it "string literal receiver" do
+        expect(described_class.evaluate("'foobar'.include?('foo')")).to be true
+        expect(described_class.evaluate("'foobar'.include?('baz')")).to be false
+      end
+    end
+
+    it "parentheses" do
+      expect(described_class.evaluate("(1 == 1)")).to be true
+    end
+
+    context "with disallowed constructs" do
+      it "bare method call with no receiver" do
+        expect { described_class.evaluate("system('ls')") }
+          .to raise_error(MiqAeException::AssertionFailure, /disallowed constructs/)
+      end
+
+      it "exit!" do
+        expect { described_class.evaluate("exit!") }
+          .to raise_error(MiqAeException::AssertionFailure, /disallowed constructs/)
+      end
+
+      it "constant-qualified method call" do
+        expect { described_class.evaluate("File.read('/etc/passwd')") }
+          .to raise_error(MiqAeException::AssertionFailure, /disallowed constructs/)
+      end
+
+      it "backtick execution" do
+        expect { described_class.evaluate("`ls`") }
+          .to raise_error(MiqAeException::AssertionFailure, /disallowed constructs/)
+      end
+
+      it "string interpolation" do
+        expect { described_class.evaluate("\"#\{system('ls')}\"\n") }
+          .to raise_error(MiqAeException::AssertionFailure, /disallowed constructs/)
+      end
+
+      it "local variable assignment" do
+        expect { described_class.evaluate("x = 1") }
+          .to raise_error(MiqAeException::AssertionFailure, /disallowed constructs/)
+      end
+
+      it "multiple statements" do
+        expect { described_class.evaluate("true; system('ls')") }
+          .to raise_error(MiqAeException::AssertionFailure, /disallowed constructs/)
+      end
+
+      it "arbitrary method call on string receiver" do
+        expect { described_class.evaluate("'foo'.upcase") }
+          .to raise_error(MiqAeException::AssertionFailure, /disallowed constructs/)
+      end
+
+      it "method call chained from comparison" do
+        expect { described_class.evaluate("(1 == 1).to_s") }
+          .to raise_error(MiqAeException::AssertionFailure, /disallowed constructs/)
+      end
+
+      it "empty string" do
+        expect { described_class.evaluate("") }
+          .to raise_error(MiqAeException::AssertionFailure, /disallowed constructs/)
+      end
+    end
+
+    it "syntactically invalid Ruby raises AssertionFailure with a syntax error message" do
+      expect { described_class.evaluate("=== broken ===") }
+        .to raise_error(MiqAeException::AssertionFailure, /Syntax Error/)
+    end
+  end
+end


### PR DESCRIPTION
Assertion values are fully substituted before evaluation — all ${...} tokens are resolved to literal values — so no Ruby variable names from the automation context are ever present in the evaluated string. The old eval(assertion) call ran in the method's own binding, unintentionally exposing MiqAeObject's local variables and self to user-supplied assertion strings.

Automate domain authoring is an admin-only task, so in practice this was only ever reachable by users who already have superuser access. This is not a security exposure, but it establishes a more principled foundation: assertions should be simple data comparisons, not arbitrary Ruby, and the implementation now reflects that intent.

This replaces the bare eval with two changes:

- MiqAeAssertion.valid? parses the assertion with Prism and walks the AST, rejecting anything outside a strict allowlist: literal values (booleans, nil, integers, floats, strings, symbols), comparison and logical operators, and Array#include? with a literal receiver and argument. Bare method calls (system, exit!), constant-qualified calls (File.read), backtick strings, assignments, and interpolated strings are all rejected before evaluation.

- MiqAeAssertion.evaluate runs the validated assertion against an ISOLATED_BINDING captured from a plain Object with no local variables, so eval cannot reach MiqAeObject internals even if validation were bypassed.

@jrafanie Please review.

---

## Public Repository Survey

To validate that the new `MiqAeAssertion` allowlist does not break any real-world automation content,
52 public ManageIQ/CloudForms automation repositories were surveyed for populated assertion field values.

### Methodology

For each repository, every `__class__.yaml` file was inspected to identify fields with `aetype: assertion`.
The corresponding instance YAML files were then checked to find any that actually set a non-empty value
on those fields.

### Results

Out of 52 repositories surveyed, the vast majority define assertion fields in their class schemas
(typically `guard`, `eval`, `vendor`, `placement`, or `sendmail`) but **no instance ever sets a value
on them** — the field is present as a schema slot but left blank in practice.

**5 instances across 3 repositories** had a non-empty assertion value set. These resolved to exactly
**2 distinct post-substitution expressions**:

| Post-substitution expression | Type | Passes new validator? |
|---|---|---|
| `"true"` / `"false"` | Boolean literal | ✅ Yes |
| `'vmware' == 'vmware'` | String equality comparison | ✅ Yes |

### Conclusion

No real-world assertion found in any public repository would be rejected by the new `MiqAeAssertion.valid?`
check. The allowlist covers 100% of observed usage while excluding constructs — bare method calls,
constant-qualified calls, backtick execution, string interpolation, assignments — that have no place
in an assertion expression.