### PR TITLE
Bump rubyzip to ~>3.6

### DIFF
--- a/app/models/miq_ae_yaml_export_zipfs.rb
+++ b/app/models/miq_ae_yaml_export_zipfs.rb
@@ -19,7 +19,7 @@ class MiqAeYamlExportZipfs < MiqAeYamlExport
 
   def export
     require 'zip/filesystem'
-    Zip::File.open(@temp_file_name, Zip::File::CREATE) do |zf|
+    Zip::File.open(@temp_file_name, create: true) do |zf|
       @zip_file = zf
       write_model
       @zip_file&.close

--- a/manageiq-automation_engine.gemspec
+++ b/manageiq-automation_engine.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "drb"
-  spec.add_dependency "rubyzip", "~>2.0.0"
   spec.add_dependency "prism"
+  spec.add_dependency "rubyzip", "~>3.6"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/spec/models/miq_ae_yaml_import_export_spec.rb
+++ b/spec/models/miq_ae_yaml_import_export_spec.rb
@@ -978,7 +978,7 @@ describe MiqAeDatastore do
 
   def create_bogus_zip_file
     require 'zip/filesystem'
-    Zip::File.open(@zip_file, Zip::File::CREATE) do |zh|
+    Zip::File.open(@zip_file, create: true) do |zh|
       zh.file.open("first.txt", "w") { |f| f.puts "Hello world" }
       zh.dir.mkdir("mydir")
       zh.file.open("mydir/second.txt", "w") { |f| f.puts "Hello again" }


### PR DESCRIPTION
rubyzip 3.0 removed Zip::File::CREATE and changed Zip::File.open to use keyword arguments. Update all call sites to the new style.

The filesystem API (zf.file, zf.dir, zf.entries, zf.remove) is unchanged. Existing export/import roundtrip tests in miq_ae_yaml_import_export_spec.rb provide coverage.

@agrare Please review.